### PR TITLE
Fix support for mercurial >= 4.5

### DIFF
--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -135,10 +135,9 @@ class Hg(Repo):
         rev = self._repo.log(self._encode(hash))[0]
         return int(rev.date.strftime("%s")) * 1000
 
-    def get_hashes_from_range(self, range_spec):
+    def get_hashes_from_range(self, range_spec, **kwargs):
         range_spec = self._encode("sort({0}, -rev)".format(range_spec))
-        return [self._decode(rev.node) for rev in self._repo.log(range_spec,
-                                                                 followfirst=True)]
+        return [self._decode(rev.node) for rev in self._repo.log(range_spec, **kwargs)]
 
     def get_hash_from_name(self, name):
         if name is None:
@@ -158,7 +157,8 @@ class Hg(Repo):
         return self.get_date(name)
 
     def get_branch_commits(self, branch):
-        return self.get_hashes_from_range("ancestors({0})".format(self.get_branch_name(branch)))
+        return self.get_hashes_from_range("ancestors({0})".format(self.get_branch_name(branch)),
+                                          followfirst=True)
 
     def get_revisions(self, commits):
         revisions = {}


### PR DESCRIPTION
The behavior or 'hg log --follow-first -r <revset>' has changed in
mercurial 4.5: https://www.mercurial-scm.org/repo/hg/rev/a177c6aa055a

This cause 'asv run' with a single revision to resolve to all ancestors
of revision and following first parent instead of only the given single
revision.

Only use --follow-first only for get_branch_commits() which is needed to
draw the graph correctly in case of merges.

This fixes running tests with hg >= 4.5