### PR TITLE
Fix skipping to operate on a per-environment basis

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -8,6 +8,7 @@ import six
 
 import logging
 import traceback
+from collections import defaultdict
 
 from . import Command
 from ..benchmarks import Benchmarks
@@ -209,7 +210,7 @@ class Run(Command):
         _returns['machine_params'] = machine_params.__dict__
 
         for commit_hash in commit_hashes:
-            skipped_benchmarks = set()
+            skipped_benchmarks = defaultdict(lambda: set())
 
             if skip_successful or skip_failed or skip_existing_commits:
                 try:
@@ -217,7 +218,7 @@ class Run(Command):
                             conf.results_dir, machine_params.machine, commit_hash):
 
                         if skip_existing_commits:
-                            skipped_benchmarks.update(benchmarks)
+                            skipped_benchmarks[result.env_name].update(benchmarks)
                             break
 
                         for key in result.get_result_keys(benchmarks):
@@ -229,19 +230,16 @@ class Run(Command):
                             failed = value is None or (isinstance(value, list) and None in value)
 
                             if skip_failed and failed:
-                                skipped_benchmarks.add(key)
+                                skipped_benchmarks[result.env_name].add(key)
                             if skip_successful and not failed:
-                                skipped_benchmarks.add(key)
+                                skipped_benchmarks[result.env_name].add(key)
                 except IOError:
                     pass
 
             for env in environments:
                 for bench in benchmarks:
-                    if bench in skipped_benchmarks:
+                    if bench in skipped_benchmarks[env.name]:
                         log.step()
-
-            if not set(six.iterkeys(benchmarks)).difference(skipped_benchmarks):
-                continue
 
             if commit_hash:
                 log.info(
@@ -250,8 +248,18 @@ class Run(Command):
 
             with log.indent():
                 for subenv in util.iter_chunks(environments, parallel):
-                    log.info("Building for {0}".format(
-                        ', '.join([x.name for x in subenv])))
+
+                    subenv_name = ', '.join([x.name for x in subenv])
+
+                    # If all the benchmarks can be skipped, no need to continue
+                    for env in subenv:
+                        if set(six.iterkeys(benchmarks)).difference(skipped_benchmarks[env.name]):
+                            break
+                    else:
+                        log.info("No benchmarks to run for {0}".format(subenv_name))
+                        continue
+
+                    log.info("Building for {0}".format(subenv_name))
 
                     with log.indent():
                         args = [(env, conf, repo, commit_hash) for env in subenv]
@@ -274,7 +282,7 @@ class Run(Command):
                         if success:
                             results = benchmarks.run_benchmarks(
                                 env, show_stderr=show_stderr, quick=quick,
-                                profile=profile, skip=skipped_benchmarks)
+                                profile=profile, skip=skipped_benchmarks[env.name])
                         else:
                             results = benchmarks.skip_benchmarks(env)
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -241,23 +241,23 @@ class Run(Command):
                     if bench in skipped_benchmarks[env.name]:
                         log.step()
 
+            active_environments = [env for env in environments
+                                   if set(six.iterkeys(benchmarks))
+                                   .difference(skipped_benchmarks[env.name])]
+
+            if not active_environments:
+                continue
+
             if commit_hash:
                 log.info(
                     "For {0} commit hash {1}:".format(
                         conf.project, commit_hash[:8]))
 
             with log.indent():
-                for subenv in util.iter_chunks(environments, parallel):
+
+                for subenv in util.iter_chunks(active_environments, parallel):
 
                     subenv_name = ', '.join([x.name for x in subenv])
-
-                    # If all the benchmarks can be skipped, no need to continue
-                    for env in subenv:
-                        if set(six.iterkeys(benchmarks)).difference(skipped_benchmarks[env.name]):
-                            break
-                    else:
-                        log.info("No benchmarks to run for {0}".format(subenv_name))
-                        continue
 
                     log.info("Building for {0}".format(subenv_name))
 

--- a/asv/results.py
+++ b/asv/results.py
@@ -301,7 +301,7 @@ class Results(object):
         Returns
         -------
         value : {float, list of float}
-            Benchmark result value. If the benchmark is parameterized, return 
+            Benchmark result value. If the benchmark is parameterized, return
             a list of values.
         """
         return _compatible_results(self._results[key],
@@ -580,3 +580,7 @@ class Results(object):
     @classmethod
     def update(cls, path):
         util.update_json(cls, path, cls.api_version)
+
+    @property
+    def env_name(self):
+        return self._env_name


### PR DESCRIPTION
This fixes #602. Example output when running ``asv run ALL --skip``:

```
· Running 470 total benchmarks (47 commits * 2 environments * 5 benchmarks)
[  2.13%] · For project commit hash 622a34ca:
[  2.13%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[  2.13%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[  4.26%] · For project commit hash d8f30472:
[  4.26%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[  4.26%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[  6.38%] · For project commit hash 5f874ea8:
[  6.38%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[  6.38%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[  8.51%] · For project commit hash ad1e1de8:
[  8.51%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[  8.51%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 10.64%] · For project commit hash 689d9503:
[ 10.64%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 10.64%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 12.77%] · For project commit hash 1cce9e12:
[ 12.77%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 12.77%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 14.89%] · For project commit hash 7eea79ba:
[ 14.89%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 14.89%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 17.02%] · For project commit hash 4806274b:
[ 17.02%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 17.02%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 19.15%] · For project commit hash f28fe3fe:
[ 19.15%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 19.15%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 21.28%] · For project commit hash 304c512d:
[ 21.28%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 21.28%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 23.40%] · For project commit hash 46b96c1c:
[ 23.40%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 23.40%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 25.53%] · For project commit hash 10760777:
[ 25.53%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 25.53%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 27.66%] · For project commit hash 5da5e01c:
[ 27.66%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 27.66%] ·· No benchmarks to run for conda-py2.7-numpy1.14
[ 28.72%] · For project commit hash 5e5b5820:
[ 28.72%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 28.72%] ·· Building for conda-py2.7-numpy1.14.
[ 28.72%] ·· Benchmarking conda-py2.7-numpy1.14
[ 28.94%] ··· Running benchmarks.MemSuite.mem_list                                                                                                2.42k
[ 29.15%] ··· Running benchmarks.TimeSuite.time_iterkeys                                                                                     32.4±0.8μs
[ 29.36%] ··· Running benchmarks.TimeSuite.time_keys                                                                                         32.4±0.7μs
[ 29.57%] ··· Running benchmarks.TimeSuite.time_range                                                                                        78.0±0.9μs
[ 29.79%] ··· Running benchmarks.TimeSuite.time_xrange                                                                                         79.0±3μs
[ 30.85%] · For project commit hash 859ef6c6:
[ 30.85%] ·· No benchmarks to run for conda-py2.7-numpy1.11
[ 30.85%] ·· Building for conda-py2.7-numpy1.14..
[ 30.85%] ·· Benchmarking conda-py2.7-numpy1.14
[ 31.06%] ··· Running benchmarks.MemSuite.mem_list                                                                                                2.42k
[ 31.28%] ··· Running benchmarks.TimeSuite.time_iterkeys                                                                                     31.6±0.5μs
[ 31.49%] ··· Running benchmarks.TimeSuite.time_keys                                                                                           33.0±1μs
[ 31.70%] ··· Running benchmarks.TimeSuite.time_range                                                                                        78.4±0.8μs
```

Prior to this, if one environment had no run benchmarks and the other did, there was no way to run the missing ones for one environment.