### PR TITLE
TST: cleanup selenium setup + add headless modes 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
   - $TRAVIS_PYTHON setup.py build_ext -i
 
 script:
-  - $TRAVIS_PYTHON -m pytest --timeout=360 -l $COVERAGE test -vv
+  - $TRAVIS_PYTHON -m pytest --timeout=360 -l $COVERAGE test -vv --webdriver=PhantomJS
 
 after_script:
   - if [[ "$COVERAGE" != '' ]]; then

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,8 @@
 
 def pytest_addoption(parser):
-    selenium_class_names = ("Android", "Chrome", "Firefox", "Ie", "Opera", "PhantomJS", "Remote", "Safari")
-    parser.addoption("--webdriver", action="store", choices=selenium_class_names,
-                     default="PhantomJS",
-                     help="Selenium WebDriver interface to use for running the test. Default: PhantomJS")
-    parser.addoption("--webdriver-options", action="store", default="{}",
-                     help="Python dictionary of options to pass to the Selenium WebDriver class. Default: {}")
+    parser.addoption("--webdriver", action="store", default="None",
+                     help=("Selenium WebDriver interface to use for running the test. "
+                           "Choices: None, PhantomJS, Chrome, Firefox, ChromeHeadless, "
+                           "FirefoxHeadless. Alternatively, it can be arbitrary Python code "
+                           "with a return statement with selenium.webdriver object, for "
+                           "example 'return Chrome()'"))

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -19,6 +19,14 @@ import asv
 
 from asv import config, util
 
+try:
+    from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.webdriver.support import expected_conditions as EC
+    from selenium.webdriver import ActionChains
+    from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
+except ImportError:
+    pass
+
 from . import tools
 from .tools import browser, get_with_retry
 
@@ -157,10 +165,6 @@ def test_web_summarygrid(browser, basic_html):
 
 
 def test_web_regressions(browser, basic_html):
-    from selenium.webdriver.support.ui import WebDriverWait
-    from selenium.webdriver.support import expected_conditions as EC
-    from selenium.webdriver import ActionChains
-
     html_dir, dvcs = basic_html
 
     bad_commit_hash = dvcs.get_hash('master~9')
@@ -258,11 +262,6 @@ def test_web_regressions(browser, basic_html):
 
 
 def test_web_summarylist(browser, basic_html):
-    from selenium.webdriver.support.ui import WebDriverWait
-    from selenium.webdriver.support import expected_conditions as EC
-    from selenium.webdriver import ActionChains
-    from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
-
     ignore_exc = (NoSuchElementException, StaleElementReferenceException)
 
     html_dir, dvcs = basic_html

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -154,6 +154,7 @@ def test_web_summarygrid(browser, basic_html):
         param_button = browser.find_element_by_link_text('benchmark.params_examples.ClassOne')
         assert 'active' in param_button.get_attribute('class').split()
         param_button.click()
+        param_button = browser.find_element_by_link_text('benchmark.params_examples.ClassOne')
         assert 'active' not in param_button.get_attribute('class').split()
 
         # Check there's no error popup; needs an explicit wait because

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -126,7 +126,8 @@ def test_web_summarygrid(browser, basic_html):
     with tools.preview(html_dir) as base_url:
         get_with_retry(browser, base_url)
 
-        assert browser.title == 'airspeed velocity of an unladen asv'
+        WebDriverWait(browser, 5).until(EC.title_is(
+            'airspeed velocity of an unladen asv'))
 
         # Verify benchmark names are displayed as expected
         for href, expected in (
@@ -306,8 +307,13 @@ def test_web_summarylist(browser, basic_html):
         # For the other CPU, there is no recent change recorded, only
         # the latest result is available
         def check(*args):
-            base_link = browser.find_element_by_link_text('params_examples.track_find_test')
-            cur_row = base_link.find_element_by_xpath('../..')
-            return cur_row.text in ('params_examples.track_find_test (1) 2.00',
-                                    'params_examples.track_find_test (2) 2.00')
+            links = browser.find_elements_by_link_text('params_examples.track_find_test')
+            visible_links = [item for item in links if item.is_displayed()]
+
+            row_texts = [link.find_element_by_xpath('../..').text
+                         for link in visible_links]
+            row_texts.sort()
+
+            return row_texts == ['params_examples.track_find_test (1) 2.00',
+                                 'params_examples.track_find_test (2) 2.00']
         WebDriverWait(browser, 5, ignored_exceptions=ignore_exc).until(check)


### PR DESCRIPTION
Remove unnecessary binary finding code from webdriver startup.
Make Chrome and Firefox headless by default.
Set default --webdriver to None.