### PR TITLE
Add a --no-pull option to asv publish and asv run

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -58,6 +58,9 @@ class Publish(Command):
             written to the ``html_dir`` given in the ``asv.conf.json``
             file, and may be served using any static web server.""")
         parser.add_argument(
+            '--no-pull', action='store_true', dest='no_pull',
+            help="Do not pull the repository")
+        parser.add_argument(
             'range', nargs='?', default=None,
             help="""Optional commit range to consider""")
         parser.add_argument(
@@ -76,7 +79,7 @@ class Publish(Command):
         if args.html_dir is not None:
             conf.html_dir = args.html_dir
         return cls.run(conf=conf, env_spec=args.env_spec,
-                       range_spec=args.range)
+                       range_spec=args.range, pull=not args.no_pull)
 
     @staticmethod
     def iter_results(conf, repo, range_spec=None):
@@ -92,7 +95,7 @@ class Publish(Command):
                 yield result
 
     @classmethod
-    def run(cls, conf, env_spec=None, range_spec=None):
+    def run(cls, conf, env_spec=None, range_spec=None, pull=True):
         params = {}
         graphs = GraphSet()
         machines = {}
@@ -139,7 +142,8 @@ class Publish(Command):
                     params.setdefault(key, set())
                     params[key].add(val)
 
-            repo.pull()
+            if pull:
+                repo.pull()
             tags = repo.get_tags()
             revisions = repo.get_revisions(set(hash_to_date.keys()) | set(tags.values()))
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -107,6 +107,9 @@ class Run(Command):
         parser.add_argument(
             "--record-samples", action="store_true",
             help="""Store raw measurement samples, not only statistics""")
+        parser.add_argument(
+            "--no-pull", action="store_true",
+            help="Do not pull the repository")
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -124,6 +127,7 @@ class Run(Command):
             skip_failed=args.skip_existing_failed or args.skip_existing,
             skip_existing_commits=args.skip_existing_commits,
             record_samples=args.record_samples,
+            pull=not args.no_pull,
             **kwargs
         )
 
@@ -132,7 +136,7 @@ class Run(Command):
             show_stderr=False, quick=False, profile=False, env_spec=None,
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
             skip_failed=False, skip_existing_commits=False, record_samples=False,
-            _returns={}):
+            pull=True, _returns={}):
         machine_params = Machine.load(
             machine_name=machine,
             _path=_machine_file, interactive=True)
@@ -145,7 +149,8 @@ class Run(Command):
             conf.dvcs = "none"
 
         repo = get_repo(conf)
-        repo.pull()
+        if pull:
+            repo.pull()
 
         if range_spec is None:
             commit_hashes = list(set([repo.get_hash_from_name(branch) for branch in conf.branches]))


### PR DESCRIPTION
When running in a loop asv run on a single benchmark and asv publish incrementally for a range of commits, pulling the source repository at each run/publish introduce an unwanted delay.

Add a --no-pull option to asv run and asv publish to avoid that.
