### PR TITLE
Always use https URLs.

### DIFF
--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -9,23 +9,23 @@
       }
     </script>
     <script language="javascript" type="text/javascript"
-            src="//code.jquery.com/jquery-1.11.0.min.js"
+            src="https://code.jquery.com/jquery-1.11.0.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"
-            src="//cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.min.js"
+            src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"
-            src="//cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.time.min.js"
+            src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.time.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"
-            src="//cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.selection.min.js"
+            src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.selection.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"
-            src="//cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.categories.min.js"
+            src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.categories.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"
@@ -41,11 +41,11 @@
             src="jquery.md5.js">
     </script>
     <script language="javascript" type="text/javascript"
-            src="//netdna.bootstrapcdn.com/bootstrap/3.1.0/js/bootstrap.min.js"
+            src="https://netdna.bootstrapcdn.com/bootstrap/3.1.0/js/bootstrap.min.js"
             onerror="js_load_failure()">
     </script>
     <link rel="stylesheet"
-          href="//netdna.bootstrapcdn.com/bootstrap/3.1.0/css/bootstrap.min.css"
+          href="https://netdna.bootstrapcdn.com/bootstrap/3.1.0/css/bootstrap.min.css"
           type="text/css"/>
     <script language="javascript" type="text/javascript"
             src="asv.js">


### PR DESCRIPTION
Using protocol-agnostic URLs has been an antipattern for 3 years [1], and it also breaks loading directly from the file system (not that that's totally supported anyway.)

[1] https://www.paulirish.com/2010/the-protocol-relative-url/