### PR TITLE
Import typo

### DIFF
--- a/asv/commands/__init__.py
+++ b/asv/commands/__init__.py
@@ -36,7 +36,7 @@ class Command(object):
 
     @classmethod
     def run_from_args(cls, args):
-        from .. import plugin_manager
+        from ..plugin_manager import plugin_manager
         conf = config.Config.load(args.config)
         for plugin in conf.plugins:
             plugin_manager.import_plugin(plugin)


### PR DESCRIPTION
I think this is what is intended -- otherwise `import_plugin` acts on the `plugin_manager` module and throws an AttributeError
