### PR TITLE
Commands docs missing again

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import asv
+
 import sys
 import os
 


### PR DESCRIPTION
#97 is back, as reported by @cdeil.
