### PR TITLE
Allow specifying project subdir in the repo

### DIFF
--- a/asv/config.py
+++ b/asv/config.py
@@ -22,6 +22,7 @@ class Config(object):
         self.project = "project"
         self.project_url = "#"
         self.repo = None
+        self.repo_subdir = ""
         self.branches = [None]
         self.pythons = ["{0[0]}.{0[1]}".format(sys.version_info)]
         self.matrix = {}

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -354,6 +354,7 @@ class Environment(object):
 
         """
         self._env_dir = conf.env_dir
+        self._repo_subdir = conf.repo_subdir
         self._install_timeout = conf.install_timeout  # GH391
         self._path = os.path.abspath(os.path.join(
             self._env_dir, self.hashname))
@@ -498,8 +499,12 @@ class Environment(object):
     def build_project(self, repo, commit_hash):
         self.checkout_project(repo, commit_hash)
         log.info("Building {0} for {1}".format(commit_hash[:8], self.name))
-        self.run(['setup.py', 'build'], cwd=self._build_root)
-        return self._build_root
+        if self._repo_subdir:
+            build_dir = os.path.join(self._build_root, self._repo_subdir)
+        else:
+            build_dir = self._build_root
+        self.run(['setup.py', 'build'], cwd=build_dir)
+        return build_dir
 
     def install_project(self, conf, repo, commit_hash):
         """

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -13,6 +13,11 @@
     // project being benchmarked
     "repo": "",
 
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
     // "branches": ["master"], // for git

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -46,6 +46,16 @@ The repository may be readonly.
    Mercurial used in ``asv`` (``python-hglib``) is being ported to Python 3.
    At the present time, Mercurial support will only function on Python 2.
 
+``repo_subdir``
+---------------
+
+The relative path to your Python project inside the repository.  This is
+where its ``setup.py`` file is located.
+
+If empty or omitted, the project is assumed to be located at the root of
+the repository.
+
+
 ``branches``
 ------------
 Branches to generate benchmark results for.

--- a/test/tools.py
+++ b/test/tools.py
@@ -245,7 +245,7 @@ def copy_template(src, dst, dvcs, values):
 
 
 def generate_test_repo(tmpdir, values=[0], dvcs_type='git',
-                       extra_branches=()):
+                       extra_branches=(), subdir=''):
     """
     Generate a test repository
 
@@ -262,6 +262,9 @@ def generate_test_repo(tmpdir, values=[0], dvcs_type='git',
         For branch start commits, use relative references, e.g.,
         the format 'master~10' or 'default~10' works both for Hg
         and Git.
+    subdir
+        A relative subdirectory inside the repository to copy the
+        test project into.
 
     Returns
     -------
@@ -283,13 +286,17 @@ def generate_test_repo(tmpdir, values=[0], dvcs_type='git',
     dvcs = dvcs_cls(dvcs_path)
     dvcs.init()
 
+    project_path = os.path.join(dvcs_path, subdir)
+    if not os.path.exists(project_path):
+        os.makedirs(project_path)
+
     for i, value in enumerate(values):
         mapping = {
             'version': i,
             'dummy_value': value
         }
 
-        copy_template(template_path, dvcs_path, dvcs, mapping)
+        copy_template(template_path, project_path, dvcs, mapping)
 
         dvcs.commit("Revision {0}".format(i))
         dvcs.tag(i)
@@ -302,7 +309,7 @@ def generate_test_repo(tmpdir, values=[0], dvcs_type='git',
                     'version': "{0}".format(i),
                     'dummy_value': value
                 }
-                copy_template(template_path, dvcs_path, dvcs, mapping)
+                copy_template(template_path, project_path, dvcs, mapping)
                 dvcs.commit("Revision {0}.{1}".format(branch_name, i))
 
     return dvcs


### PR DESCRIPTION
Some Python projects are not located at the root of their repository. For example, the Arrow project has its Python bindings in a `python` subdirectory (see https://github.com/apache/arrow/).

This allows configuring ASV so that it is able to run "setup.py build" and "pip install" from the right directory.

This PR has been checked to work with `asv run` and `asv dev` at least.

Fixes #547