### PR TITLE
Known issue: Running in Python 3.3 asv master with virtualenv 1.11

### DIFF
--- a/asv/__init__.py
+++ b/asv/__init__.py
@@ -13,3 +13,19 @@ if sys.version_info >= (3, 3):
     # inherited.
     if os.environ.get('__PYVENV_LAUNCHER__'):
         os.unsetenv('__PYVENV_LAUNCHER__')
+
+
+def check_version_compatibility():
+    """
+    Performs a number of compatibility checks with third-party
+    libraries.
+    """
+    from distutils.version import LooseVersion
+
+    if sys.version_info[0] == 3:
+        import virtualenv
+        if LooseVersion(virtualenv.__version__) == LooseVersion('1.11'):
+            raise RuntimeError("asv is not compatible with Python 3.x and virtualenv 1.11")
+
+
+check_version_compatibility()


### PR DESCRIPTION
Should be fixed in the next version of virtualenv:

https://bitbucket.org/pypa/setuptools/issue/129/assertionerror-egg-info-pkg-info-is-not-a
