### PR TITLE
Missing digits on y-axis labels

### DIFF
--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -379,7 +379,6 @@ $(function() {
                         $('#reference').popover('destroy');
                         select_reference = false;
                         reference = item.datapoint[1];
-                        console.log(reference);
                         update_graphs();
                     } else {
                         var commit_hash = master_json.date_to_hash[item.datapoint[0]];
@@ -580,8 +579,6 @@ $(function() {
                 ticks.push(Math.pow(10, x) * reference);
             }
 
-            console.log(ticks);
-
             options.yaxis.ticks = ticks;
             options.yaxis.transform = function(v) {
                 return Math.log(v / reference) / Math.LN10;
@@ -597,7 +594,7 @@ $(function() {
                         Math.log(v / reference) / Math.LN10)).toString().sup();
             };
             options.yaxis.min = Math.pow(10, min) * reference;
-            options.yaxis.max = Math.pow(10, max) * reference;     
+            options.yaxis.max = Math.pow(10, max) * reference;
 
         } else if (master_json.benchmarks[current_benchmark].unit === 'seconds') {
 
@@ -619,7 +616,7 @@ $(function() {
             if (unit_name) {
                 options.yaxis.axisLabel = unit_name;
                 options.yaxis.tickFormatter = function (v, axis) {
-                    return Math.floor(v / multiplier);
+                    return (v / multiplier).toPrecision(3);
                 };
             }
         }


### PR DESCRIPTION
If you look here you'll see that all y-axis tick labels are `1`:
http://www.astropy.org/astropy-benchmarks/#time_coordinates.FrameBenchmarks.time_init_array
(also see attached screenshot)

I guess the bug is that more digits should be printed?

![screen shot 2014-12-01 at 14 18 25](https://cloud.githubusercontent.com/assets/852409/5246144/1e8e9cb0-7965-11e4-83d2-4d352906e738.png)
