### PR TITLE
Allow user to set timeit parameters for tests

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -100,7 +100,7 @@ class Benchmark(object):
         return cls(name, func, instance)
 
     @classmethod
-    def from_name(cls, root, name):
+    def from_name(cls, root, name, quick=False):
         """
         Create a benchmark from a fully-qualified benchmark name.
 
@@ -142,7 +142,13 @@ class Benchmark(object):
 
         parts = name.split('.')
 
-        return find_on_filesystem(root, parts, '')
+        benchmark = find_on_filesystem(root, parts, '')
+
+        if quick:
+            benchmark.repeat = 1
+            benchmark.number = 1
+
+        return benchmark
 
     def do_setup(self):
         if self.module_setup is not None:
@@ -343,9 +349,11 @@ if __name__ == '__main__':
         sys.exit(0)
 
     elif mode == 'run':
-        benchmark_dir, benchmark_id = args
+        benchmark_dir, benchmark_id, quick = args
+        quick = quick == 'True'
 
-        benchmark = Benchmark.from_name(benchmark_dir, benchmark_id)
+        benchmark = Benchmark.from_name(
+            benchmark_dir, benchmark_id, quick=quick)
         benchmark.do_setup()
         result = benchmark.do_run()
         benchmark.do_teardown()

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -23,7 +23,7 @@ BENCHMARK_RUN_SCRIPT = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "benchmark.py")
 
 
-def run_benchmark(benchmark, root, env, show_exc=False):
+def run_benchmark(benchmark, root, env, show_exc=False, quick=False):
     """
     Run a single benchmark in another process in the given environment.
 
@@ -40,6 +40,9 @@ def run_benchmark(benchmark, root, env, show_exc=False):
         When `True`, write the exception to the console if the
         benchmark fails.
 
+    quick : bool, optional
+        When `True`, run the benchmark function exactly once.
+
     Returns
     -------
     result : float or None
@@ -50,7 +53,7 @@ def run_benchmark(benchmark, root, env, show_exc=False):
     console.step(benchmark['name'] + ": ")
     try:
         output = env.run(
-            [BENCHMARK_RUN_SCRIPT, 'run', root, benchmark['name']],
+            [BENCHMARK_RUN_SCRIPT, 'run', root, benchmark['name'], str(quick)],
             dots=False, timeout=benchmark['timeout'],
             display_error=show_exc)
     except util.ProcessError:
@@ -251,7 +254,7 @@ class Benchmarks(dict):
 
         return cls(conf, benchmarks=d, regex=regex)
 
-    def run_benchmarks(self, env, show_exc=False):
+    def run_benchmarks(self, env, show_exc=False, quick=False):
         """
         Run all of the benchmarks in the given `Environment`.
 
@@ -263,11 +266,18 @@ class Benchmarks(dict):
         show_exc : bool, optional
             When `True`, display the exception traceback when running
             a benchmark fails.
+
+        quick : bool, optional
+            When `True`, run each benchmark function exactly once.
+            This is useful to quickly find errors in the benchmark
+            functions, without taking the time necessary to get
+            accurate timings.
         """
         times = {}
         for name, benchmark in six.iteritems(self):
             times[name] = run_benchmark(
-                benchmark, self._benchmark_dir, env, show_exc=show_exc)
+                benchmark, self._benchmark_dir, env, show_exc=show_exc,
+                quick=quick)
         return times
 
     def skip_benchmarks(self):

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -79,8 +79,14 @@ class Run(object):
             in all cases.""")
         parser.add_argument(
             "--show-exc", "-e", action="store_true",
-            help="""When provided, display the exceptions from the
-            benchmarks when they fail.""")
+            help="""Display the exceptions from the benchmarks when
+            they fail.""")
+        parser.add_argument(
+            "--quick", "-q", action="store_true",
+            help="""Do a "quick" run, where each benchmark function is
+            run only once.  This is useful to find basic errors in the
+            benchmark functions faster.  The results are unlikely to
+            be useful, and thus are not saved.""")
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -92,12 +98,12 @@ class Run(object):
         return cls.run(
             conf=conf, range_spec=args.range, steps=args.steps,
             bench=args.bench, parallel=args.parallel,
-            show_exc=args.show_exc
+            show_exc=args.show_exc, quick=args.quick
         )
 
     @classmethod
     def run(cls, conf, range_spec="master", steps=0, bench=None, parallel=1,
-            show_exc=False, _machine_file=None):
+            show_exc=False, quick=False, _machine_file=None):
         params = {}
         machine_params = Machine.load(_path=_machine_file, interactive=True)
         params.update(machine_params.__dict__)
@@ -179,7 +185,7 @@ class Run(object):
 
                                 with console.indent():
                                     times = benchmarks.run_benchmarks(
-                                        env, show_exc=show_exc)
+                                        env, show_exc=show_exc, quick=quick)
                             else:
                                 console.add(" can't install.  skipping", "yellow")
                                 with console.indent():


### PR DESCRIPTION
At the moment, each test takes O(1s). For testing purposes we may want to do a 'quick' run, so it would be great if the user could set that the tests should take O(10ms) or O(100ms).
