### PR TITLE
Output of args in check_output

### DIFF
--- a/asv/plugins/github.py
+++ b/asv/plugins/github.py
@@ -59,7 +59,7 @@ class GithubPages(Command):
         util.check_call([git, 'add', '.nojekyll'])
 
         util.check_call([git, 'add', '-f', 'html'])
-        util.check_call("git mv html/* .", shell=True)
+        util.check_call(["git mv html/* ."], shell=True)
         util.check_call([git, 'commit', '-m', 'Generated from sources'])
 
         log.info("Updating gh-pages branch on github")

--- a/asv/util.py
+++ b/asv/util.py
@@ -268,6 +268,9 @@ def check_output(args, error=True, timeout=120, dots=True, display_error=True,
 
         return '\n'.join(content)
 
+    if isinstance(args, six.string_types):
+        args = [args]
+
     log.debug("Running '{0}'".format(' '.join(args)))
 
     proc = subprocess.Popen(


### PR DESCRIPTION
This coerces the `args` list in `check_output` to a list.  It also makes all commands in `gh-pull` pass a list, just for good measure.
