### PR TITLE
Rename timing benchmark parameter `goal_time` to `sample_time`

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -434,7 +434,7 @@ class TimeBenchmark(Benchmark):
     def _load_vars(self):
         self.repeat = _get_first_attr(self._attr_sources, 'repeat', 0)
         self.number = int(_get_first_attr(self._attr_sources, 'number', 0))
-        self.goal_time = _get_first_attr(self._attr_sources, 'goal_time', 0.1)
+        self.sample_time = _get_first_attr(self._attr_sources, 'sample_time', 0.1)
         self.warmup_time = _get_first_attr(self._attr_sources, 'warmup_time', -1)
         self.timer = _get_first_attr(self._attr_sources, 'timer', process_time)
 
@@ -476,12 +476,12 @@ class TimeBenchmark(Benchmark):
         return {'samples': samples, 'number': number}
 
     def benchmark_timing(self, timer, repeat, warmup_time, number=0):
-        goal_time = self.goal_time
+        sample_time = self.sample_time
 
         start_time = time.time()
 
-        max_time = start_time + min(warmup_time + 1.3 * repeat * goal_time,
-                                    self.timeout - 1.3 * goal_time)
+        max_time = start_time + min(warmup_time + 1.3 * repeat * sample_time,
+                                    self.timeout - 1.3 * sample_time)
 
         def too_slow():
             # too slow, don't take more samples
@@ -501,12 +501,12 @@ class TimeBenchmark(Benchmark):
                 wall_time = time.time() - start
                 actual_timing = max(wall_time, timing)
 
-                if actual_timing >= goal_time:
+                if actual_timing >= sample_time:
                     if time.time() > start_time + warmup_time:
                         break
                 else:
                     try:
-                        p = min(10.0, max(1.1, goal_time/actual_timing))
+                        p = min(10.0, max(1.1, sample_time/actual_timing))
                     except ZeroDivisionError:
                         p = 10.0
                     number = max(number + 1, int(p * number))

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -310,26 +310,26 @@ by the ``number`` and ``repeat`` attributes, as explained below.
 
 **Attributes**:
 
-- ``goal_time``: ``asv`` will automatically select the number of
-  iterations to run the benchmark so that it takes at least ``goal_time``
-  seconds each time.  If not specified, ``goal_time`` defaults to 0.1
-  seconds.
-
 - ``warmup_time``: ``asv`` will spend this time (in seconds) in calling
   the benchmarked function repeatedly, before starting to run the actual
   benchmark. If not specified, ``warmup_time`` defaults to 0.1 seconds
   (on PyPy, the default is 1.0 sec).
 
-- ``number``: Manually choose the number of iterations.  If ``number``
-  is specified, ``goal_time`` is ignored.
-  Note that ``setup`` and ``teardown`` are not run between iterations:
-  ``setup`` runs first, then the timing routine is called ``number`` times,
-  and after that ``teardown`` runs.
+- ``repeat``: The number measurement samples to collect. Each sample
+  consists of running the benchmark ``number`` times.  The median
+  time from all of these repetitions is used as the final measurement
+  result. When not provided, ``repeat`` defaults to 10. Setup and
+  teardown are before and after each sample.
 
-- ``repeat``: The number of times to repeat the benchmark, with each
-  repetition running the benchmark ``number`` of times.  The median
-  time from all of these repetitions is used as the final result.
-  When not provided, defaults to 10. Setup and teardown are run on each repeat.
+- ``number``: Manually choose the number of iterations in each sample.
+  If ``number`` is specified, ``sample_time`` is ignored.
+  Note that ``setup`` and ``teardown`` are not run between iterations:
+  ``setup`` runs first, then the timed benchmark routine is called
+  ``number`` times, and after that ``teardown`` runs.
+
+- ``sample_time``: ``asv`` will automatically select ``number`` so that
+  each sample takes approximatively ``sample_time`` seconds.  If not
+  specified, ``sample_time`` defaults to 0.1 seconds.
 
 - ``timer``: The timing function to use, which can be any source of
   monotonically increasing numbers, such as `time.clock`, `time.time`
@@ -349,7 +349,7 @@ by the ``number`` and ``repeat`` attributes, as explained below.
   measures the time used by the current process, is often the best
   choice.
 
-The ``goal_time``, ``number``, ``repeat``, and ``timer`` attributes
+The ``sample_time``, ``number``, ``repeat``, and ``timer`` attributes
 can be adjusted in the ``setup()`` routine, which can be useful for
 parameterized benchmarks.
 

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -71,7 +71,7 @@ def time_skip(n):
     list(range(n))
 time_skip.params = [1000, 2000, 3000]
 time_skip.setup = setup_skip
-time_skip.goal_time = 0.01
+time_skip.sample_time = 0.01
 
 
 def track_find_test(n):

--- a/test/benchmark/subdir/time_subdir.py
+++ b/test/benchmark/subdir/time_subdir.py
@@ -16,4 +16,4 @@ def setup_foo():
 
 
 time_foo.setup = setup_foo
-time_foo.goal_time = 0.1
+time_foo.sample_time = 0.1

--- a/test/benchmark/time_examples.py
+++ b/test/benchmark/time_examples.py
@@ -12,7 +12,7 @@ import warnings
 
 
 class TimeSuite:
-    goal_time = 0.1
+    sample_time = 0.1
 
     def setup(self):
         self.n = 100
@@ -39,7 +39,7 @@ def time_with_warnings():
     1 / 0
     warnings.warn('after')
 
-time_with_warnings.goal_time = 0.1
+time_with_warnings.sample_time = 0.1
 
 
 def time_with_timeout():
@@ -77,7 +77,7 @@ class TimeWithRepeatCalibrate(object):
     # autodetection of suitable `number`
     repeat = 1
     number = 0
-    goal_time = 0.1
+    sample_time = 0.1
 
     def setup(self):
         print("setup")
@@ -90,7 +90,7 @@ class TimeWithBadTimer(object):
     # Check that calibration of number is robust against bad timers
     repeat = 1
     number = 0
-    goal_time = 0.1
+    sample_time = 0.1
     timeout = 5
 
     def timer(self):

--- a/test/benchmark/time_secondary.py
+++ b/test/benchmark/time_secondary.py
@@ -24,7 +24,7 @@ except ImportError:
 
 
 class TimeSecondary:
-    goal_time = 0.05
+    sample_time = 0.05
 
     def time_factorial(self):
         x = 1

--- a/test/example_results/benchmarks.json
+++ b/test/example_results/benchmarks.json
@@ -27,7 +27,7 @@
     }, 
     "params_examples.TuningTest.time_it": {
         "code": "def time_it(self, n):\n    self.counter[0] += 1\n", 
-        "goal_time": 2.0, 
+        "sample_time": 2.0, 
         "name": "params_examples.TuningTest.time_it", 
         "number": 10, 
         "param_names": [
@@ -67,7 +67,7 @@
     }, 
     "params_examples.time_skip": {
         "code": "def time_skip(n):\n    list(range(n))\n", 
-        "goal_time": 0.01, 
+        "sample_time": 0.01, 
         "name": "params_examples.time_skip", 
         "number": 0, 
         "param_names": [
@@ -103,7 +103,7 @@
     }, 
     "subdir.time_subdir.time_foo": {
         "code": "def time_foo():\n    if x != 42:\n        raise RuntimeError()\n    for y in range(1000):\n        pass\n", 
-        "goal_time": 2.0, 
+        "sample_time": 2.0, 
         "name": "subdir.time_subdir.time_foo", 
         "number": 0, 
         "param_names": [], 
@@ -115,7 +115,7 @@
     }, 
     "time_examples.TimeSuite.time_example_benchmark_1": {
         "code": "def time_example_benchmark_1(self):\n    s = ''\n    for i in xrange(self.n):\n        s = s + 'x'\n", 
-        "goal_time": 2.0, 
+        "sample_time": 2.0, 
         "name": "time_examples.TimeSuite.time_example_benchmark_1", 
         "number": 0, 
         "param_names": [], 
@@ -127,7 +127,7 @@
     }, 
     "time_examples.TimeSuite.time_example_benchmark_2": {
         "code": "def time_example_benchmark_2(self):\n    s = []\n    for i in xrange(self.n):\n        s.append('x')\n    ''.join(s)\n", 
-        "goal_time": 2.0, 
+        "sample_time": 2.0, 
         "name": "time_examples.TimeSuite.time_example_benchmark_2", 
         "number": 0, 
         "param_names": [], 
@@ -139,7 +139,7 @@
     }, 
     "time_examples.TimeSuiteSub.time_example_benchmark_1": {
         "code": "def time_example_benchmark_1(self):\n    s = ''\n    for i in xrange(self.n):\n        s = s + 'x'\n", 
-        "goal_time": 2.0, 
+        "sample_time": 2.0, 
         "name": "time_examples.TimeSuiteSub.time_example_benchmark_1", 
         "number": 0, 
         "param_names": [], 
@@ -151,7 +151,7 @@
     }, 
     "time_examples.TimeSuiteSub.time_example_benchmark_2": {
         "code": "def time_example_benchmark_2(self):\n    s = []\n    for i in xrange(self.n):\n        s.append('x')\n    ''.join(s)\n", 
-        "goal_time": 2.0, 
+        "sample_time": 2.0, 
         "name": "time_examples.TimeSuiteSub.time_example_benchmark_2", 
         "number": 0, 
         "param_names": [], 
@@ -163,7 +163,7 @@
     }, 
     "time_examples.time_with_warnings": {
         "code": "def time_with_warnings():\n    print('hi')\n    warnings.warn('before')\n    1 / 0\n    warnings.warn('after')\n", 
-        "goal_time": 2.0, 
+        "sample_time": 2.0, 
         "name": "time_examples.time_with_warnings", 
         "number": 0, 
         "param_names": [], 
@@ -175,7 +175,7 @@
     }, 
     "time_secondary.TimeSecondary.time_exception": {
         "code": "def time_exception(self):\n    raise RuntimeError()\n", 
-        "goal_time": 2.0, 
+        "sample_time": 2.0, 
         "name": "time_secondary.TimeSecondary.time_exception", 
         "number": 0, 
         "param_names": [], 
@@ -187,7 +187,7 @@
     }, 
     "time_secondary.TimeSecondary.time_factorial": {
         "code": "def time_factorial(self):\n    x = 1\n    for i in xrange(100):\n        x *= i\n    # This is to generate invalid output\n    sys.stdout.write(\"X\")\n", 
-        "goal_time": 2.0, 
+        "sample_time": 2.0, 
         "name": "time_secondary.TimeSecondary.time_factorial", 
         "number": 0, 
         "param_names": [], 


### PR DESCRIPTION
In asv < 0.3 the "goal_time" parameter had a different meaning than
currently. Change the name of the parameter to avoid problems when
upgrading to newer asv version.