### PR TITLE
print what asv gh-pages is doing to the console

### DIFF
--- a/asv/plugins/github.py
+++ b/asv/plugins/github.py
@@ -8,6 +8,7 @@ import os
 
 from ..commands import Command
 from ..commands.publish import Publish
+from ..console import log
 from .. import util
 
 
@@ -61,5 +62,6 @@ class GithubPages(Command):
         util.check_call("git mv html/* .", shell=True)
         util.check_call([git, 'commit', '-m', 'Generated from sources'])
 
+        log.info("Updating gh-pages branch on github")
         util.check_call([git, 'push', '-f', 'origin', 'gh-pages'])
         util.check_call([git, 'checkout', current_branch])


### PR DESCRIPTION
I just ran `asv gh-pages` for the first time (I think) and it printed exactly the same as `asv publish` to the console:

```
$ asv publish
[ 20.00%] · Loading machine info
[ 40.00%] · Loading results..
[ 60.00%] · Generating graphs........
[ 80.00%] · Getting tags
[ 80.00%] ·· Fetching recent changes...
[100.00%] · Writing index
$ asv gh-pages
[ 20.00%] · Loading machine info
[ 40.00%] · Loading results..
[ 60.00%] · Generating graphs........
[ 80.00%] · Getting tags
[ 80.00%] ·· Fetching recent changes...
[100.00%] · Writing index.
```

Apparently it did commit to a `gh-pages` branch though and push it out to Github.
It would be nice if it printed some info to the console that it's doing this (or print the `git` commands it executed).
