### PR TITLE
Speed up test suite

### DIFF
--- a/.continuous-integration/download_reqs.py
+++ b/.continuous-integration/download_reqs.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+download_reqs.py [OPTIONS]
+
+Pre-download required packages to cache for pip and/or conda.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import sys
+import argparse
+import subprocess
+import shlex
+import time
+
+
+PY_VERSIONS = [sys.version_info]
+if sys.version_info < (3,):
+    PY_VERSIONS.append((3, 6))
+else:
+    PY_VERSIONS.append((2, 7))
+
+
+def main():
+    p = argparse.ArgumentParser(usage=__doc__.strip())
+    p.add_argument('--pip', action='store', default=None,
+                   help="download files for offline pip cache")
+    p.add_argument('--conda', action='store_true',
+                   help=("download files to conda cache.\n"
+                         "NOTE: modifies current conda environment!"))
+    args = p.parse_args()
+
+    start_time = time.time()
+
+    if args.pip:
+        do_pip(args.pip)
+    if args.conda:
+        do_conda()
+
+    end_time = time.time()
+    print("Downloading took {} sec".format(end_time - start_time))
+
+
+def do_conda():
+    subs = dict(index_cache='', ver=sys.version_info)
+
+    call("""
+    conda create --download-only -n tmp --channel conda-forge -q --yes python={ver[0]}.{ver[1]}
+    """, subs)
+
+    for pyver in PY_VERSIONS:
+        subs['ver'] = pyver
+        call("""
+        conda create --download-only -n tmp -q --yes --use-index-cache python={ver[0]}.{ver[1]} wheel pip six=1.10 colorama=0.3.7
+        conda create --download-only -n tmp -q --yes --use-index-cache python={ver[0]}.{ver[1]} wheel pip six colorama=0.3.9
+        """, subs)
+
+
+def do_pip(cache_dir):
+    subs = dict(cache_dir=cache_dir)
+    for pyver in PY_VERSIONS:
+        if pyver == sys.version_info:
+            python = sys.executable
+        else:
+            python = 'python{ver[0]}.{ver[1]}'.format(ver=pyver)
+        if has_python(python):
+            subs['python'] = python
+            call("""
+            {python} -mpip download -d {cache_dir} six==1.10 colorama==0.3.7
+            {python} -mpip download -d {cache_dir} six colorama==0.3.9
+            """, subs)
+
+
+def has_python(cmd):
+    try:
+        ret = subprocess.call([cmd, '--version'])
+        return (ret == 0)
+    except OSError:
+        return False
+
+
+def call(cmds, subs=None):
+    if subs is None:
+        subs = {}
+    cmds = cmds.splitlines()
+    for line in cmds:
+        line = line.strip()
+        if not line:
+            continue
+        parts = [x.format(**subs) for x in shlex.split(line)]
+        parts = [x for x in parts if x]
+        print("$ {}".format(" ".join(parts)))
+        sys.stdout.flush()
+        subprocess.check_call(parts)
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ develop-eggs
 distribute-*.tar.gz
 
 # Other
+.asv
 .cache
+.pytest_cache
 .tox
 .*.swp
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,12 +70,12 @@ install:
     else
       $TRAVIS_PIP install virtualenv;
     fi
-    $TRAVIS_PIP install selenium six pytest pytest-timeout feedparser python-hglib;
+    $TRAVIS_PIP install selenium six "pytest>=3.5" pytest-xdist feedparser python-hglib;
     if [[ "$COVERAGE" != '' ]]; then $TRAVIS_PIP install pytest-cov codecov; fi;
   - $TRAVIS_PYTHON setup.py build_ext -i
 
 script:
-  - $TRAVIS_PYTHON -m pytest --timeout=360 -l $COVERAGE test -vv --webdriver=PhantomJS
+  - $TRAVIS_PYTHON -m pytest -l $COVERAGE -vv --webdriver=PhantomJS -n 3 --dist=loadscope test
 
 after_script:
   - if [[ "$COVERAGE" != '' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,15 +67,22 @@ install:
       echo -e '\ntravis_retry "$HOME/miniconda3/bin/conda.real" "$@"' >> $HOME/miniconda3/bin/conda;
       chmod +x $HOME/miniconda3/bin/conda;
       if $TRAVIS_PYTHON -c 'import virtualenv'; then echo "ERROR: virtualenv package is installed"; exit 1; fi;
+      $TRAVIS_PYTHON .continuous-integration/download_reqs.py --conda --pip=$HOME/download/pip-cache
     else
-      $TRAVIS_PIP install virtualenv;
+      if $TRAVIS_PYTHON -c 'import sys; sys.exit(0 if "__pypy__" in sys.modules else 1)'; then
+        $TRAVIS_PIP install virtualenv;
+      else
+        $TRAVIS_PIP install virtualenv numpy scipy;
+      fi
+      $TRAVIS_PYTHON .continuous-integration/download_reqs.py --pip=$HOME/download/pip-cache
     fi
     $TRAVIS_PIP install selenium six "pytest>=3.5" pytest-xdist feedparser python-hglib;
     if [[ "$COVERAGE" != '' ]]; then $TRAVIS_PIP install pytest-cov codecov; fi;
   - $TRAVIS_PYTHON setup.py build_ext -i
+  - export PIP_FIND_LINKS=file://$HOME/download/pip-cache
 
 script:
-  - $TRAVIS_PYTHON -m pytest -l $COVERAGE -vv --webdriver=PhantomJS -n 3 --dist=loadscope test
+  - $TRAVIS_PYTHON -m pytest -l $COVERAGE -vv --webdriver=PhantomJS -n 3 --offline test
 
 after_script:
   - if [[ "$COVERAGE" != '' ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,6 @@ environment:
 
   matrix:
 
-      - PYTHON_VERSION: "2.7"
-        platform: x64
-        PYTHON_ARCH: "64"
       - PYTHON_VERSION: "3.6"
         platform: x64
         PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,11 @@ install:
 
     # Install the build and runtime dependencies of the project.
     - "conda update -q --yes conda"
+    - "conda install -q --yes python=%PYTHON_VERSION% conda six pip pytest pytest-xdist lockfile"
+
+    # Pre-download all necessary packages
+    - "python .continuous-integration/download_reqs.py --conda --pip=pip-cache"
+    - "set PIP_FIND_LINKS=file:///projects/asv/pip-cache"
 
     # Tell conda to not use hardlinks: on Windows it's not possible
     # to delete hard links to files in use, which causes problem when
@@ -37,15 +42,8 @@ install:
     - "conda config --set always_copy True"
     - "conda config --set allow_softlinks False"
 
-    # Create a conda environment
-    - "conda create -q --yes -n test python=%PYTHON_VERSION%"
-    - "activate test"
-
     # Check that we have the expected version of Python
     - "python --version"
-
-    # Install specified version of dependencies
-    - "conda install -q --yes six pip pytest pytest-xdist numpy"
 
     # In-place build
     - "%CMD_IN_ENV% python setup.py build_ext -i"
@@ -54,7 +52,7 @@ install:
 build: false
 
 test_script:
-    - "python -m pytest -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp -vv -n 5 --dist=loadscope test"
+    - "python -m pytest -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp -vv -n 3 --offline test"
 
 after_build:
     # Clear up pip cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
     - "python --version"
 
     # Install specified version of dependencies
-    - "conda install -q --yes six pip pytest pytest-timeout numpy"
+    - "conda install -q --yes six pip pytest pytest-xdist numpy"
 
     # In-place build
     - "%CMD_IN_ENV% python setup.py build_ext -i"
@@ -57,7 +57,7 @@ install:
 build: false
 
 test_script:
-    - "python -m pytest --timeout=360 -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp test -vv"
+    - "python -m pytest -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp -vv -n 5 --dist=loadscope test"
 
 after_build:
     # Clear up pip cache

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -408,18 +408,20 @@ class Benchmarks(dict):
                 log.error(str(last_err))
                 raise util.UserError("Failed to build the project.")
 
-            result_file = tempfile.NamedTemporaryFile(delete=False)
+            result_dir = tempfile.mkdtemp()
             try:
-                result_file.close()
+                result_file = os.path.join(result_dir, 'result.json')
                 env.run(
                     [BENCHMARK_RUN_SCRIPT, 'discover',
-                     os.path.abspath(root), result_file.name],
+                     os.path.abspath(root),
+                     os.path.abspath(result_file)],
+                    cwd=result_dir,
                     dots=False)
 
-                with open(result_file.name, 'r') as fp:
+                with open(result_file, 'r') as fp:
                     benchmarks = json.load(fp)
             finally:
-                os.remove(result_file.name)
+                util.long_path_rmtree(result_dir)
 
         return benchmarks
 

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -207,6 +207,8 @@ class Publish(Command):
             pool = multiprocessing.Pool(n_processes)
             try:
                 graphs.detect_steps(pool, dots=log.dot)
+                pool.close()
+                pool.join()
             finally:
                 pool.terminate()
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -268,13 +268,16 @@ class Run(Command):
                     with log.indent():
                         args = [(env, conf, repo, commit_hash) for env in subenv]
                         if parallel != 1:
-                            pool = multiprocessing.Pool(parallel)
                             try:
-                                successes = pool.map(_do_build_multiprocess, args)
+                                pool = multiprocessing.Pool(parallel)
+                                try:
+                                    successes = pool.map(_do_build_multiprocess, args)
+                                    pool.close()
+                                    pool.join()
+                                finally:
+                                    pool.terminate()
                             except util.ParallelFailure as exc:
                                 exc.reraise()
-                            finally:
-                                pool.close()
                         else:
                             successes = map(_do_build, args)
 

--- a/asv/commands/setup.py
+++ b/asv/commands/setup.py
@@ -67,12 +67,15 @@ class Setup(Command):
         log.info("Creating environments")
         with log.indent():
             if parallel != 1:
-                pool = multiprocessing.Pool(parallel)
                 try:
-                    pool.map(_create_parallel, environments)
+                    pool = multiprocessing.Pool(parallel)
+                    try:
+                        pool.map(_create_parallel, environments)
+                        pool.close()
+                        pool.join()
+                    finally:
+                        pool.terminate()
                 except util.ParallelFailure as exc:
                     exc.reraise()
-                finally:
-                    pool.close()
             else:
                 list(map(_create, environments))

--- a/asv/util.py
+++ b/asv/util.py
@@ -503,7 +503,7 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
         is_timeout = was_timeout[0]
     else:
         try:
-            if posix:
+            if posix and is_main_thread():
                 # Forward signals related to Ctrl-Z handling; the child
                 # process is in a separate process group so it won't receive
                 # these automatically from the terminal
@@ -543,7 +543,7 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
                         dots()
                     last_dot_time = time.time()
         finally:
-            if posix:
+            if posix and is_main_thread():
                 # Restore signal handlers
                 signal.signal(signal.SIGTSTP, signal.SIG_DFL)
                 signal.signal(signal.SIGCONT, signal.SIG_DFL)
@@ -616,6 +616,16 @@ def _killpg_safe(pgid, signo):
             pass
         else:
             raise
+
+
+def is_main_thread():
+    """
+    Return True if the current thread is the main thread.
+    """
+    if sys.version_info[0] >= 3:
+        return threading.current_thread() == threading.main_thread()
+    else:
+        return isinstance(threading.current_thread(), threading._MainThread)
 
 
 def write_json(path, data, api_version=None):

--- a/test/benchmark/cache_examples.py
+++ b/test/benchmark/cache_examples.py
@@ -64,7 +64,7 @@ class ClassLevelCacheTimeout:
 
 
 class ClassLevelCacheTimeoutSuccess:
-    timeout = 1.0
+    timeout = 2.0
 
     def setup_cache(self):
         time.sleep(2.0)

--- a/test/benchmark/time_secondary.py
+++ b/test/benchmark/time_secondary.py
@@ -25,13 +25,16 @@ except ImportError:
 
 class TimeSecondary:
     sample_time = 0.05
+    _printed = False
 
     def time_factorial(self):
         x = 1
         for i in xrange(100):
             x *= i
-        # This is to generate invalid output
-        sys.stdout.write("X")
+        # This is to print things to stdout, but not spam too much
+        if not self._printed:
+            sys.stdout.write("X")
+            self._printed = True
 
     def time_exception(self):
         raise RuntimeError()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 
 def pytest_addoption(parser):
     parser.addoption("--webdriver", action="store", default="None",
@@ -6,3 +8,13 @@ def pytest_addoption(parser):
                            "FirefoxHeadless. Alternatively, it can be arbitrary Python code "
                            "with a return statement with selenium.webdriver object, for "
                            "example 'return Chrome()'"))
+
+    parser.addoption("--offline", action="store_true", default=False,
+                     help=("Do not download items from internet. Use if you have predownloaded "
+                           "packages and set PIP_FIND_LINKS."))
+
+
+def pytest_sessionstart(session):
+    if session.config.getoption('offline'):
+        os.environ['PIP_NO_INDEX'] = '1'
+        os.environ['CONDA_OFFLINE'] = 'True'

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -100,7 +100,7 @@ def test_find_benchmarks(tmpdir):
         'time_examples.TimeSuite.time_example_benchmark_1']['result'] != [None]
     assert isinstance(times['time_examples.TimeSuite.time_example_benchmark_1']['stats'][0]['std'], float)
     # The exact number of samples may vary if the calibration is not fully accurate
-    assert len(times['time_examples.TimeSuite.time_example_benchmark_1']['samples'][0]) in (8, 9, 10)
+    assert len(times['time_examples.TimeSuite.time_example_benchmark_1']['samples'][0]) >= 5
     # Benchmarks that raise exceptions should have a time of "None"
     assert times[
         'time_secondary.TimeSecondary.time_exception']['result'] == [None]

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -68,8 +68,9 @@ def basic_conf_with_subdir(tmpdir):
 def test_dev(capsys, basic_conf):
     tmpdir, local, conf = basic_conf
 
-    # Test Dev runs
-    tools.run_asv_with_conf(conf, 'dev', _machine_file=join(tmpdir, 'asv-machine.json'))
+    # Test Dev runs (with full benchmark suite)
+    tools.run_asv_with_conf(conf, 'dev',
+                            _machine_file=join(tmpdir, 'asv-machine.json'))
     text, err = capsys.readouterr()
 
     # time_with_warnings failure case
@@ -88,7 +89,9 @@ def test_dev_with_repo_subdir(capsys, basic_conf_with_subdir):
     tmpdir, local, conf = basic_conf_with_subdir
 
     # Test Dev runs
-    tools.run_asv_with_conf(conf, 'dev', _machine_file=join(tmpdir, 'asv-machine.json'))
+    tools.run_asv_with_conf(conf, 'dev',
+                            '--bench=time_secondary.track_value',
+                            _machine_file=join(tmpdir, 'asv-machine.json'))
     text, err = capsys.readouterr()
 
     # Benchmarks were found and run
@@ -103,7 +106,10 @@ def test_run_python_same(capsys, basic_conf):
     tmpdir, local, conf = basic_conf
 
     # Test Run runs with python=same
-    tools.run_asv_with_conf(conf, 'run', '--python=same', _machine_file=join(tmpdir, 'asv-machine.json'))
+    tools.run_asv_with_conf(conf, 'run', '--python=same',
+                            '--bench=time_secondary.TimeSecondary.time_exception',
+                            '--bench=time_secondary.track_value',
+                            _machine_file=join(tmpdir, 'asv-machine.json'))
     text, err = capsys.readouterr()
 
     assert re.search("time_exception.*failed", text, re.S)

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -14,23 +14,10 @@ from asv import config
 from asv import environment
 from asv import util
 
+from .tools import PYTHON_VER1, PYTHON_VER2, COLORAMA_VERSIONS, SIX_VERSION
+
 
 WIN = (os.name == "nt")
-
-
-try:
-    util.which('python2.7')
-    HAS_PYTHON_27 = True
-except (RuntimeError, IOError):
-    HAS_PYTHON_27 = (sys.version_info[:2] == (2, 7))
-
-
-try:
-    util.which('python3.4')
-    HAS_PYTHON_34 = True
-except (RuntimeError, IOError):
-    HAS_PYTHON_34 = (sys.version_info[:2] == (3, 4))
-
 
 try:
     util.which('pypy')
@@ -40,7 +27,7 @@ except (RuntimeError, IOError):
 
 
 try:
-    # Conda can install Python 2.7 and 3.4 on demand
+    # Conda can install required Python versions on demand
     util.which('conda')
     HAS_CONDA = True
 except (RuntimeError, IOError):
@@ -54,17 +41,24 @@ except ImportError:
     HAS_VIRTUALENV = False
 
 
-@pytest.mark.skipif(not ((HAS_PYTHON_27 and HAS_PYTHON_34) or HAS_CONDA),
-                    reason="Requires Python 2.7 and 3.4")
+try:
+    util.which('python{}'.format(PYTHON_VER2))
+    HAS_PYTHON_VER2 = True
+except (RuntimeError, IOError):
+    HAS_PYTHON_VER2 = False
+
+
+@pytest.mark.skipif(not (HAS_PYTHON_VER2 or HAS_CONDA),
+                    reason="Requires two usable Python versions")
 def test_matrix_environments(tmpdir):
     conf = config.Config()
 
     conf.env_dir = six.text_type(tmpdir.join("env"))
 
-    conf.pythons = ["2.7", "3.4"]
+    conf.pythons = [PYTHON_VER1, PYTHON_VER2]
     conf.matrix = {
-        "six": ["1.10", None],
-        "colorama": ["0.3.7", "0.3.9"]
+        "six": [SIX_VERSION, None],
+        "colorama": COLORAMA_VERSIONS
     }
     environments = list(environment.get_environments(conf, None))
 
@@ -86,8 +80,6 @@ def test_matrix_environments(tmpdir):
         assert output.startswith(six.text_type(env._requirements['colorama']))
 
 
-@pytest.mark.skipif(not (HAS_PYTHON_27 or HAS_CONDA),
-                    reason="Requires Python 2.7")
 def test_large_environment_matrix(tmpdir):
     # As seen in issue #169, conda can't handle using really long
     # directory names in its environment.  This creates an environment
@@ -96,7 +88,7 @@ def test_large_environment_matrix(tmpdir):
     conf = config.Config()
 
     conf.env_dir = six.text_type(tmpdir.join("env"))
-    conf.pythons = ["2.7"]
+    conf.pythons = [PYTHON_VER1]
     for i in range(25):
         conf.matrix['foo{0}'.format(i)] = []
 
@@ -114,14 +106,12 @@ def test_large_environment_matrix(tmpdir):
         env.create()
 
 
-@pytest.mark.skipif(not (HAS_PYTHON_27 or HAS_CONDA),
-                    reason="Requires Python 2.7")
 def test_presence_checks(tmpdir):
     conf = config.Config()
 
     conf.env_dir = six.text_type(tmpdir.join("env"))
 
-    conf.pythons = ["2.7"]
+    conf.pythons = [PYTHON_VER1]
     conf.matrix = {}
     environments = list(environment.get_environments(conf, None))
 
@@ -132,12 +122,12 @@ def test_presence_checks(tmpdir):
         # Check env is recreated when info file is clobbered
         info_fn = os.path.join(env._path, 'asv-env-info.json')
         data = util.load_json(info_fn)
-        data['python'] = '3.4'
+        data['python'] = '0'
         data = util.write_json(info_fn, data)
         env._is_setup = False
         env.create()
         data = util.load_json(info_fn)
-        assert data['python'] == '2.7'
+        assert data['python'] == PYTHON_VER1
         env.run(['-c', 'import os'])
 
         # Check env is recreated if crucial things are missing
@@ -197,7 +187,7 @@ def test_matrix_expand_include():
     conf.pythons = ["2.6"]
     conf.matrix = {'a': '1'}
     conf.include = [
-        {'python': '3.4', 'b': '2'},
+        {'python': '3.5', 'b': '2'},
         {'sys_platform': sys.platform, 'python': '2.7', 'b': '3'},
         {'sys_platform': sys.platform + 'nope', 'python': '2.7', 'b': '3'},
         {'environment_type': 'nope', 'python': '2.7', 'b': '4'},
@@ -208,7 +198,7 @@ def test_matrix_expand_include():
         conf.environment_type, conf.pythons, conf))
     expected = _sorted_dict_list([
         {'python': '2.6', 'a': '1'},
-        {'python': '3.4', 'b': '2'},
+        {'python': '3.5', 'b': '2'},
         {'python': '2.7', 'b': '3'},
         {'python': '2.7', 'b': '5'}
     ])
@@ -221,22 +211,20 @@ def test_matrix_expand_include():
         list(environment.iter_requirement_matrix(conf.environment_type, conf.pythons, conf))
 
 
-@pytest.mark.skipif(not (HAS_PYTHON_27 or HAS_CONDA),
-                    reason="Requires Python 2.7")
 def test_matrix_expand_include_detect_env_type():
     conf = config.Config()
     conf.environment_type = None
-    conf.pythons = ["2.7"]
+    conf.pythons = [PYTHON_VER1]
     conf.matrix = {}
     conf.exclude = [{}]
     conf.include = [
-        {'sys_platform': sys.platform, 'python': '2.7'},
+        {'sys_platform': sys.platform, 'python': PYTHON_VER1},
     ]
 
     combinations = _sorted_dict_list(environment.iter_requirement_matrix(
         conf.environment_type, conf.pythons, conf))
     expected = _sorted_dict_list([
-        {'python': '2.7'},
+        {'python': PYTHON_VER1},
     ])
     assert combinations == expected
 
@@ -316,8 +304,7 @@ def test_matrix_expand_exclude():
     assert combinations == expected
 
 
-@pytest.mark.skipif((not HAS_CONDA),
-                    reason="Requires conda")
+@pytest.mark.skipif((not HAS_CONDA), reason="Requires conda")
 def test_conda_pip_install(tmpdir):
     # test that we can install with pip into a conda environment.
     conf = config.Config()
@@ -325,9 +312,9 @@ def test_conda_pip_install(tmpdir):
     conf.env_dir = six.text_type(tmpdir.join("env"))
 
     conf.environment_type = "conda"
-    conf.pythons = ["3.4"]
+    conf.pythons = [PYTHON_VER1]
     conf.matrix = {
-        "pip+colorama": ["0.3.9"]
+        "pip+colorama": [COLORAMA_VERSIONS[0]]
     }
     environments = list(environment.get_environments(conf, None))
 
@@ -344,7 +331,7 @@ def test_conda_pip_install(tmpdir):
 def test_environment_select():
     conf = config.Config()
     conf.environment_type = "conda"
-    conf.pythons = ["2.7", "3.4"]
+    conf.pythons = ["2.7", "3.5"]
     conf.matrix = {
         "six": ["1.10"],
     }
@@ -355,23 +342,23 @@ def test_environment_select():
     # Check default environment config
     environments = list(environment.get_environments(conf, None))
     items = sorted([(env.tool_name, env.python) for env in environments])
-    assert items == [('conda', '1.9'), ('conda', '2.7'), ('conda', '3.4')]
+    assert items == [('conda', '1.9'), ('conda', '2.7'), ('conda', '3.5')]
 
-    if HAS_PYTHON_27 and HAS_VIRTUALENV:
+    if HAS_VIRTUALENV:
         # Virtualenv plugin fails on initialization if not available,
         # so these tests pass only if virtualenv is present
 
-        conf.pythons = ["2.7"]
+        conf.pythons = [PYTHON_VER1]
 
         # Check default python specifiers
         environments = list(environment.get_environments(conf, ["conda", "virtualenv"]))
         items = sorted((env.tool_name, env.python) for env in environments)
-        assert items == [('conda', '1.9'), ('conda', '2.7'), ('virtualenv', '2.7')]
+        assert items == [('conda', '1.9'), ('conda', PYTHON_VER1), ('virtualenv', PYTHON_VER1)]
 
         # Check specific python specifiers
-        environments = list(environment.get_environments(conf, ["conda:3.4", "virtualenv:2.7"]))
+        environments = list(environment.get_environments(conf, ["conda:3.5", "virtualenv:"+PYTHON_VER1]))
         items = sorted((env.tool_name, env.python) for env in environments)
-        assert items == [('conda', '3.4'), ('virtualenv', '2.7')]
+        assert items == [('conda', '3.5'), ('virtualenv', PYTHON_VER1)]
 
     # Check same specifier
     environments = list(environment.get_environments(conf, ["existing:same", ":same", "existing"]))
@@ -390,6 +377,7 @@ def test_environment_select():
         assert os.path.normcase(os.path.abspath(env._executable)) == os.path.normcase(os.path.abspath(sys.executable))
 
     # Select by environment name
+    conf.pythons = ["2.7"]
     environments = list(environment.get_environments(conf, ["conda-py2.7-six1.10"]))
     assert len(environments) == 1
     assert environments[0].python == "2.7"
@@ -406,46 +394,44 @@ def test_environment_select():
     assert len(environments) == 1
 
 
-@pytest.mark.skipif(not ((HAS_PYTHON_27 and HAS_VIRTUALENV) or HAS_CONDA),
-                    reason="Requires Python 2.7")
 def test_environment_select_autodetect():
     conf = config.Config()
     conf.environment_type = "conda"
-    conf.pythons = ["3.4"]
+    conf.pythons = [PYTHON_VER1]
     conf.matrix = {
         "six": ["1.10"],
     }
 
     # Check autodetect
-    environments = list(environment.get_environments(conf, [":2.7"]))
+    environments = list(environment.get_environments(conf, [":" + PYTHON_VER1]))
     assert len(environments) == 1
-    assert environments[0].python == "2.7"
+    assert environments[0].python == PYTHON_VER1
     assert environments[0].tool_name in ("virtualenv", "conda")
 
     # Check interaction with exclude
     conf.exclude = [{'environment_type': 'matches nothing'}]
-    environments = list(environment.get_environments(conf, [":2.7"]))
+    environments = list(environment.get_environments(conf, [":" + PYTHON_VER1]))
     assert len(environments) == 1
 
     conf.exclude = [{'environment_type': 'virtualenv|conda'}]
-    environments = list(environment.get_environments(conf, [":2.7"]))
+    environments = list(environment.get_environments(conf, [":" + PYTHON_VER1]))
     assert len(environments) == 1
 
     conf.exclude = [{'environment_type': 'conda'}]
-    environments = list(environment.get_environments(conf, ["conda:2.7"]))
+    environments = list(environment.get_environments(conf, ["conda:" + PYTHON_VER1]))
     assert len(environments) == 1
 
 
 def test_matrix_empty():
     conf = config.Config()
     conf.environment_type = ""
-    conf.pythons = ["2.7"]
+    conf.pythons = [PYTHON_VER1]
     conf.matrix = {}
 
     # Check default environment config
     environments = list(environment.get_environments(conf, None))
     items = [env.python for env in environments]
-    assert items == ['2.7']
+    assert items == [PYTHON_VER1]
 
 
 def test_matrix_existing():
@@ -481,7 +467,7 @@ def test_conda_channel_addition(tmpdir,
     conf = config.Config()
     conf.env_dir = six.text_type(tmpdir.join("env"))
     conf.environment_type = "conda"
-    conf.pythons = ["2.7", "3.6"]
+    conf.pythons = [PYTHON_VER1]
     conf.matrix = {}
     # these have to be valid channels
     # available for online access
@@ -489,9 +475,9 @@ def test_conda_channel_addition(tmpdir,
     environments = list(environment.get_environments(conf, None))
 
     # should have one environment per Python version
-    assert len(environments) == 2
+    assert len(environments) == 1
 
-    # create the two environments
+    # create the environments
     for env in environments:
         env.create()
         # generate JSON output from conda list
@@ -510,8 +496,9 @@ def test_conda_channel_addition(tmpdir,
         json_package_list = json.loads(out_str)
         for installed_package in json_package_list:
             # check only explicitly installed packages
-            if installed_package['name'] not in ('python', 'pip', 'wheel'):
+            if installed_package['name'] not in ('python',):
                 continue
+            print(installed_package)
             assert installed_package['channel'] == expected_channel
 
 @pytest.mark.skipif(not (HAS_PYPY and HAS_VIRTUALENV), reason="Requires pypy and virtualenv")
@@ -537,7 +524,7 @@ def test_pypy_virtualenv(tmpdir):
 def test_environment_name_sanitization():
     conf = config.Config()
     conf.environment_type = "conda"
-    conf.pythons = ["3.4"]
+    conf.pythons = ["3.5"]
     conf.matrix = {
         "pip+git+http://github.com/space-telescope/asv.git": [],
     }
@@ -545,7 +532,7 @@ def test_environment_name_sanitization():
     # Check name sanitization
     environments = list(environment.get_environments(conf, []))
     assert len(environments) == 1
-    assert environments[0].name == "conda-py3.4-pip+git+http___github.com_space-telescope_asv.git"
+    assert environments[0].name == "conda-py3.5-pip+git+http___github.com_space-telescope_asv.git"
 
 
 @pytest.mark.parametrize("environment_type", [
@@ -557,10 +544,7 @@ def test_environment_environ_path(environment_type, tmpdir):
     conf = config.Config()
     conf.env_dir = six.text_type(tmpdir.join("env"))
     conf.environment_type = environment_type
-    if environment_type == "virtualenv":
-        conf.pythons = ["{0[0]}.{0[1]}".format(sys.version_info)]
-    else:
-        conf.pythons = ["3.5"]
+    conf.pythons = [PYTHON_VER1]
     conf.matrix = {}
 
     env, = environment.get_environments(conf, [])

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -36,7 +36,7 @@ sys.stderr.write("Stderr before waiting\n")
 sys.stdout.flush()
 sys.stderr.flush()
 subprocess.call([sys.executable, "-c",
-    "import sys, subprocess; subprocess.call([sys.executable, '-c', 'import time; time.sleep(60)'])"])
+    "import sys, subprocess; subprocess.call([sys.executable, '-c', 'import time; time.sleep(360)'])"])
 sys.stdout.write("Stdout after waiting\n")
 sys.stderr.write("Stderr after waiting\n")
     """)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -11,6 +11,7 @@ import sys
 import shutil
 import pickle
 import multiprocessing
+import threading
 import traceback
 import six
 import pytest
@@ -250,3 +251,21 @@ def test_human_file_size():
         assert got == expected, item
         got = util.human_value(item[1], 'bytes', *item[2:])
         assert got == expected, item
+
+
+def test_is_main_thread():
+    if sys.version_info[0] >= 3:
+        # NB: the test itself doesn't necessarily run in main thread...
+        is_main = (threading.current_thread() == threading.main_thread())
+        assert util.is_main_thread() == is_main
+
+    results = []
+
+    def worker():
+        results.append(util.is_main_thread())
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join()
+
+    assert results == [False]

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -28,7 +28,7 @@ except ImportError:
     pass
 
 from . import tools
-from .tools import browser, get_with_retry
+from .tools import browser, get_with_retry, WAIT_TIME
 
 
 @pytest.fixture(scope="session")
@@ -126,7 +126,7 @@ def test_web_summarygrid(browser, basic_html):
     with tools.preview(html_dir) as base_url:
         get_with_retry(browser, base_url)
 
-        WebDriverWait(browser, 5).until(EC.title_is(
+        WebDriverWait(browser, WAIT_TIME).until(EC.title_is(
             'airspeed velocity of an unladen asv'))
 
         # Verify benchmark names are displayed as expected
@@ -190,7 +190,7 @@ def test_web_regressions(browser, basic_html):
 
         # Sort the tables vs. benchmark name (PhantomJS doesn't allow doing it via actionchains)
         browser.execute_script("$('thead th').eq(0).stupidsort('asc')")
-        WebDriverWait(browser, 5).until(EC.text_to_be_present_in_element(
+        WebDriverWait(browser, WAIT_TIME).until(EC.text_to_be_present_in_element(
             ('xpath', '//table[1]/tbody/tr[1]/td[1]'), 'params_examples.track_find_test(1)'
             ))
 
@@ -215,8 +215,8 @@ def test_web_regressions(browser, basic_html):
         buttons[0].click()
 
         # The button should disappear, together with the link
-        WebDriverWait(browser, 5).until_not(EC.visibility_of(buttons[0]))
-        WebDriverWait(browser, 5).until_not(EC.visibility_of(regression_1))
+        WebDriverWait(browser, WAIT_TIME).until_not(EC.visibility_of(buttons[0]))
+        WebDriverWait(browser, WAIT_TIME).until_not(EC.visibility_of(regression_1))
 
         table_rows = browser.find_elements_by_xpath('//table[1]/tbody/tr')
         assert len(table_rows) == 1
@@ -228,7 +228,7 @@ def test_web_regressions(browser, basic_html):
         show_button.click()
 
         regression_1 = browser.find_element_by_link_text('params_examples.track_find_test(1)')
-        WebDriverWait(browser, 5).until(EC.visibility_of(regression_1))
+        WebDriverWait(browser, WAIT_TIME).until(EC.visibility_of(regression_1))
 
         table_rows = browser.find_elements_by_xpath('//table[2]/tbody/tr')
         assert len(table_rows) == 1
@@ -296,7 +296,7 @@ def test_web_summarylist(browser, basic_html):
         # Change table sort (sorting is async, so needs waits)
         sort_th = browser.find_element_by_xpath('//th[text()="Recent change"]')
         sort_th.click()
-        WebDriverWait(browser, 5).until(
+        WebDriverWait(browser, WAIT_TIME).until(
             EC.text_to_be_present_in_element(('xpath', '//tbody/tr[1]'),
                                               'params_examples.track_find_test'))
 
@@ -316,4 +316,4 @@ def test_web_summarylist(browser, basic_html):
 
             return row_texts == ['params_examples.track_find_test (1) 2.00',
                                  'params_examples.track_find_test (2) 2.00']
-        WebDriverWait(browser, 5, ignored_exceptions=ignore_exc).until(check)
+        WebDriverWait(browser, WAIT_TIME, ignored_exceptions=ignore_exc).until(check)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -73,7 +73,7 @@ def generate_basic_conf(tmpdir, repo_subdir=''):
         'project': 'asv',
         'matrix': {
             "six": [""],
-            "colorama": ["0.3.7", "0.3.9"],
+            "colorama": tools.COLORAMA_VERSIONS,
         },
     }
     if repo_subdir:
@@ -119,7 +119,8 @@ def test_run_publish(capfd, basic_conf):
 
     # Check parameterized test json data format
     filename = glob.glob(join(tmpdir, 'html', 'graphs', 'arch-x86_64', 'branch-master',
-                              'colorama-0.3.9',  'cpu-Blazingly fast', 'machine-orangutan',
+                              'colorama-' + tools.COLORAMA_VERSIONS[1],
+                              'cpu-Blazingly fast', 'machine-orangutan',
                               'os-GNU_Linux', 'python-*', 'ram-128GB',
                               'six', 'params_examples.time_skip.json'))[0]
     with open(filename, 'r') as fp:
@@ -251,7 +252,7 @@ def test_run_spec(basic_conf):
 
         expected = set(['machine.json'])
         for commit in expected_commits:
-            for psver in ['0.3.7', '0.3.9']:
+            for psver in tools.COLORAMA_VERSIONS:
                 expected.add('{0}-{1}-py{2}-colorama{3}-six.json'.format(
                     commit[:8], tool_name, pyver, psver))
 

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -136,9 +136,11 @@ def test_run_publish(capfd, basic_conf):
     capfd.readouterr()
     tools.run_asv_with_conf(conf, 'run', "master~5..master", '--steps=2',
                             '--quick', '--skip-existing-successful',
+                            '--bench=time_secondary.track_value',
                             '--skip-existing-failed',
                             _machine_file=join(tmpdir, 'asv-machine.json'))
     tools.run_asv_with_conf(conf, 'run', "master~5..master", '--steps=2',
+                            '--bench=time_secondary.track_value',
                             '--quick', '--skip-existing-commits',
                             _machine_file=join(tmpdir, 'asv-machine.json'))
     text, err = capfd.readouterr()
@@ -149,7 +151,9 @@ def test_run_publish(capfd, basic_conf):
         env_spec = ("-E", "conda:{0[0]}.{0[1]}".format(sys.version_info))
     else:
         env_spec = ("-E", "virtualenv:{0[0]}.{0[1]}".format(sys.version_info))
-    tools.run_asv_with_conf(conf, 'run', "EXISTING", '--quick', *env_spec,
+    tools.run_asv_with_conf(conf, 'run', "EXISTING", '--quick',
+                            '--bench=time_secondary.track_value',
+                            *env_spec,
                             _machine_file=machine_file)
 
     # Remove the benchmarks.json file and check publish fails
@@ -170,6 +174,8 @@ def test_continuous(capfd, basic_conf):
 
     # Check that asv continuous runs
     tools.run_asv_with_conf(conf, 'continuous', "master^", '--show-stderr',
+                            '--bench=params_examples.track_find_test',
+                            '--bench=params_examples.track_param',
                             *env_spec, _machine_file=machine_file)
 
     text, err = capfd.readouterr()

--- a/test/tools.py
+++ b/test/tools.py
@@ -44,6 +44,9 @@ except ImportError:
     HAVE_WEBDRIVER = False
 
 
+WAIT_TIME = 20.0
+
+
 def run_asv(*argv):
     parser, subparsers = commands.make_argparser()
     args = parser.parse_args(argv)
@@ -438,8 +441,8 @@ def browser(request, pytestconfig):
     browser = create_driver()
 
     # Set timeouts
-    browser.set_page_load_timeout(10)
-    browser.set_script_timeout(10)
+    browser.set_page_load_timeout(WAIT_TIME)
+    browser.set_script_timeout(WAIT_TIME)
 
     # Clean up on fixture finalization
     def fin():
@@ -447,7 +450,7 @@ def browser(request, pytestconfig):
     request.addfinalizer(fin)
 
     # Set default time to wait for AJAX requests to complete
-    browser.implicitly_wait(5)
+    browser.implicitly_wait(WAIT_TIME)
 
     return browser
 

--- a/test/tools.py
+++ b/test/tools.py
@@ -36,6 +36,18 @@ from asv.repo import get_repo
 from asv.results import Results
 
 
+# Two Python versions for testing
+PYTHON_VER1 = "{0[0]}.{0[1]}".format(sys.version_info)
+if sys.version_info < (3,):
+    PYTHON_VER2 = "3.6"
+else:
+    PYTHON_VER2 = "2.7"
+
+# Installable library versions to use in tests
+SIX_VERSION = "1.10"
+COLORAMA_VERSIONS = ["0.3.7", "0.3.9"]
+
+
 try:
     import selenium
     from selenium.common.exceptions import TimeoutException


### PR DESCRIPTION
Run tests in parallel with pytest-xdist.
Fix timing issues that caused problems with pytest-xdist.
Use `--bench=` in tests to avoid running the whole slow benchmark suite.
Prefer close+join when using multiprocessing, to avoid some issues on python2 on windows.
Fix test_web:basic_html fixture to work with pytest-xdist.

Add --offline option for running tests without pip/conda downloading.
Pre-download necessary packages before running tests, which also mitigates some issues with conda's parallel execution safety.