### PR TITLE
Add possibility to filter param selection to run

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -33,7 +33,7 @@ BENCHMARK_RUN_SCRIPT = os.path.join(
 
 
 def run_benchmark(benchmark, root, env, show_stderr=False,
-                  quick=False, profile=False, cwd=None):
+                  quick=False, profile=False, cwd=None, selected_idx=None):
     """
     Run a benchmark in different process in the given environment.
 
@@ -59,6 +59,10 @@ def run_benchmark(benchmark, root, env, show_stderr=False,
     cwd : str, optional
         The path to the current working directory to use when running
         the benchmark process.
+
+    selected_idx : str, optional
+        The list of parameters combination to run benchmark on. By default
+        run all combinations.
 
     Returns
     -------
@@ -120,6 +124,13 @@ def run_benchmark(benchmark, root, env, show_stderr=False,
         result['started_at'] = datetime.datetime.utcnow()
 
         for param_idx, params in param_iter:
+            if (selected_idx is not None and benchmark['params']
+                    and param_idx not in selected_idx):
+                # Use NaN to mark the result as skipped
+                bench_results.append(dict(samples=None, number=None,
+                                          result=float('nan'), stats=None))
+                bench_profiles.append(None)
+                continue
             success, data, profile_data, err, out, errcode = \
                 _run_benchmark_single(
                     benchmark, root, env, param_idx,
@@ -326,6 +337,9 @@ class Benchmarks(dict):
             `regex` is a list of regular expressions matching the
             benchmarks to run.  If none are provided, all benchmarks
             are run.
+            For parameterized benchmarks, the regex match against
+            `funcname(param0, param1, ...)` to include the parameter
+            combination in regex filtering.
         """
         self._conf = conf
         self._benchmark_dir = conf.benchmark_dir
@@ -336,10 +350,23 @@ class Benchmarks(dict):
             regex = [regex]
 
         self._all_benchmarks = {}
+        self._benchmark_selection = {}
         for benchmark in benchmarks:
             self._all_benchmarks[benchmark['name']] = benchmark
-            if not regex or any(re.search(reg, benchmark['name']) for reg in regex):
-                self[benchmark['name']] = benchmark
+            if benchmark['params']:
+                self._benchmark_selection[benchmark['name']] = []
+                for idx, param_set in enumerate(
+                        itertools.product(*benchmark['params'])):
+                    name = '%s(%s)' % (
+                        benchmark['name'],
+                        ', '.join(param_set))
+                    if not regex or any(re.search(reg, name) for reg in regex):
+                        self[benchmark['name']] = benchmark
+                        self._benchmark_selection[benchmark['name']].append(idx)
+            else:
+                self._benchmark_selection[benchmark['name']] = None
+                if not regex or any(re.search(reg, benchmark['name']) for reg in regex):
+                    self[benchmark['name']] = benchmark
 
     @classmethod
     def discover(cls, conf, repo, environments, commit_hash, regex=None):
@@ -616,7 +643,8 @@ class Benchmarks(dict):
                             benchmark, self._benchmark_dir, env,
                             show_stderr=show_stderr,
                             quick=quick, profile=profile,
-                            cwd=tmpdir)
+                            cwd=tmpdir,
+                            selected_idx=self._benchmark_selection[benchmark['name']])
                 finally:
                     shutil.rmtree(tmpdir, True)
 

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -49,7 +49,9 @@ class Profile(Command):
         parser.add_argument(
             'benchmark',
             help="""The benchmark to profile.  Must be a
-            fully-specified benchmark name.""")
+            fully-specified benchmark name. For parameterized benchmark, it
+            must include the parameter combination to use, e.g.:
+            benchmark_name(param0, param1, ...)""")
         parser.add_argument(
             'revision', nargs='?',
             help="""The revision of the project to profile.  May be a

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -80,3 +80,11 @@ def track_find_test(n):
     return asv_test_repo.dummy_value[n - 1]
 
 track_find_test.params = [1, 2]
+
+
+def track_param_selection(a, b):
+    return a + b
+
+
+track_param_selection.param_names = ['a', 'b']
+track_param_selection.params = [[1, 2], [3, 5]]

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -65,7 +65,7 @@ def test_find_benchmarks(tmpdir):
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                                        regex='example')
-    assert len(b) == 25
+    assert len(b) == 26
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                               regex='time_example_benchmark_1')
@@ -83,8 +83,22 @@ def test_find_benchmarks(tmpdir):
     assert b['custom.time_function']['pretty_name'] == 'My Custom Function'
     assert b['named.track_custom_pretty_name']['pretty_name'] == 'this.is/the.answer'
 
+    # benchmark param selection with regex
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
+                                       regex='track_param_selection\(.*, 3\)')
+    assert list(b.keys()) == ['params_examples.track_param_selection']
+    assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 2]
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
+                                       regex='track_param_selection\(1, ')
+    assert list(b.keys()) == ['params_examples.track_param_selection']
+    assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1]
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
+                                       regex='track_param_selection')
+    assert list(b.keys()) == ['params_examples.track_param_selection']
+    assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1, 2, 3]
+
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
-    assert len(b) == 35
+    assert len(b) == 36
 
     assert 'named.OtherSuite.track_some_func' in b
 


### PR DESCRIPTION
By extending --bench command to match against benchmark_name('param1', 'param2', ...)

Skipped param combination are displayed as "skipped" in asv run output
and results are merged with eventual previous results (skipped results
keep their old previous value).

This allow for instance to run only newly added parameters set.