### PR TITLE
Sphinx docs don't look OK

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -120,7 +120,11 @@ html_theme = 'bootstrap'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    # This is a workaround for a bug in `sphinx_bootstrap_theme` for
+    # Python 3.x
+    'bootswatch_theme': None
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()


### PR DESCRIPTION
I generated the docs locally and it looks like there's some CSS file missing:
![screen shot 2014-12-01 at 13 50 32](https://cloud.githubusercontent.com/assets/852409/5245830/27fec06c-7961-11e4-9310-4d1359a587d6.png)

Can you reproduce?
