### PR TITLE
Fix benchmark name displayed in summarygrid

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -303,7 +303,7 @@ class Benchmark(object):
     def __init__(self, name, func, attr_sources):
         self.name = name
         self.func = func
-        self.pretty_name = getattr(func, "pretty_name", name)
+        self.pretty_name = getattr(func, "pretty_name", None)
         self._attr_sources = attr_sources
         self._setups = list(_get_all_attrs(attr_sources, 'setup', True))[::-1]
         self._teardowns = list(_get_all_attrs(attr_sources, 'teardown', True))

--- a/test/benchmark/named.py
+++ b/test/benchmark/named.py
@@ -17,3 +17,11 @@ def named_function(self):
 
 
 named_function.benchmark_name = 'custom.time_function'
+named_function.pretty_name = 'My Custom Function'
+
+
+def track_custom_pretty_name(self):
+    return 42
+
+
+track_custom_pretty_name.pretty_name = 'this.is/the.answer'

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -71,10 +71,14 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 2
 
     b = benchmarks.Benchmarks(conf, repo, envs, regex='custom')
-    assert sorted(b.keys()) == ['custom.time_function', 'custom.track_method']
+    assert sorted(b.keys()) == ['custom.time_function', 'custom.track_method',
+                                'named.track_custom_pretty_name']
+    assert 'pretty_name' not in b['custom.track_method']
+    assert b['custom.time_function']['pretty_name'] == 'My Custom Function'
+    assert b['named.track_custom_pretty_name']['pretty_name'] == 'this.is/the.answer'
 
     b = benchmarks.Benchmarks(conf, repo, envs)
-    assert len(b) == 33
+    assert len(b) == 34
 
     start_timestamp = datetime.datetime.utcnow()
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -120,8 +120,19 @@ def test_web_summarygrid(browser, basic_html):
 
         assert browser.title == 'airspeed velocity of an unladen asv'
 
+        # Verify benchmark names are displayed as expected
+        for href, expected in (
+            ('#subdir.time_subdir.time_foo', u'time_subdir.time_foo'),
+            ('#params_examples.ParamSuite.track_value', u'ParamSuite.track_value'),
+            ('#custom.time_function', u'My Custom Function'),
+            ('#named.track_custom_pretty_name', u'this.is/the.answer'),
+        ):
+            item = browser.find_element_by_xpath(
+                "//a[@href='{}']/div[@class='benchmark-text']".format(href))
+            assert item.text == expected
+
         # Open a graph display, scroll to item and click
-        item = browser.find_element_by_link_text('params_examples.track_param')
+        item = browser.find_element_by_link_text('track_param')
 
         y = item.location['y']
         browser.execute_script('window.scrollTo(0, {0})'.format(y - 200))


### PR DESCRIPTION
Commit c72518a (Display last part of benchmark name in left pannel)
wasn't working before when no pretty_name is set for the benchmark since
it was defaulting to the full benchmark name.

I see no reason to have a default for pretty_name and it's better to
have pretty_name undefined in javascript in this case, so let's drop the
default.