### PR TITLE
asv quickstart not producing default config

### DIFF
--- a/asv/commands/__init__.py
+++ b/asv/commands/__init__.py
@@ -9,6 +9,7 @@ import sys
 
 import six
 
+from .. import config
 from .. import util
 
 # This list is ordered in order of average workflow
@@ -32,8 +33,15 @@ class Command(object):
         raise NotImplementedError()
 
     @classmethod
-    def run_from_args(cls, conf, args):
-        # TODO: Document me
+    def run_from_args(cls, args):
+        from .. import plugin_manager
+        conf = config.Config.load(args.config)
+        for plugin in conf.plugins:
+            plugin_manager.import_plugin(plugin)
+        return cls.run_from_conf_args(conf, args)
+
+    @classmethod
+    def run_from_conf_args(cls, conf, args):
         raise NotImplementedError()
 
 

--- a/asv/commands/machine.py
+++ b/asv/commands/machine.py
@@ -33,7 +33,7 @@ class Machine(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, conf, args):
+    def run_from_conf_args(cls, conf, args):
         return cls.run(**vars(args))
 
     @classmethod

--- a/asv/commands/preview.py
+++ b/asv/commands/preview.py
@@ -50,7 +50,7 @@ class Preview(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, conf, args):
+    def run_from_conf_args(cls, conf, args):
         return cls.run(conf=conf, port=args.port,
                        browser=args.browser)
 

--- a/asv/commands/profile.py
+++ b/asv/commands/profile.py
@@ -88,7 +88,7 @@ class Profile(Command):
                 cls.guis[x.name] = x
 
     @classmethod
-    def run_from_args(cls, conf, args):
+    def run_from_conf_args(cls, conf, args):
         return cls.run(
             conf=conf, benchmark=args.benchmark[0], revision=args.revision[0],
             gui=args.gui, output=args.output, force=args.force,

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -35,7 +35,7 @@ class Publish(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, conf, args):
+    def run_from_conf_args(cls, conf, args):
         return cls.run(conf=conf)
 
     @classmethod

--- a/asv/commands/quickstart.py
+++ b/asv/commands/quickstart.py
@@ -28,7 +28,7 @@ class Quickstart(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, conf, args):
+    def run_from_args(cls, args):
         return cls.run(dest=args.dest)
 
     @classmethod

--- a/asv/commands/rm.py
+++ b/asv/commands/rm.py
@@ -40,7 +40,7 @@ class Rm(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, conf, args):
+    def run_from_conf_args(cls, conf, args):
         return cls.run(conf, args.patterns, args.y)
 
     @classmethod

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -95,7 +95,7 @@ class Run(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, conf, args):
+    def run_from_conf_args(cls, conf, args):
         return cls.run(
             conf=conf, range_spec=args.range, steps=args.steps,
             bench=args.bench, parallel=args.parallel,

--- a/asv/commands/setup.py
+++ b/asv/commands/setup.py
@@ -52,7 +52,7 @@ class Setup(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, conf, args):
+    def run_from_conf_args(cls, conf, args):
         return cls.run(conf=conf, parallel=args.parallel)
 
     @classmethod

--- a/asv/commands/update.py
+++ b/asv/commands/update.py
@@ -26,7 +26,7 @@ class Update(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, conf, args):
+    def run_from_args(cls, args):
         return cls.run(args.config)
 
     @classmethod

--- a/asv/main.py
+++ b/asv/main.py
@@ -26,18 +26,13 @@ def main():
 
     log.enable(args.verbose)
 
-    conf = Config.load(args.config)
-
     # Use the path to the config file as the cwd for the remainder of
     # the run
     dirname = os.path.dirname(os.path.abspath(args.config))
     os.chdir(dirname)
 
-    for plugin in conf.plugins:
-        plugin_manager.import_plugin(plugin)
-
     try:
-        args.func(conf, args)
+        args.func(args)
     except RuntimeError as e:
         log.error(six.text_type(e))
         sys.exit(1)


### PR DESCRIPTION
at least on my machine with py27 and osx 10.9 - same for asv help:

`➜  tardis git:(master) ✗ asv quickstart
Traceback (most recent call last):
  File "/Users/wkerzend/Library/Python/2.7/bin/asv", line 9, in <module>
    load_entry_point('asv==0.1', 'console_scripts', 'asv')()
  File "/Users/wkerzend/Library/Python/2.7/lib/python/site-packages/asv-0.1-py2.7.egg/asv/main.py", line 29, in main
    conf = Config.load(args.config)
  File "/Users/wkerzend/Library/Python/2.7/lib/python/site-packages/asv-0.1-py2.7.egg/asv/config.py", line 44, in load
    raise RuntimeError("Config file {0} not found.".format(path))
RuntimeError: Config file asv.conf.json not found.`

great tool though - looking forward to using it.
