### PR TITLE
Use one virtual environment per tested commit

### DIFF
--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -30,6 +30,18 @@ Optional dependencies, required only to determine machine information:
 
     - `numpy <http://www.numpy.org/>`__
 
+Optional optimization
+---------------------
+
+If your project being benchmarked contains C, C++, Objective-C or
+Cython, consider installing ``ccache``.  `ccache
+<https://ccache.samba.org/>`__ is a compiler cache that speeds up
+compilation time when the same objects are repeatedly compiled.  In
+**airspeed velocity**, the project being benchmarked is recompiled at
+many different points in its history, often with only minor changes to
+the source code, so `ccache` can help speed up the total benchmarking
+time considerably.
+
 Running the self-tests
 ----------------------
 


### PR DESCRIPTION
Once the main virtual environment has been set up, would it be possible to set up a 'child' virtual environment that inherits numpy and Cython, and then adds the relevant revision of Astropy? If so, we could (optionally) keep the virtualenvs for all the (tested) astropy revisions. At the moment, the bottleneck is installing and uninstalling Astropy many times, but with the idea I'm proposing, you only set up Astropy once for each revision. It does take a little more disk space, but if the virtualenvs 'inherit' from the common numpy/cython one, then at least it won't be too bad. Maybe this could be an option that could be turned on? (since it wouldn't be feasible for e.g. 10000 revisions).
