### PR TITLE
Group benchmarks in summary grid

### DIFF
--- a/asv/www/asv.css
+++ b/asv/www/asv.css
@@ -125,8 +125,11 @@ nav li.active span.navbar-brand:hover {
 
 /* Summary page */
 
+.benchmark-group > h1 {
+    text-align: center;
+}
+
 .benchmark-container {
-    float: left;
     width: 300px;
     height: 116px;
     padding: 4px;

--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -398,6 +398,20 @@ $(document).ready(function() {
         return rev;
     }
 
+    function get_benchmark_by_groups() {
+        var groups = {};
+        $.each(master_json.benchmarks, function(bm_name, bm) {
+            var i = bm_name.indexOf('.');
+            var group = bm_name.slice(0, i);
+            var name = bm_name.slice(i + 1);
+            if (groups[group] === undefined) {
+                groups[group] = [];
+            }
+            groups[group].push(bm_name);
+        });
+        return groups;
+    }
+
     function init() {
         /* Fetch the master index.json and then set up the page elements
            based on it. */
@@ -448,6 +462,7 @@ $(document).ready(function() {
     this.load_graph_data = load_graph_data;
     this.get_commit_hash = get_commit_hash;
     this.get_revision = get_revision;
+    this.get_benchmark_by_groups = get_benchmark_by_groups;
 
     this.master_json = master_json; /* Updated after index.json loads */
 

--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -398,20 +398,6 @@ $(document).ready(function() {
         return rev;
     }
 
-    function get_benchmark_by_groups() {
-        var groups = {};
-        $.each(master_json.benchmarks, function(bm_name, bm) {
-            var i = bm_name.indexOf('.');
-            var group = bm_name.slice(0, i);
-            var name = bm_name.slice(i + 1);
-            if (groups[group] === undefined) {
-                groups[group] = [];
-            }
-            groups[group].push(bm_name);
-        });
-        return groups;
-    }
-
     function init() {
         /* Fetch the master index.json and then set up the page elements
            based on it. */
@@ -462,7 +448,6 @@ $(document).ready(function() {
     this.load_graph_data = load_graph_data;
     this.get_commit_hash = get_commit_hash;
     this.get_revision = get_revision;
-    this.get_benchmark_by_groups = get_benchmark_by_groups;
 
     this.master_json = master_json; /* Updated after index.json loads */
 

--- a/asv/www/summarygrid.js
+++ b/asv/www/summarygrid.js
@@ -24,7 +24,7 @@ $(document).ready(function() {
             '"/>');
         var plot_div = $(
             '<div id="summarygrid-' + bm.name + '" class="benchmark-plot"/>');
-        var display_name = bm.pretty_name || bm.name;
+        var display_name = bm.pretty_name || bm.name.slice(bm.name.indexOf('.') + 1);
         var name = $('<div class="benchmark-text">' + display_name + '</div>');
         name.tooltip({
             title: bm.name,
@@ -95,8 +95,14 @@ $(document).ready(function() {
             return;
         }
 
-        $.each(master_json.benchmarks, function(bm_name, bm) {
-            summary_container.append(benchmark_container(bm));
+        $.each($.asv.get_benchmark_by_groups(), function(group, benchmarks) {
+            var group_container = $('<div class="benchmark-group"/>')
+            group_container.append($('<h1>' + group + '</h1>'));
+            summary_display.append(group_container);
+            $.each(benchmarks, function(i, bm_name) {
+                var bm = $.asv.master_json.benchmarks[bm_name];
+                group_container.append(benchmark_container(bm));
+            });
         });
 
         summary_display.append(summary_container);

--- a/asv/www/summarygrid.js
+++ b/asv/www/summarygrid.js
@@ -24,7 +24,8 @@ $(document).ready(function() {
             '"/>');
         var plot_div = $(
             '<div id="summarygrid-' + bm.name + '" class="benchmark-plot"/>');
-        var name = $('<div class="benchmark-text">' + bm.name + '</div>');
+        var display_name = bm.pretty_name || bm.name;
+        var name = $('<div class="benchmark-text">' + display_name + '</div>');
         name.tooltip({
             title: bm.name,
             html: true,

--- a/asv/www/summarygrid.js
+++ b/asv/www/summarygrid.js
@@ -18,6 +18,21 @@ $(document).ready(function() {
         $(window).on('scroll', handler);
     }
 
+    function get_benchmarks_by_groups() {
+        var master_json = $.asv.master_json;
+        var groups = {};
+        $.each(master_json.benchmarks, function(bm_name, bm) {
+            var i = bm_name.indexOf('.');
+            var group = bm_name.slice(0, i);
+            var name = bm_name.slice(i + 1);
+            if (groups[group] === undefined) {
+                groups[group] = [];
+            }
+            groups[group].push(bm_name);
+        });
+        return groups;
+    }
+
     function benchmark_container(bm) {
         var container = $(
             '<a class="btn benchmark-container" href="#' + bm.name +
@@ -95,7 +110,7 @@ $(document).ready(function() {
             return;
         }
 
-        $.each($.asv.get_benchmark_by_groups(), function(group, benchmarks) {
+        $.each(get_benchmarks_by_groups(), function(group, benchmarks) {
             var group_container = $('<div class="benchmark-group"/>')
             group_container.append($('<h1>' + group + '</h1>'));
             summary_display.append(group_container);

--- a/asv/www/summarygrid.js
+++ b/asv/www/summarygrid.js
@@ -18,6 +18,73 @@ $(document).ready(function() {
         $(window).on('scroll', handler);
     }
 
+    function benchmark_container(bm) {
+        var container = $(
+            '<a class="btn benchmark-container" href="#' + bm.name +
+            '"/>');
+        var plot_div = $(
+            '<div id="summarygrid-' + bm.name + '" class="benchmark-plot"/>');
+        var name = $('<div class="benchmark-text">' + bm.name + '</div>');
+        name.tooltip({
+            title: bm.name,
+            html: true,
+            placement: 'top',
+            container: 'body',
+            animation: false
+        });
+
+        plot_div.tooltip({
+            title: bm.code,
+            html: true,
+            placement: 'bottom',
+            container: 'body',
+            animation: false
+        });
+
+        container.append(name);
+        container.append(plot_div);
+
+        callback_in_view(plot_div, function() {
+            $.asv.load_graph_data(
+                'graphs/summary/' + bm.name + '.json'
+            ).done(function(data) {
+                var options = {
+                    colors: $.asv.colors,
+                    series: {
+                        lines: {
+                            show: true,
+                            lineWidth: 2
+                        },
+                        shadowSize: 0
+                    },
+                    grid: {
+                        borderWidth: 1,
+                        margin: 0,
+                        labelMargin: 0,
+                        axisMargin: 0,
+                        minBorderMargin: 0
+                    },
+                    xaxis: {
+                        ticks: [],
+                    },
+                    yaxis: {
+                        ticks: [],
+                        min: 0
+                    },
+                    legend: {
+                        show: false
+                    }
+                };
+
+                var plot = $.plot(
+                    plot_div, [{data: data}], options);
+            }).fail(function() {
+                // TODO: Handle failure
+            });
+        });
+        return container;
+    }
+
     function make_summary() {
         var summary_display = $('#summarygrid-display');
         var master_json = $.asv.master_json;
@@ -28,70 +95,7 @@ $(document).ready(function() {
         }
 
         $.each(master_json.benchmarks, function(bm_name, bm) {
-            var container = $(
-                '<a class="btn benchmark-container" href="#' + bm_name +
-                '"/>');
-            var plot_div = $(
-                '<div id="summarygrid-' + bm_name + '" class="benchmark-plot"/>');
-            var name = $('<div class="benchmark-text">' + bm_name + '</div>');
-            name.tooltip({
-                title: bm_name,
-                html: true,
-                placement: 'top',
-                container: 'body',
-                animation: false
-            });
-
-            plot_div.tooltip({
-                title: bm.code,
-                html: true,
-                placement: 'bottom',
-                container: 'body',
-                animation: false
-            });
-
-            container.append(name);
-            container.append(plot_div);
-            summary_container.append(container);
-
-            callback_in_view(plot_div, function() {
-                $.asv.load_graph_data(
-                    'graphs/summary/' + bm_name + '.json'
-                ).done(function(data) {
-                    var options = {
-                        colors: $.asv.colors,
-                        series: {
-                            lines: {
-                                show: true,
-                                lineWidth: 2
-                            },
-                            shadowSize: 0
-                        },
-                        grid: {
-                            borderWidth: 1,
-                            margin: 0,
-                            labelMargin: 0,
-                            axisMargin: 0,
-                            minBorderMargin: 0
-                        },
-                        xaxis: {
-                            ticks: [],
-                        },
-                        yaxis: {
-                            ticks: [],
-                            min: 0
-                        },
-                        legend: {
-                            show: false
-                        }
-                    };
-
-                    var plot = $.plot(
-                        plot_div, [{data: data}], options);
-                }).fail(function() {
-                    // TODO: Handle failure
-                });
-            });
+            summary_container.append(benchmark_container(bm));
         });
 
         summary_display.append(summary_container);


### PR DESCRIPTION
Use the first component of the benchmark name as group name and use it
as separation between benchmarks. So we can remove group name from
benchmark name and it become shorted.
This ease quickly reading the summary grid.

Screenshot https://framapic.org/Bo0MeTRUrTWX/RSzZevQISzuu.png