### PR TITLE
Display last part of benchmark name in left pannel

### DIFF
--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -185,7 +185,7 @@ $(document).ready(function() {
                 });
             }
 
-            var name = bm.pretty_name || bm.name || parts[parts.length - 1];
+            var name = bm.pretty_name || parts[parts.length - 1];
             var top = $('<li><a href="#' + bm_name + '">' + name + '</li>');
             stack[stack.length - 1].append(top);
 


### PR DESCRIPTION
On left pannel, navigation accross benchmark is generated using
benchmark name partitioned by '.', only display last part of the name
since all other parts are already displayed.

Previous code using "bm.name || last_part" was inconsistent since
bm.name is never empty and last_part is generated using bm.name