### PR TITLE
Fix benchmark names for referenced methods

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -674,9 +674,9 @@ def _get_benchmark(attr_name, module, klass, func):
         sources = [func, module]
     else:
         instance = klass()
-        func = getattr(instance, func.__name__)
+        func = getattr(instance, attr_name)
         if name is None:
-            name = ".".join([mname, klass.__name__, func.__name__])
+            name = ".".join([mname, klass.__name__, attr_name])
         sources = [func, instance, module]
     return cls(name, func, sources)
 

--- a/test/benchmark/named.py
+++ b/test/benchmark/named.py
@@ -25,3 +25,13 @@ def track_custom_pretty_name(self):
 
 
 track_custom_pretty_name.pretty_name = 'this.is/the.answer'
+
+
+class BaseSuite:
+
+    def some_func():
+        return 0
+
+
+class OtherSuite:
+    track_some_func = BaseSuite.some_func

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -78,7 +78,9 @@ def test_find_benchmarks(tmpdir):
     assert b['named.track_custom_pretty_name']['pretty_name'] == 'this.is/the.answer'
 
     b = benchmarks.Benchmarks(conf, repo, envs)
-    assert len(b) == 34
+    assert len(b) == 35
+
+    assert 'named.OtherSuite.track_some_func' in b
 
     start_timestamp = datetime.datetime.utcnow()
 


### PR DESCRIPTION
When a method point to another method, use the method name instead of
the referenced method name.

Regression introduced in 93a4e5a

Fixes #604