### PR TITLE
quickstart should not overwrite by default

### DIFF
--- a/asv/commands/quickstart.py
+++ b/asv/commands/quickstart.py
@@ -37,6 +37,15 @@ class Quickstart(Command):
             os.path.dirname(os.path.abspath(__file__)), '..', 'template')
         for entry in os.listdir(template_path):
             path = os.path.join(template_path, entry)
+            dest_path = os.path.join(dest, entry)
+            if os.path.exists(dest_path):
+                log.info("Template content already exists.")
+                log.info("Edit asv.conf.json to continue.")
+                return 1
+
+        for entry in os.listdir(template_path):
+            path = os.path.join(template_path, entry)
+            dest_path = os.path.join(dest, entry)
             if os.path.isdir(path):
                 shutil.copytree(path, os.path.join(dest, entry))
             elif os.path.isfile(path):


### PR DESCRIPTION
I just accidentally overwrote the `asv.con.json` I had just edited by re-running `asv quickstart`.

Can you change `asv quickstart` to not do this, but instead tell me that `asv.conf.json` already exists and I should edit it?
