### PR TITLE
Run benchmarks in deterministic order

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -328,7 +328,8 @@ class Benchmarks(dict):
         log.info("Benchmarking {0}".format(env.name))
         with log.indent():
             times = {}
-            for name, benchmark in six.iteritems(self):
+            benchmarks = sorted(list(six.iteritems(self)))
+            for name, benchmark in benchmarks:
                 times[name] = run_benchmark(
                     benchmark, self._benchmark_dir, env, show_exc=show_exc,
                     quick=quick, profile=profile)


### PR DESCRIPTION
When developing benchmarks, it is nice to have them run on a deterministic order in the console. A simple sorted order (as is expected from unit tests) would be sufficient.
