### PR TITLE
[WIP] Attempted fix for #645 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ install:
       popd;
       export PATH=$HOME/miniconda3/bin:$PATH;
       conda update --yes conda;
+      conda info
+      . $HOME/miniconda3/etc/profile.d/conda.sh  # enable conda bash function
       mv $HOME/miniconda3/bin/conda $HOME/miniconda3/bin/conda.real;
       echo -e '#!/bin/bash\n' > $HOME/miniconda3/bin/conda;
       declare -f travis_retry >> $HOME/miniconda3/bin/conda;

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -18,6 +18,37 @@ from .. import util
 WIN = (os.name == "nt")
 
 
+def _find_conda():
+    """Find the conda executable robustly across conda versions.
+
+    Returns
+    -------
+    conda : str
+        Path to the conda executable.
+
+    Raises
+    ------
+    IOError
+        If the executable cannot be found in either the CONDA_EXE environment
+        variable or in the PATH.
+
+    Notes
+    -----
+    In POSIX platforms in conda >= 4.4, conda can be set up as a bash function
+    rather than an executable. (This is to enable the syntax
+    ``conda activate env-name``.) In this case, the environment variable
+    ``CONDA_EXE`` contains the path to the conda executable. In other cases,
+    we use standard search for the appropriate name in the PATH.
+
+    See https://github.com/airspeed-velocity/asv/issues/645 for more details.
+    """
+    if 'CONDA_EXE' in os.environ:
+        conda = os.environ['CONDA_EXE']
+    else:
+        conda = util.which('conda')
+    return conda
+
+
 class Conda(environment.Environment):
     """
     Manage an environment using conda.
@@ -61,7 +92,7 @@ class Conda(environment.Environment):
             return False
 
         try:
-            conda = util.which('conda')
+            conda = _find_conda()
         except IOError:
             return False
         else:
@@ -87,7 +118,7 @@ class Conda(environment.Environment):
 
     def _setup(self):
         try:
-            conda = util.which('conda')
+            conda = _find_conda()
         except IOError as e:
             raise util.UserError(str(e))
 

--- a/asv/util.py
+++ b/asv/util.py
@@ -279,6 +279,12 @@ def which(filename, paths=None):
 
     Raises an IOError if no result is found.
     """
+    # shortcut to conda for conda >= 4.4 in POSIX platforms
+    # conda is a bash function, not an executable, since 4.4, breaking
+    # path search. See https://github.com/airspeed-velocity/asv/issues/645
+    if filename == 'conda' and 'CONDA_EXE' in os.environ:
+        return os.environ['CONDA_EXE']
+
     # Hide traceback from expected exceptions in pytest reports
     __tracebackhide__ = operator.methodcaller('errisinstance', IOError)
 

--- a/asv/util.py
+++ b/asv/util.py
@@ -279,12 +279,6 @@ def which(filename, paths=None):
 
     Raises an IOError if no result is found.
     """
-    # shortcut to conda for conda >= 4.4 in POSIX platforms
-    # conda is a bash function, not an executable, since 4.4, breaking
-    # path search. See https://github.com/airspeed-velocity/asv/issues/645
-    if filename == 'conda' and 'CONDA_EXE' in os.environ:
-        return os.environ['CONDA_EXE']
-
     # Hide traceback from expected exceptions in pytest reports
     __tracebackhide__ = operator.methodcaller('errisinstance', IOError)
 


### PR DESCRIPTION
Fixes #645 

In conda >= 4.4, conda shipped with a conda bash function to enable the
syntax "conda activate env-name". This shadows the conda binary and
prevents it from being found in the PATH. However, the path to the conda
executable is found in the environment variable CONDA_EXE in this case