### PR TITLE
Perform benchmark discovery only when running benchmarks

### DIFF
--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -91,7 +91,8 @@ class Find(Command):
             log.error("No environments selected")
             return 1
 
-        benchmarks = Benchmarks(conf, repo, environments, regex=bench)
+        benchmarks = Benchmarks.discover(conf, repo, environments,
+                                         commit_hashes, regex=bench)
         if len(benchmarks) == 0:
             log.error("'{0}' benchmark not found".format(bench))
             return 1

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -164,7 +164,9 @@ class Profile(Command):
                     "Profiles must be run in the same version of Python as the "
                     "asv master process")
 
-            benchmarks = Benchmarks(conf, repo, environments, regex='^{0}$'.format(benchmark))
+            benchmarks = Benchmarks.discover(conf, repo, environments,
+                                             [commit_hash],
+                                             regex='^{0}$'.format(benchmark))
             if len(benchmarks) != 1:
                 raise util.UserError(
                     "Could not find benchmark {0}".format(benchmark))

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -68,8 +68,6 @@ class Publish(Command):
                 "Optional output directory. Default is 'html_dir' "
                 "from asv config"))
 
-        common_args.add_environment(parser)
-
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
@@ -78,8 +76,7 @@ class Publish(Command):
     def run_from_conf_args(cls, conf, args):
         if args.html_dir is not None:
             conf.html_dir = args.html_dir
-        return cls.run(conf=conf, env_spec=args.env_spec,
-                       range_spec=args.range, pull=not args.no_pull)
+        return cls.run(conf=conf, range_spec=args.range, pull=not args.no_pull)
 
     @staticmethod
     def iter_results(conf, repo, range_spec=None):
@@ -95,7 +92,7 @@ class Publish(Command):
                 yield result
 
     @classmethod
-    def run(cls, conf, env_spec=None, range_spec=None, pull=True):
+    def run(cls, conf, range_spec=None, pull=True):
         params = {}
         graphs = GraphSet()
         machines = {}
@@ -106,9 +103,8 @@ class Publish(Command):
         if os.path.exists(conf.html_dir):
             util.long_path_rmtree(conf.html_dir)
 
-        environments = list(environment.get_environments(conf, env_spec))
         repo = get_repo(conf)
-        benchmarks = Benchmarks.load(conf, repo, environments)
+        benchmarks = Benchmarks.load(conf)
 
         template_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), '..', 'www')

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -187,11 +187,15 @@ class Run(Command):
                         "No range spec may be specified if benchmarking in "
                         "an existing environment")
 
-        benchmarks = Benchmarks(conf, repo, environments, regex=bench)
+        benchmarks = Benchmarks.discover(conf, repo, environments,
+                                         commit_hashes, regex=bench)
+        benchmarks.save()
         if len(benchmarks) == 0:
             log.error("No benchmarks selected")
-            return 1
-        benchmarks.save()
+            if bench == ["just-discover"]:
+                return 0
+            else:
+                return 1
 
         steps = len(commit_hashes) * len(benchmarks) * len(environments)
 

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -497,23 +497,15 @@ class Environment(object):
 
     def build_project(self, repo, commit_hash):
         self.checkout_project(repo, commit_hash)
-        log.info("Building for {0}".format(self.name))
+        log.info("Building {0} for {1}".format(commit_hash[:8], self.name))
         self.run(['setup.py', 'build'], cwd=self._build_root)
         return self._build_root
 
-    def install_project(self, conf, repo, commit_hash=None):
+    def install_project(self, conf, repo, commit_hash):
         """
         Install the benchmarked project into the environment.
         Uninstalls any installed copy of the project first.
-        If no specific commit hash is given, one is chosen;
-        either a choice that already exist in wheel cache,
-        or first current branch configured.
         """
-        if commit_hash is None:
-            commit_hash = self._cache.get_existing_commit_hash()
-            if commit_hash is None:
-                commit_hash = repo.get_hash_from_name(conf.branches[0])
-
         self.uninstall(conf.project)
 
         build_root = self._cache.build_project_cached(

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -57,34 +57,40 @@ def test_find_benchmarks(tmpdir):
 
     envs = list(environment.get_environments(conf, None))
 
-    b = benchmarks.Benchmarks(conf, repo, envs, regex='secondary')
+    commit_hash = repo.get_hash_from_name(repo.get_branch_name())
+
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
+                                       regex='secondary')
     assert len(b) == 3
 
-    b = benchmarks.Benchmarks(conf, repo, envs, regex='example')
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
+                                       regex='example')
     assert len(b) == 25
 
-    b = benchmarks.Benchmarks(conf, repo, envs, regex='time_example_benchmark_1')
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
+                              regex='time_example_benchmark_1')
     assert len(b) == 2
 
-    b = benchmarks.Benchmarks(conf, repo, envs, regex=['time_example_benchmark_1',
-                                                       'some regexp that does not match anything'])
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
+                              regex=['time_example_benchmark_1',
+                                     'some regexp that does not match anything'])
     assert len(b) == 2
 
-    b = benchmarks.Benchmarks(conf, repo, envs, regex='custom')
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex='custom')
     assert sorted(b.keys()) == ['custom.time_function', 'custom.track_method',
                                 'named.track_custom_pretty_name']
     assert 'pretty_name' not in b['custom.track_method']
     assert b['custom.time_function']['pretty_name'] == 'My Custom Function'
     assert b['named.track_custom_pretty_name']['pretty_name'] == 'this.is/the.answer'
 
-    b = benchmarks.Benchmarks(conf, repo, envs)
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
     assert len(b) == 35
 
     assert 'named.OtherSuite.track_some_func' in b
 
     start_timestamp = datetime.datetime.utcnow()
 
-    b = benchmarks.Benchmarks(conf, repo, envs)
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
     times = b.run_benchmarks(envs[0], profile=True, show_stderr=True)
 
     end_timestamp = datetime.datetime.utcnow()
@@ -180,9 +186,10 @@ def test_invalid_benchmark_tree(tmpdir):
 
     repo = get_repo(conf)
     envs = list(environment.get_environments(conf, None))
+    commit_hash = repo.get_hash_from_name(repo.get_branch_name())
 
     with pytest.raises(util.UserError):
-        b = benchmarks.Benchmarks(conf, repo, envs)
+        b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
 
 
 def test_table_formatting():
@@ -266,8 +273,10 @@ def track_this():
 
     repo = get_repo(conf)
     envs = list(environment.get_environments(conf, None))
+    commit_hash = repo.get_hash_from_name(repo.get_branch_name())
 
-    b = benchmarks.Benchmarks(conf, repo, envs, regex='track_this')
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
+                                       regex='track_this')
     assert len(b) == 1
 
 
@@ -287,8 +296,9 @@ def test_quick(tmpdir):
 
     repo = get_repo(conf)
     envs = list(environment.get_environments(conf, None))
+    commit_hash = repo.get_hash_from_name(repo.get_branch_name())
 
-    b = benchmarks.Benchmarks(conf, repo, envs)
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
     skip_names = [name for name in b.keys() if name != 'time_examples.TimeWithRepeat.time_it']
     times = b.run_benchmarks(envs[0], quick=True, show_stderr=True, skip=skip_names)
 
@@ -314,10 +324,11 @@ def test_code_extraction(tmpdir):
     conf = config.Config.from_json(d)
 
     repo = get_repo(conf)
-
     envs = list(environment.get_environments(conf, None))
+    commit_hash = repo.get_hash_from_name(repo.get_branch_name())
 
-    b = benchmarks.Benchmarks(conf, repo, envs, regex=r'^code_extraction\.')
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
+                                       regex=r'^code_extraction\.')
 
     expected_code = textwrap.dedent("""
     def track_test():

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -138,12 +138,12 @@ def test_run_publish(capfd, basic_conf):
     tools.run_asv_with_conf(conf, 'run', "EXISTING", '--quick', *env_spec,
                             _machine_file=machine_file)
 
-    # Remove the benchmarks.json file to make sure publish can
-    # regenerate it
+    # Remove the benchmarks.json file and check publish fails
 
     os.remove(join(tmpdir, "results_workflow", "benchmarks.json"))
 
-    tools.run_asv_with_conf(conf, 'publish')
+    with pytest.raises(util.UserError):
+        tools.run_asv_with_conf(conf, 'publish')
 
 
 def test_continuous(capfd, basic_conf):


### PR DESCRIPTION
Discover benchmarks only when the project is going to be built and the
commit hashes to be checked are known, so the benchmark discovery can be
performed using those commits.  This also adjusts the Benchmarks API so
that the discovery is explicit.

Previously, benchmark discovery was done installing a version of the
project at the tip of the branch or from an existing wheel. This leads
to problems when the build fails or the project is not in an importable
state.

This also changes "asv publish" to emit an error message rather than
running benchmark discovery, if benchmarks.json is damaged or missing.
That is an unusual error condition, so it is reasonable to handle it as
such (the error message explains how to resolve it).