### PR TITLE
Update `machine-information` section in docs

### DIFF
--- a/asv/commands/machine.py
+++ b/asv/commands/machine.py
@@ -43,4 +43,4 @@ class Machine(object):
                 different[key] = kwargs.get(key)
 
         machine.Machine.load(
-            interactive=(len(different) == 0), **different)
+            force_interactive=(len(different) == 0), **different)

--- a/asv/machine.py
+++ b/asv/machine.py
@@ -149,7 +149,7 @@ class Machine(object):
         return values
 
     @classmethod
-    def load(cls, interactive=False, **kwargs):
+    def load(cls, interactive=False, force_interactive=False, **kwargs):
         self = Machine()
 
         unique_machine_name = cls.get_unique_machine_name()
@@ -158,7 +158,7 @@ class Machine(object):
         except ValueError:
             d = {}
         d.update(kwargs)
-        if not len(d) and interactive:
+        if (not len(d) and interactive) or force_interactive:
             d.update(self.generate_machine_file())
 
         self.__dict__.update(d)

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -61,7 +61,7 @@ will look for the binaries ``python2.7`` and ``python3.3`` on the path.
     different versions of Python for you.  They must already be
     installed and on the path.  Depending on your platform, you can
     install multiple versions of Python using your package manager or
-    using `pythonbrew <https://github.com/utahta/pythonbrew>`_.
+    using `pyenv <https://github.com/yyuu/pyenv>`_.
 
 ``matrix``
 ----------

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -103,15 +103,20 @@ Running benchmarks
 
 Benchmarks are run using the ``asv run`` subcommand.
 
+Let's start by just benchmarking the current ``master`` of the project::
+
+    $ asv run master^!
+
 Machine information
 ```````````````````
 
-If this is the first time using ``asv run`` on a given machine, you
-will be prompted for information about the machine, such as its
-platform, cpu and memory.  **airspeed velocity** will try to make
-reasonable guesses, so it's usually ok to just press ``Enter`` to
-accept each default value.  This information is stored in the
-``.asv-machine.json`` file in your home directory::
+If this is the first time using ``asv run`` on a given machine, (which
+it probably is, if you're following along), you will be prompted for
+information about the machine, such as its platform, cpu and memory.
+**airspeed velocity** will try to make reasonable guesses, so it's
+usually ok to just press ``Enter`` to accept each default value.  This
+information is stored in the ``.asv-machine.json`` file in your home
+directory::
 
     No ASV machine info file found.
     I will now ask you some questions about this machine to identify
@@ -127,6 +132,11 @@ accept each default value.  This information is stored in the
     CPU [Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)]:
     4. RAM: The amount of physical RAM in the system.
     RAM [8.2G]:
+
+.. note::
+
+    If you ever need to update the machine information later, you can
+    run `asv machine`.
 
 Environments
 ````````````
@@ -152,10 +162,9 @@ start much faster.
     ``python3.3`` on the path.  There are many ways to get multiple
     versions of Python installed -- your package manager, ``apt-get``,
     ``yum``, ``MacPorts`` or ``homebrew`` probably has them, or you
-    can also use `pythonbrew
-    <https://github.com/utahta/pythonbrew>`__.  ``asv`` always works
-    in a virtual environment, so it will not change what is installed
-    in any of the python environments on your system.
+    can also use `pyenv <https://github.com/yyuu/pyenv>`__.  ``asv``
+    always works in a virtual environment, so it will not change what
+    is installed in any of the python environments on your system.
 
 Benchmarking
 ````````````


### PR DESCRIPTION
I'm trying to follow the docs.

It seems here `asv run` was changed to `asv machine` and the docs need to be updated?
http://spacetelescope.github.io/asv/using.html#machine-information
