### PR TITLE
Include 0 on y axis by default.

### DIFF
--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -102,8 +102,8 @@ $(function() {
     var graphs = [];
     /* True when log scaling is enabled. */
     var log_scale = false;
-    /* True when zero scaling is enabled. */
-    var zero_scale = false;
+    /* True when zooming in on the y-axis. */
+    var zoom_y_axis = false;
     /* True when log scaling is enabled. */
     var reference_scale = false;
     /* True when selecting a reference point */
@@ -297,15 +297,15 @@ $(function() {
         $('#log-scale').on('click', function(evt) {
             log_scale = !evt.target.classList.contains("active");
             reference_scale = false;
-            zero_scale = false;
+            zoom_y_axis = false;
             $('#reference').removeClass('active');
-            $('#zero-scale').removeClass('active');
+            $('#zoom-y-axis').removeClass('active');
             reference = 1.0;
             update_graphs();
         });
 
-        $('#zero-scale').on('click', function(evt) {
-            zero_scale = !evt.target.classList.contains("active");
+        $('#zoom-y-axis').on('click', function(evt) {
+            zoom_y_axis = !evt.target.classList.contains("active");
             reference_scale = false;
             log_scale = false;
             $('#reference').removeClass('active');
@@ -317,9 +317,9 @@ $(function() {
         $('#reference').on('click', function(evt) {
             reference_scale = !evt.target.classList.contains("active");
             log_scale = false;
-            zero_scale = false;
+            zoom_y_axis = false;
             $('#log-scale').removeClass('active');
-            $('#zero-scale').removeClass('active');
+            $('#zoom-y-axis').removeClass('active');
             if (!reference_scale) {
                 update_graphs();
             } else {
@@ -485,6 +485,7 @@ $(function() {
                         },
                         yaxis: {
                             ticks: [],
+                            min: 0
                         },
                         legend: {
                             show: false
@@ -715,7 +716,7 @@ $(function() {
 
         } else if (master_json.benchmarks[current_benchmark].unit === 'seconds') {
 
-            if (zero_scale) {
+            if (!zoom_y_axis) {
                 options.yaxis.min = 0.;
                 options.yaxis.max = max * 1.3;
             }

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -91,10 +91,10 @@
                  title="Use a logarithmic scale on the y-axis">
                 log scale
               </a>
-              <a id="zero-scale" class="btn btn-default btn-xs" role="button"
+              <a id="zoom-y-axis" class="btn btn-default btn-xs" role="button"
                  data-toggle="tooltip" data-placement="right"
-                 title="Extend the y-axis down to 0">
-                zero scale
+                 title="Zoom y axis to the range of the data, rather than down to zero.">
+                zoom <i>y</i> axis
               </a>
               <a id="reference" class="btn btn-default btn-xs" role="button"
                  data-toggle="tooltip" data-placement="right"


### PR DESCRIPTION
This inverts the logic of the "zero scale" option to now be called "zoom y axis".  Also displays the summary graphs with 0.
