### PR TITLE
ENH: Benchmarking import times.

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -33,6 +33,7 @@ import json
 import os
 import pickle
 import re
+import subprocess
 import textwrap
 import timeit
 
@@ -596,6 +597,59 @@ class PeakMemBenchmark(Benchmark):
         return get_maxrss()
 
 
+class ImpBenchmark(TimeBenchmark):
+    """
+    Represents a single benchmark for tracking import times.
+    """
+    name_regex = re.compile(
+        '^(Imp[A-Z_].+)|(imp_.+)$')
+    subprocess_tmpl = textwrap.dedent('''
+        from __future__ import print_function
+        from timeit import timeit
+        try:
+            # Python 3.3+.
+            from time import process_time as timer
+        except ImportError:
+            from timeit import default_timer as timer
+
+        print(timeit(stmt="""{stmt}""", number={number}, timer=timer))
+    ''').strip()
+
+    def do_profile(self, filename=None):
+        raise ValueError("Import benchmarks cannot be profiled")
+
+    def run(self, *param):
+        if param:
+            raise ValueError("Import benchmarks do not support parameters")
+        body = self.code[self.code.index('\n') + 1:]
+        stmt = textwrap.dedent(body).replace('"""', r'\"\"\"')
+
+        def subprocess_timeit(number):
+            self.redo_setup()
+            script = self.subprocess_tmpl.format(stmt=stmt, number=number)
+            timing = subprocess.check_output((sys.executable, '-c', script))
+            return float(timing)
+
+        number = self.number
+        if number == 0:
+            # Consequent imports take negligible time.
+            number = 1
+
+        timings = []
+        repeat = self.repeat
+        if repeat == 0:
+            # Do not exceed the goal time by more than one run (taking into
+            # account interpreter startup overhead in the subprocess).
+            system_time = timeit.default_timer
+            start = system_time()
+            while system_time() - start < self.goal_time:
+                timings.append(subprocess_timeit(number))
+        else:
+            for r in range(repeat):
+                timings.append(subprocess_timeit(number))
+        return min(timings) / number
+
+
 class TrackBenchmark(Benchmark):
     """
     Represents a single benchmark for tracking an arbitrary value.
@@ -616,7 +670,7 @@ class TrackBenchmark(Benchmark):
 
 
 benchmark_types = [
-    TimeBenchmark, MemBenchmark, PeakMemBenchmark, TrackBenchmark
+    TimeBenchmark, MemBenchmark, PeakMemBenchmark, ImpBenchmark, TrackBenchmark
 ]
 
 

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -253,6 +253,8 @@ Note that ``setup_cache`` is not parameterized.
 Benchmark types
 ---------------
 
+.. _timing:
+
 Timing
 ``````
 
@@ -389,6 +391,38 @@ memory usage you want to track::
    ``setup`` routine, which may confound the benchmark results. One
    way to avoid this is to use ``setup_cache`` instead.
 
+Imports
+```````
+
+To benchmark import times use the ``imp`` prefix::
+
+    def imp_inspect():
+        import inspect
+
+Importing a module takes a meaningful amount of time only the first time
+it is executed, therefore a fresh interpreter is used for each iteration of
+the benchmark. The source code of the benchmark function is executed in a
+subprocess; the setup is performed in the base benchmark process, parameters
+and profiling are not supported.
+
+The ``goal_time``, ``number``, and ``repeat`` arguments have the same meaning
+as in :ref:`timing` benchmarks, but by default ``number`` is set to 1 and
+``repeat`` is adjusted to approximate the goal time. The ``timer`` argument is
+ignored, ``process_time`` is used inside the subprocess (falling back to
+``timeit.default_timer`` under older Pythons).
+
+.. note::
+
+   Timing standard library modules is possible as long as they are not
+   `built-in`_ or brought in by importing the ``timeit`` module (which
+   further imports ``gc``, ``sys``, ``time``, and ``itertools``).
+
+.. note::
+
+   Import benchmarks require Python 2.7 or later, the timing is more precise
+   with Python 3.3 or later.
+
+.. _built-in: https://hg.python.org/cpython/file/tip/Modules/Setup.dist
 
 .. _tracking:
 

--- a/test/benchmark/imp_examples.py
+++ b/test/benchmark/imp_examples.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import inspect  # Checked below.
+import sys
+
+
+class ImpSuite(object):
+    def imp_fresh(self):
+        # The test interpreter should not be polluted with anything.
+        import sys
+        assert 'asv' not in sys.modules
+        assert 'inspect' not in sys.modules
+
+    def imp_docstring(self):
+        """
+        Docstrings may be used to comment benchmarks.
+        """
+        pass
+
+    def imp_timeout(self):
+        # Inside the grandchild.
+        while True:
+            pass
+    imp_timeout.timeout = .1
+
+    def imp_count(self):
+        # Using number other than one or a fixed repeat should work.
+        import sys
+        sys.stderr.write('0')
+    imp_count.number = 3
+    imp_count.repeat = 7


### PR DESCRIPTION
Imports require a fairly specific treatment:
* just the first import takes time, a fresh interpreter is needed for each iteration;
* the user may want to judge the impact of importing a standard library module, so the benchmark environment should be pristine;
* `goal_time` may be approximated by adjusting `repeat`, but `number` in most cases should be 1.

There are a couple of approaches:
* a specialized benchmark (as presented here);
* a new `subprocess` argument;
* finding a way to reset the Python interpreter;
* sub-interpreters (`Py_NewInterpreter`).

The `subprocess` flag would be slightly more general, but for what else would it be useful? On the other hand, a specialized benchmark could be extended to also evaluate memory usage of imports (with #179).
Properly resetting the interpreter (if at all possible, cleaning `sys.modules` is not sufficient) or benchmarking in sub-interpreters may be hard to keep compatible across multiple versions of Python.

Some discussion can be found in https://github.com/numpy/numpy/pull/8159 and https://github.com/astropy/astropy-benchmarks/pull/15.