### PR TITLE
Disable coverage warning & logging capture that causes problems in tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 include = */asv/*
 branch = True
+disable_warnings =
+    include-ignored

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [zest.releaser]
 python-file-with-version = asv/__init__.py
+
+[tool:pytest]
+addopts=-p no:logging


### PR DESCRIPTION
Coverage may print warnings in spawned subprocesses, which causes
problems e.g. for test_timeout. Disable problematic warnings.