### PR TITLE
ValueError raised in json/decoder.py (using anaconda)

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -326,7 +326,12 @@ def load_json(path, api_version=None):
         content = fd.read()
 
     content = minify_json.json_minify(content)
-    d = json.loads(content)
+    try:
+        d = json.loads(content)
+    except ValueError as e:
+        raise ValueError(
+            "Error parsing JSON in file '{0}': {1}".format(
+                path, six.text_type(e)))
 
     if api_version is not None:
         if 'version' in d:


### PR DESCRIPTION
I'm trying to use this for the first time.  I followed the quickstart instructions (http://spacetelescope.github.io/asv/using.html) but got the following when I ran `asv run`:

```
Traceback (most recent call last):
  File "/Users/ketch/anaconda/bin/asv", line 9, in <module>
    load_entry_point('asv==0.1', 'console_scripts', 'asv')()
  File "/Users/ketch/anaconda/lib/python2.7/site-packages/asv-0.1-py2.7.egg/asv/main.py", line 35, in main
    result = args.func(args)
  File "/Users/ketch/anaconda/lib/python2.7/site-packages/asv-0.1-py2.7.egg/asv/commands/__init__.py", line 39, in run_from_args
    conf = config.Config.load(args.config)
  File "/Users/ketch/anaconda/lib/python2.7/site-packages/asv-0.1-py2.7.egg/asv/config.py", line 46, in load
    d = util.load_json(path, cls.api_version)
  File "/Users/ketch/anaconda/lib/python2.7/site-packages/asv-0.1-py2.7.egg/asv/util.py", line 329, in load_json
    d = json.loads(content)
  File "/Users/ketch/anaconda/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/Users/ketch/anaconda/lib/python2.7/json/decoder.py", line 365, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Users/ketch/anaconda/lib/python2.7/json/decoder.py", line 381, in raw_decode
    obj, end = self.scan_once(s, idx)
ValueError: Expecting property name: line 1 column 126 (char 125)
```
