### PR TITLE
Benchmark runner refactoring and interleaved benchmark sampling

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -498,7 +498,7 @@ class TimeBenchmark(Benchmark):
         if repeat == 0:
             # automatic number of samples: 10 is large enough to
             # estimate the median confidence interval
-            repeat = -(-10//self.processes)  # ceildiv
+            repeat = 5 if self.processes > 1 else 10
             default_number = (number == 0)
 
             def too_slow(timing):

--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -446,6 +446,7 @@ class TimeBenchmark(Benchmark):
         self.type = "time"
         self.unit = "seconds"
         self._attr_sources = attr_sources
+        self.processes = int(_get_first_attr(self._attr_sources, 'processes', 2))
         self._load_vars()
 
     def _load_vars(self):
@@ -497,7 +498,7 @@ class TimeBenchmark(Benchmark):
         if repeat == 0:
             # automatic number of samples: 10 is large enough to
             # estimate the median confidence interval
-            repeat = 10
+            repeat = -(-10//self.processes)  # ceildiv
             default_number = (number == 0)
 
             def too_slow(timing):
@@ -745,7 +746,7 @@ def disc_benchmarks(root):
                     yield benchmark
 
 
-def get_benchmark_from_name(root, name, quick=False):
+def get_benchmark_from_name(root, name, extra_params=None):
     """
     Create a benchmark from a fully-qualified benchmark name.
 
@@ -808,11 +809,12 @@ def get_benchmark_from_name(root, name, quick=False):
     if param_idx is not None:
         benchmark.set_param_idx(param_idx)
 
-    if quick:
-        class QuickBenchmarkAttrs:
-            repeat = 1
-            number = 1
-        benchmark._attr_sources.insert(0, QuickBenchmarkAttrs)
+    if extra_params:
+        class ExtraBenchmarkAttrs:
+            pass
+        for key, value in extra_params.items():
+            setattr(ExtraBenchmarkAttrs, key, value)
+        benchmark._attr_sources.insert(0, ExtraBenchmarkAttrs)
 
     return benchmark
 
@@ -854,13 +856,15 @@ def main_setup_cache(args):
 
 
 def main_run(args):
-    (benchmark_dir, benchmark_id, quick, profile_path, result_file) = args
-    quick = (quick == 'True')
+    (benchmark_dir, benchmark_id, params_str, profile_path, result_file) = args
+
+    extra_params = json.loads(params_str)
+
     if profile_path == 'None':
         profile_path = None
 
     benchmark = get_benchmark_from_name(
-        benchmark_dir, benchmark_id, quick=quick)
+        benchmark_dir, benchmark_id, extra_params=extra_params)
 
     if benchmark.setup_cache_key is not None:
         with open("cache.pickle", "rb") as fd:

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -248,7 +248,7 @@ class Benchmarks(dict):
                                  "regenerate benchmarks.json".format(str(err)))
 
     def run_benchmarks(self, env, show_stderr=False, quick=False, profile=False,
-                       skip=None):
+                       skip=None, extra_params=None):
         """
         Run all of the benchmarks in the given `Environment`.
 
@@ -272,6 +272,9 @@ class Benchmarks(dict):
 
         skip : set, optional
             Benchmark names to skip.
+
+        extra_params : dict, optional
+            Override values for benchmark attributes.
 
         Returns
         -------
@@ -311,6 +314,7 @@ class Benchmarks(dict):
                                                   self._benchmark_dir,
                                                   show_stderr=show_stderr,
                                                   quick=quick,
+                                                  extra_params=extra_params,
                                                   profile=profile,
                                                   selected_idx=self._benchmark_selection)
         jobs = benchmark_runner.plan()

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -56,14 +56,16 @@ class Continuous(Command):
     def run_from_conf_args(cls, conf, args, **kwargs):
         return cls.run(
             conf=conf, branch=args.branch, base=args.base, factor=args.factor,
-            show_stderr=args.show_stderr, bench=args.bench, machine=args.machine,
+            show_stderr=args.show_stderr, bench=args.bench, attribute=args.attribute,
+            machine=args.machine,
             env_spec=args.env_spec, record_samples=args.record_samples,
             quick=args.quick, **kwargs
         )
 
     @classmethod
     def run(cls, conf, branch=None, base=None, factor=None, show_stderr=False, bench=None,
-            machine=None, env_spec=None, record_samples=False, quick=False, _machine_file=None):
+            attribute=None, machine=None, env_spec=None, record_samples=False, quick=False,
+            _machine_file=None):
         repo = get_repo(conf)
         repo.pull()
 
@@ -80,7 +82,7 @@ class Continuous(Command):
         run_objs = {}
 
         result = Run.run(
-            conf, range_spec=commit_hashes, bench=bench,
+            conf, range_spec=commit_hashes, bench=bench, attribute=attribute,
             show_stderr=show_stderr, machine=machine, env_spec=env_spec,
             record_samples=record_samples, quick=quick,
             _returns=run_objs, _machine_file=_machine_file)

--- a/asv/commands/dev.py
+++ b/asv/commands/dev.py
@@ -28,13 +28,15 @@ class Dev(Run):
 
     @classmethod
     def run_from_conf_args(cls, conf, args, **kwargs):
-        return cls.run(conf, bench=args.bench, machine=args.machine, env_spec=args.env_spec,
+        return cls.run(conf, bench=args.bench, attribute=args.attribute,
+                       machine=args.machine, env_spec=args.env_spec,
                        **kwargs)
 
     @classmethod
-    def run(cls, conf, bench=None, env_spec=None, machine=None, _machine_file=None):
+    def run(cls, conf, bench=None, attribute=None, env_spec=None, machine=None, _machine_file=None):
         if not env_spec:
             env_spec = ["existing:same"]
-        return super(cls, Dev).run(conf=conf, bench=bench, show_stderr=True, quick=True,
+        return super(cls, Dev).run(conf=conf, bench=bench, attribute=attribute,
+                                   show_stderr=True, quick=True,
                                    env_spec=env_spec, machine=machine, dry_run=True,
                                    _machine_file=_machine_file)

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -198,11 +198,7 @@ class Run(Command):
                 log.error("No benchmarks selected")
                 return 1
 
-        if quick:
-            benchmark_count = len(benchmarks)
-        else:
-            benchmark_count = sum(b.get('processes', 1) for b in benchmarks.values())
-
+        benchmark_count = len(benchmarks)
         steps = len(commit_hashes) * benchmark_count * len(environments)
 
         log.info(

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -120,7 +120,7 @@ class Run(Command):
     def run_from_conf_args(cls, conf, args, **kwargs):
         return cls.run(
             conf=conf, range_spec=args.range, steps=args.steps,
-            bench=args.bench, parallel=args.parallel,
+            bench=args.bench, attribute=args.attribute, parallel=args.parallel,
             show_stderr=args.show_stderr, quick=args.quick,
             profile=args.profile, env_spec=args.env_spec,
             dry_run=args.dry_run, machine=args.machine,
@@ -133,7 +133,7 @@ class Run(Command):
         )
 
     @classmethod
-    def run(cls, conf, range_spec=None, steps=None, bench=None, parallel=1,
+    def run(cls, conf, range_spec=None, steps=None, bench=None, attribute=None, parallel=1,
             show_stderr=False, quick=False, profile=False, env_spec=None,
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
             skip_failed=False, skip_existing_commits=False, record_samples=False,
@@ -294,7 +294,8 @@ class Run(Command):
                         if success:
                             results = benchmarks.run_benchmarks(
                                 env, show_stderr=show_stderr, quick=quick,
-                                profile=profile, skip=skipped_benchmarks[env.name])
+                                profile=profile, skip=skipped_benchmarks[env.name],
+                                extra_params=attribute)
                         else:
                             results = benchmarks.skip_benchmarks(env)
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -198,7 +198,12 @@ class Run(Command):
                 log.error("No benchmarks selected")
                 return 1
 
-        steps = len(commit_hashes) * len(benchmarks) * len(environments)
+        if quick:
+            benchmark_count = len(benchmarks)
+        else:
+            benchmark_count = sum(b.get('processes', 1) for b in benchmarks.values())
+
+        steps = len(commit_hashes) * benchmark_count * len(environments)
 
         log.info(
             "Running {0} total benchmarks "

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -1,0 +1,728 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import io
+import json
+import os
+import re
+import sys
+import shutil
+import tempfile
+import itertools
+import datetime
+import pstats
+
+import six
+
+from .console import log, truncate_left
+from . import util
+from . import statistics
+
+
+WIN = (os.name == "nt")
+
+
+# Can't use benchmark.__file__, because that points to the compiled
+# file, so it can't be run by another version of Python.
+BENCHMARK_RUN_SCRIPT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "benchmark.py")
+
+
+class BenchmarkRunner(object):
+    """
+    Control and plan running of a set of benchmarks.
+
+    Takes care of:
+
+    - setup_cache
+    - distributing benchmarks to multiple processes
+    - launching benchmarks
+    - logging messages and displaying results
+
+    The `plan` method generates a sequence of Job objects,
+    which the `run` method then runs.
+    """
+
+    def __init__(self, benchmarks, benchmark_dir, show_stderr=False, quick=False,
+                 profile=False, extra_params=None, selected_idx=None):
+        """
+        Initialize BenchmarkRunner.
+
+        Parameters
+        ----------
+        benchmarks : dict, {benchmark_name: Benchmark}
+            Set of benchmarks to run.
+        benchmark_dir : str
+            Root directory for the benchmark suite.
+        show_stderr : bool
+            Whether to dump output stream from benchmark program.
+        quick : bool
+            Whether to force a 'quick' run.
+
+        """
+        self.benchmarks = benchmarks
+        self.benchmark_dir = benchmark_dir
+        self.show_stderr = show_stderr
+        self.quick = quick
+        self.profile = profile
+        if extra_params is None:
+            self.extra_params = {}
+        else:
+            self.extra_params = dict(extra_params)
+        if selected_idx is None:
+            selected_idx = {}
+        else:
+            self.selected_idx = selected_idx
+
+        if quick:
+            self.extra_params['number'] = 1
+            self.extra_params['repeat'] = 1
+            self.extra_params['warmup_time'] = 0
+
+    def plan(self):
+        # Find all setup_cache routines needed
+        setup_caches = {}
+        setup_cache_timeout = {}
+
+        for name, benchmark in self.benchmarks:
+            key = benchmark.get('setup_cache_key')
+            setup_cache_timeout[key] = max(benchmark.get('setup_cache_timeout',
+                                                         benchmark['timeout']),
+                                           setup_cache_timeout.get(key, 0))
+
+        # Interleave benchmark runs, in setup_cache order
+        jobs = []
+
+        insert_stack = []
+        benchmark_order = {}
+        cache_users = {}
+        setup_cache_jobs = {None: None}
+        prev_runs = {}
+
+        for name, benchmark in self.benchmarks:
+            key = benchmark.get('setup_cache_key')
+            benchmark_order.setdefault(key, []).append((name, benchmark))
+
+        for setup_cache_key, benchmark_set in six.iteritems(benchmark_order):
+            for name, benchmark in benchmark_set:
+                processes = benchmark.get('processes', 1)
+                if self.quick:
+                    processes = 1
+                insert_stack.append((name, benchmark, processes, setup_cache_key))
+                cache_users.setdefault(setup_cache_key, []).append(name)
+
+        while insert_stack:
+            name, benchmark, processes, setup_cache_key = insert_stack.pop(0)
+
+            # Setup cache first, if needed
+            if setup_cache_key is None:
+                setup_cache_job = None
+            elif setup_cache_key in setup_cache_jobs:
+                setup_cache_job = setup_cache_jobs[setup_cache_key]
+            else:
+                setup_cache_job = SetupCacheJob(self.benchmark_dir,
+                                                name,
+                                                setup_cache_key,
+                                                setup_cache_timeout[setup_cache_key])
+                setup_cache_jobs[setup_cache_key] = setup_cache_job
+                jobs.append(setup_cache_job)
+
+            # Run benchmark
+            prev_job = prev_runs.get(name, None)
+            job = LaunchBenchmarkJob(name, benchmark, self.benchmark_dir,
+                                     self.profile, self.extra_params,
+                                     cache_job=setup_cache_job, prev_job=prev_job,
+                                     partial=(processes > 1),
+                                     selected_idx=self.selected_idx.get(name))
+            prev_runs[name] = job
+            jobs.append(job)
+
+            # Interleave remaining runs
+            if processes > 1:
+                insert_stack.append((name, benchmark, processes - 1, setup_cache_key))
+
+            # Cleanup setup cache, if no users left
+            if setup_cache_job is not None and processes == 1:
+                cache_users[setup_cache_key].remove(name)
+                if not cache_users[setup_cache_key]:
+                    # No users of this cache left, perform cleanup
+                    job = SetupCacheCleanupJob(setup_cache_job)
+                    jobs.append(job)
+                    del cache_users[setup_cache_key]
+
+        return jobs
+
+    def run(self, jobs, env):
+        times = {}
+
+        name_max_width = max(16, util.get_terminal_width() - 33)
+
+        try:
+            with log.indent():
+                for job in jobs:
+                    log.step()
+
+                    short_name = truncate_left(job.name, name_max_width)
+
+                    if isinstance(job, SetupCacheJob):
+                        self._log_initial("Setting up {0}".format(short_name))
+                        job.run(env)
+                        self._log_cache_result(job)
+                    elif isinstance(job, LaunchBenchmarkJob):
+                        self._log_initial('Running {0}'.format(short_name))
+                        job.run(env)
+                        self._log_benchmark_result(job)
+                        if job.result is not None:
+                            times[job.name] = job.result
+                    else:
+                        self._log_initial("Cleaning up {0}".format(short_name))
+                        job.run(env)
+                        self._log_cache_result(job)
+        finally:
+            for job in jobs:
+                if isinstance(job, SetupCacheCleanupJob):
+                    job.run(env)
+
+        return times
+
+    def _log_initial(self, msg):
+        self._initial_message = msg
+        log.info(msg)
+
+    def _log_result(self, msg):
+        assert self._initial_message is not None
+        padding_length = util.get_terminal_width() - len(self._initial_message) - 14 - 1 - len(msg)
+        self._initial_message = None
+        if WIN:
+            padding_length -= 1
+        padding = " "*padding_length
+        log.add(" {0}{1}".format(padding, msg))
+
+    def _log_cache_result(self, item):
+        pass
+
+    def _log_benchmark_result(self, job):
+        if job.partial:
+            self._log_result("...")
+            return
+
+        # Display status
+        if job.failure_count > 0:
+            if job.bad_output is None:
+                if job.failure_count == job.total_count:
+                    self._log_result("failed")
+                else:
+                    self._log_result("{0}/{1} failed".format(job.failure_count,
+                                                             job.total_count))
+            else:
+                self._log_result("invalid output")
+                with log.indent():
+                    log.debug(job.bad_output)
+
+        # Display results
+        if job.benchmark['params'] and self.show_stderr:
+            # Long format display
+            if job.failure_count == 0:
+                self._log_result("ok")
+
+            display_result = [(v, statistics.get_err(v, s) if s is not None else None)
+                              for v, s in zip(job.result['result'], job.result['stats'])]
+            display = _format_benchmark_result(display_result, job.benchmark)
+            log.info("\n" + "\n".join(display))
+        else:
+            if job.failure_count == 0:
+                # Failure already shown above
+                if not job.result['result']:
+                    display = "[]"
+                else:
+                    if job.result['stats'][0]:
+                        err = statistics.get_err(job.result['result'][0], job.result['stats'][0])
+                    else:
+                        err = None
+                    display = util.human_value(job.result['result'][0], job.benchmark['unit'], err=err)
+                    if len(job.result['result']) > 1:
+                        display += ";..."
+                self._log_result(display)
+
+        # Dump program output
+        if self.show_stderr and job.result.get('stderr'):
+            with log.indent():
+                log.error(job.result['stderr'])
+
+
+class LaunchBenchmarkJob(object):
+    """
+    Job launching a benchmarking process and parsing its results.
+
+    Attributes
+    ----------
+    result : dict
+        Present after completing the job (successfully or unsuccessfully).
+        A dictionary with the following keys:
+
+        - `result`: List of numeric values of the benchmarks (one for each parameter
+          combination), either returned directly or obtained from `samples` via 
+          statistical analysis.
+
+          Values are `None` if benchmark failed or NaN if it was skipped.
+
+          If benchmark is not parameterized, the list contains a single number.
+
+        - `params`: Same as `benchmark['params']`. Empty list if non-parameterized.
+
+        - `samples`: List of lists of sampled raw data points, if benchmark produces
+          those and was successful.
+
+        - `stats`: List of results of statistical analysis of data.
+
+        - `profile`: If `profile` is `True` and run was at least partially successful, 
+          this key will be a byte string containing the cProfile data. Otherwise, None.
+
+        - `stderr`: Output produced.
+
+        - `errcode`: Error return code.
+    """
+
+    def __init__(self, name, benchmark, benchmark_dir, profile, extra_params,
+                 cache_job=None, prev_job=None, partial=False, selected_idx=None):
+        """
+        Parameters
+        ----------
+        benchmark : Benchmark object
+
+        root : str
+            Path to benchmark directory in which to find the benchmark
+
+        show_stderr : bool
+            When `True`, write the stderr out to the console.
+
+        quick : bool, optional
+            When `True`, run the benchmark function exactly once.
+
+        profile : bool, optional
+            When `True`, run the benchmark through the `cProfile` profiler
+            and save the results.
+
+        prev_result : dict, optional
+            Result from a previous run. If given, any raw measurement samples present
+            are included in the results (if successful). Nothing else is retained.
+
+        result_message : str, optional
+            Message to display instead of the measurement results.
+            If not given, display the measurement results.
+
+        """
+        self.name = name
+        self.benchmark = benchmark
+        self.benchmark_dir = benchmark_dir
+        self.profile = profile
+        self.extra_params = extra_params
+        self.cache_job = cache_job
+        self.prev_job = prev_job
+        self.partial = partial
+        self.selected_idx = selected_idx
+
+        self.result = None
+        self.bad_output = None
+        self.failure_count = 0
+        self.total_count = 0
+
+    def __repr__(self):
+        return "<asv.runner.LaunchBenchmarkJob '{}' at 0x{:x}>".format(self.name, id(self))
+
+    def run(self, env):
+        if self.cache_job is not None and self.cache_job.cache_dir is None:
+            # Our setup_cache failed, so skip this job
+            timestamp = datetime.datetime.utcnow()
+            self.result = {'result': None,
+                           'samples': None,
+                           'stats': None,
+                           'params': [],
+                           'stderr': self.cache_job.stderr,
+                           'started_at': timestamp,
+                           'ended_at': timestamp}
+            return
+
+        if self.prev_job is not None and self.prev_job.result['result'] is None:
+            # Previous job in a multi-process benchmark failed, so skip this job
+            self.result = self.prev_job.result
+            return
+
+        result = {"stderr": "", "errcode": 0}
+
+        extra_params = dict(self.extra_params)
+
+        if self.benchmark['params']:
+            param_iter = enumerate(itertools.product(*self.benchmark['params']))
+        else:
+            param_iter = [(None, None)]
+
+        self.bad_output = None
+
+        result['started_at'] = datetime.datetime.utcnow()
+
+        bench_results = []
+        bench_profiles = []
+
+        for param_idx, params in param_iter:
+            if (self.selected_idx is not None and
+                    self.benchmark['params'] and
+                    param_idx not in self.selected_idx):
+                # Use NaN to mark the result as skipped
+                bench_results.append(dict(samples=None, result=float('nan'),
+                                          stats=None))
+                bench_profiles.append(None)
+                continue
+
+            if self.prev_job:
+                idx = param_idx
+                if idx is None:
+                    idx = 0
+                prev_stats = self.prev_job.result['stats'][idx]
+                if prev_stats is not None:
+                    extra_params['number'] = prev_stats['number']
+                prev_samples = self.prev_job.result['samples'][idx]
+            else:
+                prev_samples = None
+
+            if self.cache_job is None:
+                cwd = tempfile.mkdtemp()
+            else:
+                cwd = self.cache_job.cache_dir
+
+            try:
+                success, data, profile_data, err, out, errcode = \
+                    run_benchmark_single(
+                        self.benchmark, self.benchmark_dir, env, param_idx,
+                        extra_params=extra_params, profile=self.profile,
+                        cwd=cwd)
+            finally:
+                if self.cache_job is None:
+                    shutil.rmtree(cwd, True)
+
+            self.total_count += 1
+            if success:
+                if isinstance(data, dict) and 'samples' in data:
+                    if prev_samples is not None:
+                        # Combine samples
+                        data['samples'] = prev_samples + data['samples']
+
+                    value, stats = statistics.compute_stats(data['samples'],
+                                                            data['number'])
+                    result_data = dict(samples=data['samples'],
+                                       result=value,
+                                       stats=stats)
+                else:
+                    result_data = dict(samples=None,
+                                       result=data,
+                                       stats=None)
+
+                bench_results.append(result_data)
+                if self.profile:
+                    bench_profiles.append(profile_data)
+            else:
+                self.failure_count += 1
+                bench_results.append(dict(samples=None, result=None, stats=None))
+                bench_profiles.append(None)
+                if data is not None:
+                    self.bad_output = data
+
+            err = err.strip()
+            out = out.strip()
+
+            if errcode:
+                if errcode == util.TIMEOUT_RETCODE:
+                    if err:
+                        err += "\n\n"
+                    err += "asv: benchmark timed out (timeout {0}s)\n".format(self.benchmark['timeout'])
+                result['errcode'] = errcode
+
+            if err or out:
+                err += out
+                if self.benchmark['params']:
+                    head_msg = "\n\nFor parameters: %s\n" % (", ".join(params),)
+                else:
+                    head_msg = ''
+
+                result['stderr'] += head_msg
+                result['stderr'] += err
+
+        # Produce result
+        for key in ['samples', 'result', 'stats']:
+            result[key] = [x[key] for x in bench_results]
+
+        if self.benchmark['params']:
+            result['params'] = self.benchmark['params']
+        else:
+            result['params'] = []
+
+        # Combine profile data
+        if self.prev_job and 'profile' in self.prev_job.result:
+            bench_profiles.append(self.prev_job.result['profile'])
+
+        profile_data = _combine_profile_data(bench_profiles)
+        if profile_data is not None:
+            result['profile'] = profile_data
+
+        result['ended_at'] = datetime.datetime.utcnow()
+
+        self.result = result
+
+    def _format_result():
+        pass
+
+
+class SetupCacheJob(object):
+    """
+    Job for running setup_cache and managing its results.
+    """
+
+    def __init__(self, benchmark_dir, benchmark_id, setup_cache_key, timeout):        
+        if setup_cache_key is None:
+            raise ValueError()
+
+        self.benchmark_dir = benchmark_dir
+        self.benchmark_id = benchmark_id
+        self.setup_cache_key = setup_cache_key
+        self.timeout = timeout
+
+        self.cache_dir = None
+
+    @property
+    def name(self):
+        name = os.path.split(self.setup_cache_key)
+        return name[-1]
+
+    def __repr__(self):
+        return "<asv.runner.SetupCacheJob '{}' at 0x{:x}>".format(self.name, id(self))
+
+    def run(self, env):
+        cache_dir = tempfile.mkdtemp()
+
+        out, err, errcode = env.run(
+            [BENCHMARK_RUN_SCRIPT, 'setup_cache',
+             os.path.abspath(self.benchmark_dir),
+             self.benchmark_id],
+            dots=False, display_error=False,
+            return_stderr=True, valid_return_codes=None,
+            cwd=cache_dir, timeout=self.timeout)
+
+        if errcode == 0:
+            self.stderr = None
+            self.cache_dir = cache_dir
+        else:
+            self.stderr = err
+            self.clean()
+
+    def clean(self):
+        if self.cache_dir is not None:
+            util.long_path_rmtree(self.cache_dir, True)
+            self.cache_dir = None
+
+
+class SetupCacheCleanupJob(object):
+    def __init__(self, cache_job):
+        self.cache_job = cache_job
+
+    @property
+    def name(self):
+        return self.cache_job.name
+
+    def __repr__(self):
+        return "<asv.runner.SetupCacheCleanupJob '{}' at 0x{:x}>".format(self.name, id(self))
+
+    def run(self, env):
+        self.cache_job.clean()
+
+
+def run_benchmark_single(benchmark, root, env, param_idx, profile, extra_params, cwd):
+    """
+    Run a benchmark, for single parameter combination index in case it
+    is parameterized
+
+    Returns
+    -------
+    success : bool
+        Whether test was successful
+    data
+        If success, the parsed JSON data. If failure, unparsed json data.
+    profile_data
+        Collected profiler data
+    err
+        Stderr content
+    out
+        Stdout content
+    errcode
+        Process return value
+
+    """
+    name = benchmark['name']
+    if param_idx is not None:
+        name += '-%d' % (param_idx,)
+
+    if profile:
+        profile_fd, profile_path = tempfile.mkstemp()
+        os.close(profile_fd)
+    else:
+        profile_path = 'None'
+
+    result_file = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        result_file.close()
+
+        success = True
+        params_str = json.dumps(extra_params)
+
+        out, err, errcode = env.run(
+            [BENCHMARK_RUN_SCRIPT, 'run', os.path.abspath(root),
+             name, params_str, profile_path, result_file.name],
+            dots=False, timeout=benchmark['timeout'],
+            display_error=False, return_stderr=True,
+            valid_return_codes=None, cwd=cwd)
+
+        if errcode:
+            success = False
+            parsed = None
+        else:
+            with open(result_file.name, 'r') as stream:
+                data = stream.read()
+            try:
+                parsed = json.loads(data)
+            except:
+                success = False
+                parsed = data
+
+        if profile:
+            with io.open(profile_path, 'rb') as profile_fd:
+                profile_data = profile_fd.read()
+            if not profile_data:
+                profile_data = None
+        else:
+            profile_data = None
+
+        return success, parsed, profile_data, err, out, errcode
+    finally:
+        os.remove(result_file.name)
+        if profile:
+            os.remove(profile_path)
+
+
+def _combine_profile_data(datasets):
+    """
+    Combine a list of profile data to a single profile
+    """
+    datasets = [data for data in datasets if data is not None]
+    if not datasets:
+        return None
+    elif len(datasets) == 1:
+        return datasets[0]
+
+    # Load and combine stats
+    stats = None
+
+    while datasets:
+        data = datasets.pop(0)
+
+        f = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            f.write(data)
+            f.close()
+            if stats is None:
+                stats = pstats.Stats(f.name)
+            else:
+                stats.add(f.name)
+        finally:
+            os.remove(f.name)
+
+    # Write combined stats out
+    f = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        f.close()
+        stats.dump_stats(f.name)
+        with open(f.name, 'rb') as fp:
+            return fp.read()
+    finally:
+        os.remove(f.name)
+
+
+def _format_benchmark_result(result, benchmark, max_width=None):
+    """
+    Format the result from a parameterized benchmark as an ASCII table
+    """
+    if not result:
+        return ['[]']
+
+    def do_formatting(num_column_params):
+        # Fold result to a table
+        if num_column_params > 0:
+            column_params = benchmark['params'][-num_column_params:]
+        else:
+            column_params = []
+
+        rows = []
+        if column_params:
+            row_params = benchmark['params'][:-len(column_params)]
+            header = benchmark['param_names'][:len(row_params)]
+            column_param_permutations = list(itertools.product(*column_params))
+            header += [" / ".join(_format_param_value(value) for value in values)
+                       for values in column_param_permutations]
+            rows.append(header)
+            column_items = len(column_param_permutations)
+            name_header = " / ".join(benchmark['param_names'][len(row_params):])
+        else:
+            column_items = 1
+            row_params = benchmark['params']
+            name_header = ""
+            header = benchmark['param_names']
+            rows.append(header)
+
+        for j, values in enumerate(itertools.product(*row_params)):
+            row_results = [util.human_value(x[0], benchmark['unit'], err=x[1])
+                           for x in result[j*column_items:(j+1)*column_items]]
+            row = [_format_param_value(value) for value in values] + row_results
+            rows.append(row)
+
+        if name_header:
+            display = util.format_text_table(rows, 1,
+                                             top_header_text=name_header,
+                                             top_header_span_start=len(row_params))
+        else:
+            display = util.format_text_table(rows, 1)
+
+        return display.splitlines()
+
+    # Determine how many parameters can be fit to columns
+    if max_width is None:
+        max_width = util.get_terminal_width() * 3//4
+
+    text = do_formatting(0)
+    for j in range(1, len(benchmark['params'])):
+        new_text = do_formatting(j)
+        width = max(len(line) for line in new_text)
+        if width < max_width:
+            text = new_text
+        else:
+            break
+
+    return text
+
+
+def _format_param_value(value_repr):
+    """
+    Format a parameter value for displaying it as test output. The
+    values are string obtained via Python repr.
+
+    """
+    regexs = ["^'(.+)'$",
+              "^u'(.+)'$",
+              "^<class '(.+)'>$"]
+
+    for regex in regexs:
+        m = re.match(regex, value_repr)
+        if m and m.group(1).strip():
+            return m.group(1)
+
+    return value_repr

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -286,40 +286,44 @@ class LaunchBenchmarkJob(object):
         - `errcode`: Error return code.
     """
 
-    def __init__(self, name, benchmark, benchmark_dir, profile, extra_params,
+    def __init__(self, name, benchmark, benchmark_dir, profile=False, extra_params=None,
                  cache_job=None, prev_job=None, partial=False, selected_idx=None):
         """
         Parameters
         ----------
+        name : str
+            Name of the benchmark
+
         benchmark : Benchmark object
 
-        root : str
+        benchmark_dir : str
             Path to benchmark directory in which to find the benchmark
 
-        show_stderr : bool
-            When `True`, write the stderr out to the console.
-
-        quick : bool, optional
-            When `True`, run the benchmark function exactly once.
-
-        profile : bool, optional
+        profile : bool
             When `True`, run the benchmark through the `cProfile` profiler
             and save the results.
 
-        prev_result : dict, optional
-            Result from a previous run. If given, any raw measurement samples present
-            are included in the results (if successful). Nothing else is retained.
+        extra_params : dict, optional
+            Benchmark attribute overrides.
 
-        result_message : str, optional
-            Message to display instead of the measurement results.
-            If not given, display the measurement results.
+        cache_job : SetupCacheJob, optional
+            Job that sets up the required setup cache
+
+        prev_job : LaunchBenchmarkJob, optional
+            Previous job for this benchmark, whose result to combine
+
+        partial : bool, optional
+            Whether this is the final run for this benchmark, or intermediate one.
+
+        selected_idx : list of int, optional
+            Which items to run in a parametrized bencmark.
 
         """
         self.name = name
         self.benchmark = benchmark
         self.benchmark_dir = benchmark_dir
         self.profile = profile
-        self.extra_params = extra_params
+        self.extra_params = extra_params if extra_params is not None else {}
         self.cache_job = cache_job
         self.prev_job = prev_job
         self.partial = partial
@@ -470,9 +474,6 @@ class LaunchBenchmarkJob(object):
         result['ended_at'] = datetime.datetime.utcnow()
 
         self.result = result
-
-    def _format_result():
-        pass
 
 
 class SetupCacheJob(object):

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -81,6 +81,7 @@ class BenchmarkRunner(object):
             self.extra_params['number'] = 1
             self.extra_params['repeat'] = 1
             self.extra_params['warmup_time'] = 0
+            self.extra_params['processes'] = 1
 
     def plan(self):
         # Find all setup_cache routines needed
@@ -108,9 +109,10 @@ class BenchmarkRunner(object):
 
         for setup_cache_key, benchmark_set in six.iteritems(benchmark_order):
             for name, benchmark in benchmark_set:
-                processes = benchmark.get('processes', 1)
-                if self.quick:
-                    processes = 1
+                if 'processes' in self.extra_params:
+                    processes = int(self.extra_params['processes'])
+                else:
+                    processes = int(benchmark.get('processes', 1))
                 insert_stack.append((name, benchmark, processes, setup_cache_key))
                 cache_users.setdefault(setup_cache_key, []).append(name)
 

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -166,8 +166,6 @@ class BenchmarkRunner(object):
         try:
             with log.indent():
                 for job in jobs:
-                    log.step()
-
                     short_name = truncate_left(job.name, name_max_width)
 
                     if isinstance(job, SetupCacheJob):
@@ -183,6 +181,7 @@ class BenchmarkRunner(object):
                                 self._log_initial('Running benchmarks...')
                             partial_info_printed = True
                         else:
+                            log.step()
                             self._log_initial('{0}'.format(short_name))
                             partial_info_printed = False
                         job.run(env)

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -315,7 +315,12 @@ by the ``number`` and ``repeat`` attributes, as explained below.
   benchmark. If not specified, ``warmup_time`` defaults to 0.1 seconds
   (on PyPy, the default is 1.0 sec).
 
-- ``repeat``: The number measurement samples to collect. Each sample
+- ``processes``: How many processes to launch for running the benchmarks
+  (default: 2). The processes run benchmarks in an interleaved order,
+  allowing to sample over longer periods of background performance
+  variations (e.g. CPU power levels).
+
+- ``repeat``: The number measurement samples to collect per process. Each sample
   consists of running the benchmark ``number`` times.  The median
   time from all of these repetitions is used as the final measurement
   result. When not provided (``repeat`` set to 0), the number of samples

--- a/test/benchmark/named.py
+++ b/test/benchmark/named.py
@@ -12,7 +12,7 @@ class Suite:
     named_method.benchmark_name = 'custom.track_method'
 
 
-def named_function(self):
+def named_function():
     pass
 
 
@@ -20,7 +20,7 @@ named_function.benchmark_name = 'custom.time_function'
 named_function.pretty_name = 'My Custom Function'
 
 
-def track_custom_pretty_name(self):
+def track_custom_pretty_name():
     return 42
 
 
@@ -29,7 +29,7 @@ track_custom_pretty_name.pretty_name = 'this.is/the.answer'
 
 class BaseSuite:
 
-    def some_func():
+    def some_func(self):
         return 0
 
 

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -43,23 +43,26 @@ class ParamSuite:
 
 class TuningTest:
     params = [1, 2]
-    counter = [0]
+    counter = [0, 0]
     number = 10
     repeat = 10
+    processes = 1
     warmup_time = 0
 
     def setup(self, n):
         self.number = 1
         self.repeat = n
-        self.counter[0] = 0
+        self.counter[1] = 0
 
     def time_it(self, n):
         self.counter[0] += 1
+        self.counter[1] += 1
 
     def teardown(self, n):
         # The time benchmark may call it one additional time
-        if not (n <= self.counter[0] <= n + 1):
-            raise RuntimeError("Number and repeat didn't have effect")
+        if not (self.counter[0] <= n + 1 and self.counter[1] == 1):
+            raise RuntimeError("Number and repeat didn't have effect: {} {}".format(
+                self.counter, n))
 
 
 def setup_skip(n):

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -148,6 +148,7 @@ def test_find_benchmarks(tmpdir):
     assert times['params_examples.ParamSuite.track_value']['result'] == [1+0, 2+0, 3+0]
 
     assert isinstance(times['params_examples.TuningTest.time_it']['result'][0], float)
+    assert isinstance(times['params_examples.TuningTest.time_it']['result'][1], float)
 
     assert isinstance(times['params_examples.time_skip']['result'][0], float)
     assert isinstance(times['params_examples.time_skip']['result'][1], float)
@@ -284,7 +285,7 @@ def track_this():
     d.update(ASV_CONF_JSON)
     d['env_dir'] = "env"
     d['benchmark_dir'] = 'benchmark'
-    d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
+    d['repo'] = tools.generate_test_repo(tmpdir, [[0, 1]]).path
     conf = config.Config.from_json(d)
 
     repo = get_repo(conf)

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -17,6 +17,7 @@ import textwrap
 from hashlib import sha256
 
 from asv import benchmarks
+from asv import runner
 from asv import config
 from asv import environment
 from asv import util
@@ -213,7 +214,7 @@ def test_table_formatting():
     benchmark = {'params': [], 'param_names': [], 'unit': 's'}
     result = []
     expected = ["[]"]
-    assert benchmarks._format_benchmark_result(result, benchmark) == expected
+    assert runner._format_benchmark_result(result, benchmark) == expected
 
     benchmark = {'params': [['a', 'b', 'c']], 'param_names': ['param1'], "unit": "seconds"}
     result = list(zip([1e-6, 2e-6, 3e-6], [3e-6, 2e-6, 1e-6]))
@@ -224,7 +225,7 @@ def test_table_formatting():
                 "   b      2.00\u00b12\u03bcs \n"
                 "   c      3.00\u00b11\u03bcs \n"
                 "======== ==========")
-    table = "\n".join(benchmarks._format_benchmark_result(result, benchmark, max_width=80))
+    table = "\n".join(runner._format_benchmark_result(result, benchmark, max_width=80))
     assert table == expected
 
     benchmark = {'params': [["'a'", "'b'", "'c'"], ["[1]", "[2]"]], 'param_names': ['param1', 'param2'], "unit": "seconds"}
@@ -238,7 +239,7 @@ def test_table_formatting():
                 "   b      failed   4.00s \n"
                 "   c      5.00s     n/a  \n"
                 "======== ======== =======")
-    table = "\n".join(benchmarks._format_benchmark_result(result, benchmark, max_width=80))
+    table = "\n".join(runner._format_benchmark_result(result, benchmark, max_width=80))
     assert table == expected
 
     expected = ("======== ======== ========\n"
@@ -251,7 +252,7 @@ def test_table_formatting():
                 "   c       [1]     5.00s  \n"
                 "   c       [2]      n/a   \n"
                 "======== ======== ========")
-    table = "\n".join(benchmarks._format_benchmark_result(result, benchmark, max_width=0))
+    table = "\n".join(runner._format_benchmark_result(result, benchmark, max_width=0))
     assert table == expected
 
 

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -75,7 +75,7 @@ def test_dev(capsys, basic_conf):
 
     # time_with_warnings failure case
     assert re.search("File.*time_exception.*RuntimeError", text, re.S)
-    assert re.search(r"Running time_secondary.track_value\s+42.0", text)
+    assert re.search(r"time_secondary.track_value\s+42.0", text)
 
     # Check that it did not clone or install
     assert "Cloning" not in text
@@ -95,7 +95,7 @@ def test_dev_with_repo_subdir(capsys, basic_conf_with_subdir):
     text, err = capsys.readouterr()
 
     # Benchmarks were found and run
-    assert re.search(r"Running time_secondary.track_value\s+42.0", text)
+    assert re.search(r"time_secondary.track_value\s+42.0", text)
 
     # Check that it did not clone or install
     assert "Cloning" not in text
@@ -113,7 +113,7 @@ def test_run_python_same(capsys, basic_conf):
     text, err = capsys.readouterr()
 
     assert re.search("time_exception.*failed", text, re.S)
-    assert re.search(r"Running time_secondary.track_value\s+42.0", text)
+    assert re.search(r"time_secondary.track_value\s+42.0", text)
 
     # Check that it did not clone or install
     assert "Cloning" not in text

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -103,6 +103,7 @@ def test_run_publish(capfd, basic_conf):
     # Tests a typical complete run/publish workflow
     tools.run_asv_with_conf(conf, 'run', "master~5..master", '--steps=2',
                             '--quick', '--show-stderr', '--profile',
+                            '-a', 'warmup_time=0',
                             _machine_file=machine_file)
     text, err = capfd.readouterr()
 


### PR DESCRIPTION
Refactor benchmark runner by decoupling preparation/running/result printing steps from each other.

Also enable interleaved sampling runs, i.e. each benchmark run is split to multiple parts and these are run in an interleaved order. This enables each benchmark to sample over long-time variations in CPU and other background factors.