### PR TITLE
Enabled stdin for run range_spec.

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
+import sys
 import logging
 import traceback
 
@@ -53,7 +54,7 @@ class Run(Command):
             description="Run a benchmark suite.")
 
         parser.add_argument(
-            'range', nargs='?', default=None,
+            'range', nargs='?', default=sys.stdin,
             help="""Range of commits to benchmark.  For a git
             repository, this is passed as the first argument to ``git
             log``.  See 'specifying ranges' section of the
@@ -161,7 +162,10 @@ class Run(Command):
         elif isinstance(range_spec, list):
             commit_hashes = range_spec
         else:
-            commit_hashes = repo.get_hashes_from_range(range_spec)
+            try:  # if range_spec is stdin it will have .read()
+                commit_hashes = range_spec.read().splitlines()
+            except AttributeError:
+                commit_hashes = repo.get_hashes_from_range(range_spec)
 
         if len(commit_hashes) == 0:
             log.error("No commit hashes selected")

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -89,7 +89,7 @@ class Repo(object):
 
     def get_new_range_spec(self, latest_result, branch=None):
         """
-        Returns a formatted string giving the results between the 
+        Returns a formatted string giving the results between the
         latest result and the newest hash in a given branch.
         If no branch given, use the 'master' branch.
         """
@@ -107,6 +107,13 @@ class Repo(object):
         syntax of the range specifier will depend on the DVCS used.
         """
         raise NotImplementedError()
+
+    def get_hashes_from_pipe(self, text):
+        """
+        Get a list of commit hashes given a chunk of text where each hash is on
+        a new line.
+        """
+        return [s.strip() for s in text.splitlines()]
 
     def get_hash_from_name(self, name):
         """


### PR DESCRIPTION
This assumes that you supply a chunk of text in which a commit hash is
on each line of the text. For example, this now works:

git log --oneline --format=%H | asv run

Fixes issue 561.