### PR TITLE
Slight bug in publish on Python 3

### DIFF
--- a/asv/machine.py
+++ b/asv/machine.py
@@ -4,6 +4,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import six
+
 import os
 import platform
 import sys
@@ -120,7 +122,7 @@ class Machine(object):
 
         cpu = util.get_cpu_info()
 
-        ram = util.get_memsize()
+        ram = six.text_type(util.get_memsize())
 
         return {
             'machine': node,


### PR DESCRIPTION
On [this line](https://github.com/spacetelescope/asv/blob/32c6471679520b7a95361dfde6f538637873191e/asv/commands/publish.py#L109) I was getting a crash because one of my machine's parameters (ram) was an integer (some number in megabytes), while on another machine the ram parameter was a string "8GB".  I'm not sure if it should have just not been an integer in the first place, but I just went with the default that the configuration provided which was the int value.

This resulted in an "unorderable types" error when sorting.
