### PR TITLE
Add a min-height on graphs to avoid a flot traceback

### DIFF
--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -148,10 +148,10 @@
       <div style="position: absolute; left: 220px; top: 60px; bottom: 10px; right: 20px;">
         <div id="graph">
           <div style="position: absolute; top: 48px; left: 0; right: 0; bottom: 100px;">
-            <div id="main-graph" style="width: 100%; height: 100%"></div>
+            <div id="main-graph" style="min-height: 100px; width: 100%; height: 100%"></div>
           </div>
           <div style="position: absolute; height: 100px; left: 0; right: 0; bottom: 0; padding-top: 24px">
-            <div id="overview" style="width: 100%; height: 100%"></div>
+            <div id="overview" style="min-height: 100px; width: 100%; height: 100%"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
When the height of the graph come to zero, flot raises a "Invalid
dimensions for plot", this can be achieved by resizing the chrome debug
toolbar to fill almost all the screen. Fix this by adding a min-height
on graphs.

Co-Authored-By: Frank Bessou <frank.bessou@logilab.fr>