### PR TITLE
ENH: add support for requirements files with virtualenv

### DIFF
--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -31,6 +31,11 @@
     // variable.
     "environment_type": "virtualenv",
 
+    // An optional pip requirements file to be installed into the
+    // environment. If not set, `pip install -r` will not be run. This
+    // option is ignored if environment_type is not "virtualenv".
+    // requirements_file: "requirements.txt",
+
     // the base URL to show a commit for the project.
     // "show_commit_url": "http://github.com/owner/project/commit/",
 

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -215,6 +215,11 @@ Specifies the tool to use to create environments.  May be "conda",
 missing or the empty string, the tool will be automatically determined
 by looking for tools on the ``PATH`` environment variable.
 
+``requirements_file``
+---------------------
+When using ``virtualenv``, this specifies the path to a requirements file
+to be installed using ``pip install -r``. This key is optional.
+
 ``env_dir``
 -----------
 The directory, relative to the current directory, to cache the Python

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -211,6 +211,10 @@ versions of Python installed -- your package manager, ``apt-get``,
 ``yum``, ``MacPorts`` or ``homebrew`` probably has them, or you
 can also use `pyenv <https://github.com/yyuu/pyenv>`__.
 
+Additionally, a ``requirements_file`` key, if present, will cause
+``asv`` to run ``pip install -r <file>`` in the newly-created
+environment.
+
 Benchmarking
 ````````````
 


### PR DESCRIPTION
I was fiddling with a project that uses `pip install -r requirements.txt` rather than `install_requires` in `setup.py` and came up with the following extension to the `virtualenv` plugin.

Is the "right" way to achieve this? I don't like the overloading of `environment.build_project`, but this needs to appear between VCS checkout and the call to `setup.py`, which both happen therein.

I'll write some tests if this looks mergeable.
