### PR TITLE
ENH: Add an option to randomize the order of the hashes

### DIFF
--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -290,3 +290,14 @@ def test_run_build_failure(basic_conf):
     assert len(data_ok['results']) == 1
     assert data_broken['results'][bench_name] is None
     assert data_ok['results'][bench_name] == 42.0
+
+
+def test_randomize(capfd, basic_conf):
+
+    tmpdir, local, conf, machine_file = basic_conf
+
+    # Tests a typical complete run/publish workflow
+    tools.run_asv_with_conf(conf, 'run', "ALL", '--steps=3',
+                            '--quick', '--randomize-order',
+                            _machine_file=machine_file)
+


### PR DESCRIPTION
When running on a repo with e.g. 10,000 commits, this allows one to see the general trends building up slowly rather than doing each commit sequentially.
