### PR TITLE
How does the help sub-command work?

### DIFF
--- a/asv/commands/__init__.py
+++ b/asv/commands/__init__.py
@@ -55,7 +55,7 @@ def make_argparser():
     Most of the real work is handled by the subcommands in the
     commands subpackage.
     """
-    def help(conf, args):
+    def help(args):
         parser.print_help()
         sys.exit(0)
 


### PR DESCRIPTION
I don't get how the `asv help` sub-command is supposed to work ... trying to use it like `git help` gives me errors:

``` bash
$ asv help
Traceback (most recent call last):
  File "/Users/deil/Library/Python/2.7/bin/asv", line 9, in <module>
    load_entry_point('asv==0.1', 'console_scripts', 'asv')()
  File "/Users/deil/Library/Python/2.7/lib/python/site-packages/asv-0.1-py2.7.egg/asv/main.py", line 35, in main
    result = args.func(args)
TypeError: help() takes exactly 2 arguments (1 given)
$ asv help run
usage: asv [-h] [--verbose] [--config CONFIG]
           {help,quickstart,machine,setup,run,continuous,find,rm,publish,preview,profile,update,gh-pages}
           ...
asv: error: unrecognized arguments: run
```

If this works for you, it might be an installation issue on my machine ... apparently the installed 3.4 version of asv executes the 2.7 version I installed a few months ago. Is this a bug?

``` bash
$ which asv
/Users/deil/Library/Python/3.4/bin/asv
$ asv help
Traceback (most recent call last):
  File "/Users/deil/Library/Python/2.7/bin/asv", line 9, in <module>
    load_entry_point('asv==0.1', 'console_scripts', 'asv')()
  File "/Users/deil/Library/Python/2.7/lib/python/site-packages/asv-0.1-py2.7.egg/asv/main.py", line 35, in main
    result = args.func(args)
TypeError: help() takes exactly 2 arguments (1 given)
```
