### PR TITLE
Fix URLs to parametrized benchmarks in atom feed + drop idx= query parameter

### DIFF
--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -147,6 +147,17 @@ class Regressions(OutputPublisher):
             else:
                 benchmark_name = name
 
+            benchmark = benchmarks[benchmark_name]
+
+            if idx is not None:
+                graph_params = dict(graph_params)
+
+                # Add URL parameters
+                param_values, = itertools.islice(itertools.product(*benchmark['params']),
+                                                 idx, idx + 1)
+                for k, v in zip(benchmark['param_names'], param_values):
+                    graph_params['p-' + k] = v
+
             jumps, last_value, best_value = info
 
             for rev1, rev2, value1, value2 in jumps:
@@ -156,8 +167,7 @@ class Regressions(OutputPublisher):
                 updated = datetime.datetime.fromtimestamp(last_timestamp/1000)
 
                 params = dict(graph_params)
-                if idx is not None:
-                    params['idx'] = idx
+
                 if rev1 is None:
                     params['commits'] = '{0}'.format(revision_to_hash[rev2])
                 else:
@@ -194,7 +204,7 @@ class Regressions(OutputPublisher):
                     commit_url = conf.show_commit_url + commit_a
                     commit_ref = 'in commit <a href="{0}">{1}</a>'.format(commit_url, commit_a[:8])
 
-                unit = benchmarks[benchmark_name].get('unit', '')
+                unit = benchmark.get('unit', '')
                 best_value_str = util.human_value(best_value, unit)
                 last_value_str = util.human_value(last_value, unit)
                 value1_str = util.human_value(value1, unit)

--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -96,7 +96,7 @@ $(document).ready(function() {
     }
 
 
-    function display_benchmark(bm_name, state_selection, sub_benchmark_idx, highlight_revisions) {
+    function display_benchmark(bm_name, state_selection, highlight_revisions) {
         setup_benchmark_graph_display();
 
         $('#graph-display').show();
@@ -112,7 +112,7 @@ $(document).ready(function() {
         current_benchmark = bm_name;
         highlighted_revisions = highlight_revisions;
         $("#title").text(bm_name);
-        setup_benchmark_params(state_selection, sub_benchmark_idx);
+        setup_benchmark_params(state_selection);
         replace_graphs();
     }
 
@@ -324,7 +324,7 @@ $(document).ready(function() {
         });
     }
 
-    function setup_benchmark_params(state_selection, sub_benchmark_idx) {
+    function setup_benchmark_params(state_selection) {
         if (!current_benchmark) {
             x_coordinate_axis = 0;
             x_coordinate_is_category = false;
@@ -373,35 +373,29 @@ $(document).ready(function() {
         /* Default plot: time series */
         x_coordinate_axis = 0;
 
-        if (sub_benchmark_idx !== null) {
-            /* Only a single parameter set */
-            benchmark_param_selection = $.asv.param_selection_from_flat_idx(params, sub_benchmark_idx);
-        }
-        else {
-            /* Default plot: up to 8 lines */
-            benchmark_param_selection = [[null]];
-            if (params.length >= 1) {
-                var count = 1;
-                var max_curves = 8;
+        /* Default plot: up to 8 lines */
+        benchmark_param_selection = [[null]];
+        if (params.length >= 1) {
+            var count = 1;
+            var max_curves = 8;
 
-                for (var k = 0; k < params.length; ++k) {
-                    var param_name = param_names[k]
-                    var param_values = params[k]
-                    var item = [];
-                    if (state_selection['p-'+param_name] !== undefined) {
-                        for (var j = 0; j < param_values.length; ++j) {
-                            if (state_selection['p-'+param_name].includes(param_values[j])) {
-                                item.push(j);
-                            }
-                        }
-                    } else {
-                        for (var j = 0; j < param_values.length && (j+1)*count <= max_curves; ++j) {
+            for (var k = 0; k < params.length; ++k) {
+                var param_name = param_names[k]
+                var param_values = params[k]
+                var item = [];
+                if (state_selection['p-'+param_name] !== undefined) {
+                    for (var j = 0; j < param_values.length; ++j) {
+                        if (state_selection['p-'+param_name].includes(param_values[j])) {
                             item.push(j);
                         }
                     }
-                    count = count * item.length;
-                    benchmark_param_selection.push(item);
+                } else {
+                    for (var j = 0; j < param_values.length && (j+1)*count <= max_curves; ++j) {
+                        item.push(j);
+                    }
                 }
+                count = count * item.length;
+                benchmark_param_selection.push(item);
             }
         }
 
@@ -1290,14 +1284,8 @@ $(document).ready(function() {
 
     $.asv.register_page('graphdisplay', function(params) {
         var benchmark = params['benchmark'];
-        var sub_benchmark_idx = null;
         var highlight_revisions = null;
         var state_selection = null;
-
-        if (params['idx']) {
-            sub_benchmark_idx = parseInt(params['idx'][0]);
-            delete params['idx'];
-        }
 
         if (params['commits']) {
             highlight_revisions = [];
@@ -1339,6 +1327,6 @@ $(document).ready(function() {
             state_selection = params;
         }
 
-        display_benchmark(benchmark, state_selection, sub_benchmark_idx, highlight_revisions);
+        display_benchmark(benchmark, state_selection, highlight_revisions);
     });
 });

--- a/test/tools.py
+++ b/test/tools.py
@@ -372,6 +372,7 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
     benchmark_version = sha256(os.urandom(16)).hexdigest()
 
     params = None
+    param_names = None
     for commit, value in values.items():
         if isinstance(value, dict):
             params = value["params"]
@@ -389,11 +390,14 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
         result.add_result("time_func", value, benchmark_version)
         result.save(result_dir)
 
+    if params:
+        param_names = ["param{}".format(k) for k in range(len(params))]
+
     util.write_json(join(result_dir, "benchmarks.json"), {
         "time_func": {
             "name": "time_func",
             "params": params or [],
-            "param_names": params or [],
+            "param_names": param_names or [],
             "version": benchmark_version,
         }
     }, api_version=1)


### PR DESCRIPTION
The URL format for parametrized benchmarks was changed in gh-580.

Update the Atom feed to generate URLs in the new format.

Also completely remove the "old way" of referring to sub-benchmarks via the `idx=` query parameter, as it conflicts with the "new way" (e.g. the parameter selection buttons stop working when it is present in the query string).