### PR TITLE
Random order of displayed benchmarks

### DIFF
--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -481,6 +481,7 @@ $(function() {
                     }
                 });
 
+                results.sort();
                 return results;
             }
 


### PR DESCRIPTION
I was going through the Astropy benchmarks and wanted to see if Python 3 is still systematically slower than Python 2.

It seems the order in which the benchmarks are shown is randomly changing on page refresh!?
This makes it very hard to browse the results and quickly notice what's what.

You should be able to reprodue this by refreshing this page a few times:
http://www.astropy.org/astropy-benchmarks/#time_coordinates.FrameBenchmarks.time_init_scalar

Here's two screenshots from that page to illustrate what I mean:
![screen shot 2014-12-15 at 17 39 14](https://cloud.githubusercontent.com/assets/852409/5439613/7326e0d0-8481-11e4-905c-4e02ce8a759c.png)
![screen shot 2014-12-15 at 17 39 33](https://cloud.githubusercontent.com/assets/852409/5439614/732b75dc-8481-11e4-8332-a9c303cf0ea5.png)
