### PR TITLE
BF: to decide if Git repo, just check if .git exists

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -41,7 +41,7 @@ class Git(Repo):
     @classmethod
     def is_local_repo(cls, path):
         return os.path.isdir(path) and (
-            os.path.isdir(os.path.join(path, '.git')) or
+            os.path.exists(os.path.join(path, '.git')) or
             os.path.isdir(os.path.join(path, 'objects')))
 
     @classmethod


### PR DESCRIPTION
.git could be a symbolic link to the corresponding .git/ directory
(e.g. if a submodule with "old fashion" submodule referencing) or
.git file which would have a line with "gitdir: " pointing to the
actual location for that workdir or submodule

Closes #516 
I've checked correct functioning only with workdir setup and `asv gh-pages` command