### PR TITLE
git: always set GIT_CEILING_DIRECTORIES

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -66,9 +66,10 @@ class Git(Repo):
         kwargs['cwd'] = cwd
         env = dict(kwargs.pop('env', os.environ))
         if cwd is not None:
-            env['GIT_CEILING_DIRECTORIES'] = ':'.join([
-                os.path.join(cwd, os.pardir),
-                env.get('GIT_CEILING_DIRECTORIES', '')])
+            prev = env.get('GIT_CEILING_DIRECTORIES')
+            env['GIT_CEILING_DIRECTORIES'] = os.pathsep.join(
+                [os.path.join(os.path.abspath(cwd), os.pardir)]
+                + ([prev] if prev is not None else []))
         return util.check_output([self._git] + args, env=env, **kwargs)
 
     def get_new_range_spec(self, latest_result, branch=None):

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -64,7 +64,12 @@ class Git(Repo):
         if cwd is True:
             cwd = self._path
         kwargs['cwd'] = cwd
-        return util.check_output([self._git] + args, **kwargs)
+        env = dict(kwargs.pop('env', os.environ))
+        if cwd is not None:
+            env['GIT_CEILING_DIRECTORIES'] = ':'.join([
+                os.path.join(cwd, os.pardir),
+                env.get('GIT_CEILING_DIRECTORIES', '')])
+        return util.check_output([self._git] + args, env=env, **kwargs)
 
     def get_new_range_spec(self, latest_result, branch=None):
         return '{0}..{1}'.format(latest_result, self.get_branch_name(branch))

--- a/asv/util.py
+++ b/asv/util.py
@@ -422,6 +422,12 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
 
     log.debug("Running '{0}'".format(' '.join(args)))
 
+    if env and WIN and sys.version_info < (3,):
+        # Environment keys and values cannot be unicode
+        def _fix_env(s):
+            return s.encode('mbcs') if isinstance(s, unicode) else s
+        env = {_fix_env(k): _fix_env(v) for k, v in env.items()}
+
     kwargs = dict(shell=shell, env=env, cwd=cwd,
                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if WIN:

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import os
 import sys
 import time
 
@@ -102,6 +103,20 @@ for j in range(3):
         assert e.retcode == util.TIMEOUT_RETCODE
     else:
         assert False, "Expected exception"
+
+
+def test_env():
+    code = r"""
+import os
+print(os.environ['TEST_ASV_FOO'])
+print(os.environ['TEST_ASV_BAR'])
+"""
+    env = os.environ.copy()
+    env['TEST_ASV_FOO'] = 'foo'
+    # Force unicode string on Python 2
+    env['TEST_ASV_BAR'] = u'bar'
+    output = util.check_output([sys.executable, "-c", code], env=env)
+    assert output.splitlines() == ['foo', 'bar']
 
 
 # This *does* seem to work, only seems untestable somehow...


### PR DESCRIPTION
By default when git don't find a repository in current working dir, it
search for git repository in parent directories.

This may lead to unwanted behavior when the benchmarked repository is
nested inside other repo since in `checkout()` we expect to given path
to be the repository and re-clone it if it's not. When the given path is
not a repository we may run git commands (like a checkout) on unrelated
repo.

This bug occur in appveyor tests where `--basetemp` is set to a
directory inside asv checkout, and `test_repo.test_repo_git()` run a
checkout() after `rm -rf .git` causing tests to run a `git checkout -f
master` on asv repo.

We don't have similar issue with hglib since it use the `-R` option to
explicitly set the repository root.