### PR TITLE
Make it clearer that config should not end with comma

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -329,6 +329,8 @@ def load_json(path, api_version=None):
         content = fd.read()
 
     content = minify_json.json_minify(content)
+    content = content.replace(",]", "]")
+    content = content.replace(",}", "}")
     try:
         d = json.loads(content)
     except ValueError as e:

--- a/test/asv.conf.json
+++ b/test/asv.conf.json
@@ -22,5 +22,5 @@
 
     "version": 1,
 
-    "plugins": [".example_plugin"]
+    "plugins": [".example_plugin"],
 }


### PR DESCRIPTION
If one simply edits the default settings, the last non-commented item finishes with a comma which causes the error:

```
ValueError: Error parsing JSON in file '/Users/tom/tmp/wcsaxes-benchmarks/asv.conf.json': Expecting property name enclosed in double quotes: line 1 column 131 (char 130)
```

It would be nice to have a more explicit error message.
