### PR TITLE
Feature request - equal commit spacing on x axis

### DIFF
--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -77,6 +77,7 @@
           <div class="btn-group-vertical" style="width: 100%" data-toggle="buttons">
             <a id="log-scale" class="btn btn-default btn-xs" role="button">log scale</a>
             <a id="reference" class="btn btn-default btn-xs" role="button">reference</a>
+            <a id="even-spacing" class="btn btn-default btn-xs" role="button">even commit spacing</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Sometimes development happens fast over a few hours, then nothing for a month, and then more active development. For cases like this, it could be interesting to space the commits equally on the x-axis - would it be easy to add a mode for this?
