### PR TITLE
Resolve TypeError: Object of type 'bytes' is not JSON serializable

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -9,6 +9,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import datetime
+import base64
 import json
 import math
 import os
@@ -623,8 +624,13 @@ def write_json(path, data, api_version=None):
         os.makedirs(dirname)
 
     if api_version is not None:
-        data = dict(data)
         data['version'] = api_version
+    
+    data = dict(data)
+    for key in data.keys():
+        if isinstance(data[key], bytes):
+            encoded = base64.encodestring(data[key])
+            data[key] = encoded.decode('ascii')
 
     with long_path_open(path, 'w', encoding='utf-8') as fd:
         json.dump(data, fd, indent=4, sort_keys=True)

--- a/asv/util.py
+++ b/asv/util.py
@@ -624,13 +624,14 @@ def write_json(path, data, api_version=None):
         os.makedirs(dirname)
 
     if api_version is not None:
+        data = dict(data)
         data['version'] = api_version
     
-    data = dict(data)
-    for key in data.keys():
-        if isinstance(data[key], bytes):
-            encoded = base64.encodestring(data[key])
-            data[key] = encoded.decode('ascii')
+#     data = dict(data)
+#     for key in data.keys():
+#         if isinstance(data[key], bytes):
+#             encoded = base64.encodestring(data[key])
+#             data[key] = encoded.decode('ascii')
 
     with long_path_open(path, 'w', encoding='utf-8') as fd:
         json.dump(data, fd, indent=4, sort_keys=True)

--- a/asv/util.py
+++ b/asv/util.py
@@ -626,7 +626,7 @@ def write_json(path, data, api_version=None):
         data = dict(data)
         data['version'] = api_version
 
-    with long_path_open(path, 'w') as fd:
+    with long_path_open(path, 'w', encoding='utf-8') as fd:
         json.dump(data, fd, indent=4, sort_keys=True)
 
 


### PR DESCRIPTION
I had this TypeError when I tried to do 
`asv run --profile`

At the end of the tests, it reported this TypeError.  I did some research, looks like it is something to do with the bytes stream not JSON serializable.  Made the minor modification to the code.  It seems to have resolved this issue. 

Related issue:
https://github.com/airspeed-velocity/asv/issues/619