### PR TITLE
Remove virtualenv as a hard requirement

### DIFF
--- a/asv/__init__.py
+++ b/asv/__init__.py
@@ -15,24 +15,4 @@ if sys.version_info >= (3, 3):
         os.unsetenv('__PYVENV_LAUNCHER__')
 
 
-def check_version_compatibility():
-    """
-    Performs a number of compatibility checks with third-party
-    libraries.
-    """
-    from distutils.version import LooseVersion
-
-    try:
-        import virtualenv
-    except ImportError:
-        pass
-    else:
-        if LooseVersion(virtualenv.__version__) == LooseVersion('1.11.0'):
-            raise RuntimeError(
-                "asv is not compatible with virtualenv 1.11 due to a bug in "
-                "setuptools.")
-
-
-check_version_compatibility()
-
 from . import plugin_manager

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+from distutils.version import LooseVersion
 import inspect
 import os
 import shutil
@@ -69,6 +70,19 @@ class Virtualenv(environment.Environment):
 
     @classmethod
     def matches(self, python):
+        try:
+            import virtualenv
+        except ImportError:
+            return False
+        else:
+            if LooseVersion(virtualenv.__version__) == LooseVersion('1.11.0'):
+                log.warn(
+                    "asv is not compatible with virtualenv 1.11 due to a bug in "
+                    "setuptools.")
+            if LooseVersion(virtualenv.__version__) < LooseVersion('1.10'):
+                log.warn(
+                    "If using virtualenv, it much be at least version 1.10")
+
         try:
             util.which('python{0}'.format(python))
         except IOError:

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ setup(
     },
 
     install_requires=[
-        str('six>=1.4'),
-        str('virtualenv>=1.10,!=1.11.0')
+        str('six>=1.4')
     ],
 
     package_data={


### PR DESCRIPTION
Since conda support was added, it isn't strictly required anymore.
