### PR TITLE
Strip long venv dirs from profile output

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -78,7 +78,7 @@ def run_benchmark(benchmark, root, env, show_stderr=False,
         - `samples`: List of lists of sampled raw data points, if benchmark produces
           those and was successful.
 
-        - `number`: Repeact count associated with each sample.
+        - `number`: Repeat count associated with each sample.
 
         - `stats`: List of results of statistical analysis of data.
 

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -12,6 +12,8 @@ import re
 import sys
 import tempfile
 
+from six.moves import StringIO
+
 from . import Command
 from ..benchmarks import Benchmarks
 from ..console import log
@@ -202,7 +204,8 @@ class Profile(Command):
 def _strip_env(stats):
     """
     Wrap pstats.Stats.print_stats() to strip long directory prefixes off of
-    filenames.
+    filenames.  This is different from `pstats.Stats.strip_dirs` in that it
+    does not strip _all_ directories, just the least interesting ones.
 
     Parameters
     ----------
@@ -212,12 +215,14 @@ def _strip_env(stats):
     -------
     res : str
     """
-    c = io.StringIO()
-    stats.print_stats(c)
+    c = StringIO()
+    stats.stream = c
+    stats.print_stats()
     stats_str = c.getvalue()
 
     # Leading ' ' ensures we don't accidentally substitute the actual stats
-    res = re.sub(' /.*/env/[0-9abcdef]+/lib/python\d\.\d/(site-packages)?',
+    res = re.sub(' /.*/env/[0-9abcdef]+/(bin/\.\./)?lib/python\d\.\d/(site-packages/)?',
                  ' ',
                  stats_str)
+
     return res


### PR DESCRIPTION
Just a tweak to make profiling output more readable.  So instead of 

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.604    2.604 /usr/local/lib/python2.7/site-packages/asv-0.3.dev0_-py2.7-macosx-10.12-x86_64.egg/asv/benchmark.py:401(method_caller)
        1    0.004    0.004    2.604    2.604 /Users/username/Desktop/dateutil/profile/dateutil/asv_bench/benchmarks/parsing.py:34(time_parse_fuzzy_long)
     1000    0.006    0.000    2.600    0.003 /Users/username/Desktop/dateutil/profile/dateutil/asv_bench/env/1b5862776063636a1bd6a1931ef20cce/lib/python2.7/site-packages/dateutil/parser/_parser.py:1192(parse)
     1000    0.026    0.000    2.594    0.003 /Users/username/Desktop/dateutil/profile/dateutil/asv_bench/env/1b5862776063636a1bd6a1931ef20cce/lib/python2.7/site-packages/dateutil/parser/_parser.py:534(parse)
     1000    0.533    0.001    2.446    0.002 /Users/username/Desktop/dateutil/profile/dateutil/asv_bench/env/1b5862776063636a1bd6a1931ef20cce/lib/python2.7/site-packages/dateutil/parser/_parser.py:625(_parse)
     1000    0.059    0.000    1.018    0.001 /Users/username/Desktop/dateutil/profile/dateutil/asv_bench/env/1b5862776063636a1bd6a1931ef20cce/lib/python2.7/site-packages/dateutil/parser/_parser.py:203(split)
    25000    0.042    0.000    0.932    0.000 /Users/username/Desktop/dateutil/profile/dateutil/asv_bench/env/1b5862776063636a1bd6a1931ef20cce/lib/python2.7/site-packages/dateutil/parser/_parser.py:200(next)
[...]
```

we get

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.717    2.717 /usr/local/lib/python2.7/site-packages/asv-0.3.dev0_-py2.7-macosx-10.12-x86_64.egg/asv/benchmark.py:401(method_caller)
        1    0.004    0.004    2.717    2.717 /Users/username/Desktop/dateutil/profile/dateutil/asv_bench/benchmarks/parsing.py:34(time_parse_fuzzy_long)
     1000    0.006    0.000    2.713    0.003 dateutil/parser/_parser.py:1192(parse)
     1000    0.027    0.000    2.707    0.003 dateutil/parser/_parser.py:534(parse)
     1000    0.547    0.001    2.550    0.003 dateutil/parser/_parser.py:625(_parse)
     1000    0.060    0.000    1.071    0.001 dateutil/parser/_parser.py:203(split)
    25000    0.044    0.000    0.983    0.000 dateutil/parser/_parser.py:200(next)

[...]
```