### PR TITLE
Python 3 error with ``asv publish``

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -107,7 +107,7 @@ class Publish(object):
                 }
             for key, val in six.iteritems(params):
                 val = list(val)
-                val.sort()
+                val.sort(key=lambda x: x or '')
                 params[key] = val
             util.write_json(os.path.join(conf.html_dir, "index.json"), {
                 'project': conf.project,


### PR DESCRIPTION
When I run `asv publish` using Python 3.3, I get:

```
$ asv publish
Loading results
Generating graphs
Getting tags
 Fetching recent changes...........
Writing indexERROR: TypeError: unorderable types: NoneType() < str() [asv.commands.publish]
Traceback (most recent call last):
  File "/Volumes/Raptor/Library/Python/3.3/bin/asv", line 9, in <module>
    load_entry_point('asv==0.1', 'console_scripts', 'asv')()
  File "/Volumes/Raptor/Library/Python/3.3/lib/python/site-packages/asv-0.1-py3.3.egg/asv/main.py", line 22, in main
    args.func(args)
  File "/Volumes/Raptor/Library/Python/3.3/lib/python/site-packages/asv-0.1-py3.3.egg/asv/commands/publish.py", line 39, in run_from_args
    return cls.run(conf=conf)
  File "/Volumes/Raptor/Library/Python/3.3/lib/python/site-packages/asv-0.1-py3.3.egg/asv/commands/publish.py", line 110, in run
    val.sort()
TypeError: unorderable types: NoneType() < str()
```

I can look into it later.
