### PR TITLE
For small samples, estimate median CI by distribution fit

### DIFF
--- a/asv/statistics.py
+++ b/asv/statistics.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import math
 
-from .step_detect import solve_potts_approx
+from .util import inf, nan
 
 
 def compute_stats(samples):
@@ -41,18 +41,22 @@ def compute_stats(samples):
     y_25 = quantile(Y, 0.25)
     y_75 = quantile(Y, 0.75)
 
-    # Look for big shifts in the time series
-    min_size = max(5, len(Y)//5)
-    gamma = quantile([abs(yp - y_50) for yp in Y], 0.5) * min_size
-    if min_size <= len(Y):
-        step_right, step_mu, _ = solve_potts_approx(Y, gamma=gamma, p=1, min_size=min_size)
-    else:
-        step_mu = [y_50]
+    # If nonparametric CI estimation didn't give an estimate,
+    # use the credible interval of a bayesian posterior distribution.
+    a, b = ci_50
+    if (math.isinf(a) or math.isinf(b)) and len(Y) > 1:
+        # Compute posterior distribution for location, assuming
+        # exponential noise. The MLE is equal to the median.
+        c = LaplacePosterior(Y)
 
-    # Broaden the confidence interval by the detected steps
-    ci_a, ci_b = ci_50
-    ci_a -= y_50 - min(step_mu)
-    ci_b += max(step_mu) - y_50
+        # Use the CI from that distribution to extend beyond sample
+        # bounds
+        if math.isinf(a):
+            a = min(c.ppf(0.01/2), min(Y))
+        if math.isinf(b):
+            b = max(c.ppf(1 - 0.01/2), max(Y))
+
+        ci_50 = (a, b)
 
     # Produce results
     mean = sum(Y) / len(Y)
@@ -61,15 +65,14 @@ def compute_stats(samples):
 
     result = y_50
 
-    stats = {'ci_99': [ci_a, ci_b],
+    stats = {'ci_99': list(ci_50),
              'q_25': y_25,
              'q_75': y_75,
              'min': min(Y),
              'max': max(Y),
              'mean': mean,
              'std': std,
-             'n': len(Y),
-             'systematic': max(step_mu) - min(step_mu)}
+             'n': len(Y)}
 
     return result, stats
 
@@ -84,12 +87,11 @@ def get_err(result, stats):
 
 
 def is_different(stats_a, stats_b):
-    """
-    Check whether the samples are statistically different.
+    """Check whether the samples are statistically different.
 
-    This is a pessimistic check, and not statistically fully rigorous.
-    The false negative rate is probably relatively high if the distributions 
-    overlap significantly.
+    This is a pessimistic check --- if it returns True, then the
+    difference is statistically significant. If it returns False,
+    there might still might be difference.
 
     Parameters
     ----------
@@ -110,7 +112,7 @@ def is_different(stats_a, stats_b):
     return True
 
 
-def quantile_ci(x, q, alpha_min=0.99):
+def quantile_ci(x, q, alpha_min=0.01):
     """
     Compute a quantile and a confidence interval.
 
@@ -123,7 +125,8 @@ def quantile_ci(x, q, alpha_min=0.99):
     q : float
         Quantile to compute, in [0,1].
     alpha_min : float, optional
-        Lower bound for the coverage.
+        Limit for coverage.
+        The result has coverage >= 1 - alpha_min.
 
     Returns
     -------
@@ -137,29 +140,39 @@ def quantile_ci(x, q, alpha_min=0.99):
     y = sorted(x)
     n = len(y)
 
-    cdf = 0
-
     alpha_min = min(alpha_min, 1 - alpha_min)
     pa = alpha_min / 2
     pb = 1 - pa
 
-    a = y[0]
-    b = y[-1]
+    a = -inf
+    b = inf
 
+    # It's known that
+    #
+    # Pr[X_{(r)} < m < X_{(s)}] = Pr[r <= K <= s-1], K ~ Bin(n,p)
+    #
+    # where cdf(m) = p defines the quantile.
+    #
+    # Simplest median CI follows by picking r,s such that
+    #
+    #   F(r;n,q) <= alpha/2
+    #   F(s;n,q) >= 1 - alpha/2
+    #
+    #   F(k;n,q) = sum(binom_pmf(n, j, q) for j in range(k))
+    #
+    # Then (y[r-1], y[s-1]) is a CI.
+    # If no such r or s exists, replace by +-inf.
+
+    F = 0
     for k, yp in enumerate(y):
-        cdf += binom_pmf(n, k, q)
+        F += binom_pmf(n, k, q)
+        # F = F(k+1;n,q)
 
-        if cdf <= pa:
-            if k < len(y) - 1:
-                a = 0.5*(yp + y[k+1])
-            else:
-                a = yp
+        if F <= pa:
+            a = yp
 
-        if cdf >= pb:
-            if k > 0:
-                b = 0.5*(yp + y[k-1])
-            else:
-                b = yp
+        if F >= pb:
+            b = yp
             break
 
     m = quantile(y, q)
@@ -237,4 +250,224 @@ def lgamma(x):
         return math.log(math.factorial(int_x - 1))
 
     # Would need full implementation
-    return float("nan")
+    return nan
+
+
+class LaplacePosterior(object):
+    """
+    Univariate distribution::
+
+        p(beta|y) = N [sum(|y_j - beta|)]**(-nu-1)
+
+    where N is the normalization factor.
+
+    Parameters
+    ----------
+    y : list of float
+        Samples
+    nu : float, optional
+        Degrees of freedom. Default: len(y)-1
+
+    Notes
+    -----
+    This is the posterior distribution in the Bayesian model assuming
+    Laplace distributed noise::
+
+        p(y|beta,sigma) = N exp(- sum_j (1/sigma) |y_j - beta|)
+
+        p(sigma) ~ 1/sigma
+
+        nu = len(y) - 1
+
+    The MLE for beta is median(y).
+
+    Note that the same approach applied to a Gaussian model::
+
+        p(y|beta,sigma) = N exp(- sum_j 1/(2 sigma^2) (y_j - beta)^2)
+
+    results to::
+
+        p(beta|y) = N T(t, m-1);   t = (beta - mean(y)) / (sstd(y) / sqrt(m))
+
+    where ``T(t, nu)`` is the Student t-distribution pdf, which then gives
+    the standard textbook formulas for the mean.
+
+    """
+
+    def __init__(self, y, nu=None):
+        if len(y) == 0:
+            raise ValueError("empty input")
+
+        if nu is None:
+            self.nu = len(y) - 1
+        else:
+            self.nu = nu
+
+        # Sort input
+        y = sorted(y)
+
+        # Get location and scale so that data is centered at MLE, and
+        # the unnormalized PDF at MLE has amplitude ~ 1/nu.
+        #
+        # Proper scaling of inputs is important to avoid overflows
+        # when computing the unnormalized CDF integrals below.
+        self.mle = quantile(y, 0.5)
+        self._y_scale = sum(abs(yp - self.mle) for yp in y)
+        self._y_scale *= self.nu**(1/(self.nu + 1))
+
+        # Shift and scale
+        if self._y_scale != 0:
+            self.y = [(yp - self.mle)/self._y_scale for yp in y]
+        else:
+            self.y = [0 for yp in y]
+
+        self._cdf_norm = None
+        self._cdf_memo = {}
+
+    def _cdf_unnorm(self, beta):
+        """
+        Unnormalized CDF of this distribution::
+
+            cdf_unnorm(b) = int_{-oo}^{b} 1/(sum_j |y - b'|)**(m+1) db'
+
+        """
+        if beta != beta:
+            return beta
+
+        for k, y in enumerate(self.y):
+            if y > beta:
+                k0 = k
+                break
+        else:
+            k0 = len(self.y)
+
+        cdf = 0
+
+        nu = self.nu
+
+        # Save some work by memoizing intermediate results
+        if k0 - 1 in self._cdf_memo:
+            k_start = k0
+            cdf = self._cdf_memo[k0 - 1]
+        else:
+            k_start = 0
+            cdf = 0
+
+        # Do the integral piecewise, resolving the absolute values
+        for k in range(k_start, k0 + 1):
+            c = 2*k - len(self.y)
+            y = sum(self.y[k:]) - sum(self.y[:k])
+
+            if k == 0:
+                a = -inf
+            else:
+                a = self.y[k-1]
+
+            if k == k0:
+                b = beta
+            else:
+                b = self.y[k]
+
+            if c == 0:
+                term = (b - a) / y**(nu+1)
+            else:
+                term = 1/(nu*c) * ((a*c + y)**(-nu) - (b*c + y)**(-nu))
+
+            cdf += max(0, term)  # avoid rounding error
+
+            if k != k0:
+                self._cdf_memo[k] = cdf
+
+        if beta == inf:
+            self._cdf_memo[len(self.y)] = cdf
+
+        return cdf
+
+    def _ppf_unnorm(self, cdfx):
+        """
+        Inverse function for _cdf_unnorm
+        """
+        # Find interval
+        for k in range(len(self.y) + 1):
+            if cdfx <= self._cdf_memo[k]:
+                break
+
+        # Invert on interval
+        c = 2*k - len(self.y)
+        y = sum(self.y[k:]) - sum(self.y[:k])
+        nu = self.nu
+        if k == 0:
+            term = cdfx
+        else:
+            a = self.y[k-1]
+            term = cdfx - self._cdf_memo[k-1]
+
+        if k == 0:
+            z = -nu*c*term
+            if z > 0:
+                beta = (z**(-1/nu) - y) / c
+            else:
+                beta = -inf
+        elif c == 0:
+            beta = a + term * y**(nu+1)
+        else:
+            z = (a*c + y)**(-nu) - nu*c*term
+            if z > 0:
+                beta = (z**(-1/nu) - y)/c
+            else:
+                beta = inf
+
+        if k < len(self.y):
+            beta = min(beta, self.y[k])
+
+        return beta
+
+    def pdf(self, beta):
+        """
+        Probability distribution function
+        """
+        return math.exp(self.logpdf(beta))
+
+    def logpdf(self, beta):
+        """
+        Logarithm of probability distribution function
+        """
+        if self._y_scale == 0:
+            return inf if beta == self.mle else -inf
+
+        beta = (beta - self.mle) / self._y_scale
+
+        if self._cdf_norm is None:
+            self._cdf_norm = self._cdf_unnorm(inf)
+
+        ws = sum(abs(yp - beta) for yp in self.y)
+        m = self.nu
+        return -(m+1)*math.log(ws) - math.log(self._cdf_norm) - math.log(self._y_scale)
+
+    def cdf(self, beta):
+        """
+        Cumulative probability distribution function
+        """
+        if self._y_scale == 0:
+            return 1.0*(beta > self.mle)
+
+        beta = (beta - self.mle) / self._y_scale
+
+        if self._cdf_norm is None:
+            self._cdf_norm = self._cdf_unnorm(inf)
+        return self._cdf_unnorm(beta) / self._cdf_norm
+
+    def ppf(self, cdf):
+        """
+        Percent point function (inverse function for cdf)
+        """
+        if cdf < 0 or cdf > 1.0:
+            return nan
+
+        if self._cdf_norm is None:
+            self._cdf_norm = self._cdf_unnorm(inf)
+
+        cdfx = min(cdf * self._cdf_norm, self._cdf_norm)
+        beta = self._ppf_unnorm(cdfx)
+        return beta * self._y_scale + self.mle
+

--- a/asv/util.py
+++ b/asv/util.py
@@ -33,6 +33,7 @@ from .extern import minify_json
 
 
 nan = float('nan')
+inf = float('inf')
 
 WIN = (os.name == 'nt')
 

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -153,8 +153,7 @@ A benchmark suite directory has the following layout.  The
         - ``stats``: dictionary containing results of statistical
           analysis. Contains keys ``ci_99`` (confidence interval
           estimate for the result), ``q_25``, ``q_75`` (percentiles),
-          ``min``, ``max``, ``mean``, ``std``, ``n``, and
-          ``systematic`` (estimate of systematic error).
+          ``min``, ``max``, ``mean``, ``std``, and ``n``.
 
           This key is omitted if there is no statistical analysis.
 

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -4,9 +4,11 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import warnings
 from itertools import product
 import pytest
 
+from asv.util import inf
 import asv.statistics as statistics
 
 
@@ -18,7 +20,7 @@ except ImportError:
 
 
 try:
-    from scipy import special, stats
+    from scipy import integrate, special, stats
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
@@ -35,7 +37,6 @@ def test_compute_stats():
         samples = np.random.randn(nsamples) + true_mean
         result, stats = statistics.compute_stats(samples)
 
-        assert np.allclose(stats['systematic'], 0)
         assert np.allclose(stats['n'], len(samples))
         assert np.allclose(stats['mean'], np.mean(samples))
         assert np.allclose(stats['q_25'], np.percentile(samples, 25))
@@ -68,48 +69,108 @@ def test_is_different():
         assert statistics.is_different(stats_a, stats_b) == significant
 
 
+def _check_ci(estimator, sampler, nsamples=300):
+    """
+    Check whether confidence behaves as advertized.
+
+    Draw random samples from a distribution and check how often the
+    true value (assumed 0) falls in the estimated CI.
+
+    Parameters
+    ----------
+    ci_estimator : callable(samples, alpha)
+        Estimator returning ``(m, (a, b))`` for coverage alpha,
+        for the estimate ``m`` and CI ``(a, b)``
+    sampler : callable(size)
+        Draw samples from a distribution with zero value for the true
+        location parameter.
+    nsamples : int, optional
+        Number of samples to draw
+
+    Yields
+    ------
+    size, alpha, alpha_got
+
+    """
+    alphas = [0.5, 0.1, 0.01]
+    sizes = [2, 5, 10, 30, 100]
+
+    for size, alpha in product(sizes, alphas):
+        samples = []
+        for k in range(nsamples):
+            z = sampler(size)
+            m, ci = estimator(z, alpha)
+            a, b = ci
+            assert a <= m <= b
+            samples.append(a <= 0 <= b)
+
+        alpha_got = 1 - sum(samples) / len(samples)
+
+        yield size, alpha, alpha_got
+
+
 @pytest.mark.skipif(not HAS_NUMPY, reason="Requires numpy")
 def test_quantile_ci():
     # Test the confidence intervals
 
-    def get_z_exp(loc, scale, size):
+    scale = 2.5
+
+    def sample_exp(size):
         z = np.random.exponential(scale, size=size)
         z *= 2 * np.random.randint(0, 2, size=len(z)) - 1
-        return loc + z
-
-    def get_z_normal(loc, scale, size):
-        z = np.random.normal(loc, scale, size=size)
         return z
 
-    loc = 2.5
-    scale = 2.5
+    def sample_normal(size):
+        return np.random.normal(0, scale, size=size)
 
     np.random.seed(1)
 
-    for alpha_min in [0.5, 0.9, 0.99, 0.999]:
-        for sampler in [get_z_exp, get_z_normal]:
-            for size in [10, 30]:
-                samples = []
-                for k in range(300):
-                    z = sampler(loc, scale, size)
-                    m, ci = statistics.quantile_ci(z, 0.5, alpha_min)
-                    assert np.allclose(m, np.median(z))
-                    a, b = ci
-                    samples.append(a <= loc <= b)
-
-                alpha = sum(samples) / len(samples)
-
-                # Order of magnitude should match
-                assert 1 - alpha <= 5 * (1 - alpha_min), (alpha_min, sampler, size)
+    for sampler in [sample_exp, sample_normal]:
+        cis = _check_ci(lambda z, alpha: statistics.quantile_ci(z, 0.5, alpha),
+                        sampler, nsamples=300)
+        atol = 5/300
+        for size, alpha, alpha_got in cis:
+            if size < 20:
+                assert 0 <= alpha_got <= 1.2*alpha
+            else:
+                assert 0.5*alpha - atol <= alpha_got <= 1.1*alpha + atol
 
 
 def test_quantile_ci_small():
-    # Small samples should give min/max ci
+    # Small samples should give infinite ci
     for n in range(1, 7):
         sample = list(range(n))
         m, ci = statistics.quantile_ci(sample, 0.5, 0.99)
-        assert ci[0] == min(sample)
-        assert ci[1] == max(sample)
+        assert ci[0] == -inf
+        assert ci[1] == inf
+
+
+def test_quantile_ci_r():
+    # Compare to R
+    x = [-2.47946614, -1.49595963, -1.02812482, -0.76592323, -0.09452743,  0.10732743,
+         0.27798342, 0.50173779, 0.57829823, 0.60474948, 0.94695675, 1.20159789]
+
+    # quantile(x, type=7, prob=p)
+    q_20_e = -0.9756845
+    q_50_e = 0.1926554
+    q_80_e = 0.5994592
+
+    # asht::quantileTest(x, prob=p, conf.level=0.8)$conf.int
+    ci_20_80_e = [-2.47946614, -0.09452743]
+    ci_50_80_e = [-0.7659232, 0.5782982]
+    ci_80_80_e = [0.5017378, 1.2015979,]
+
+    q_20, ci_20_80 = statistics.quantile_ci(x, 0.2, 0.8)
+    q_50, ci_50_80 = statistics.quantile_ci(x, 0.5, 0.8)
+    q_80, ci_80_80 = statistics.quantile_ci(x, 0.8, 0.8)
+
+    assert q_20 == pytest.approx(q_20_e)
+    assert q_50 == pytest.approx(q_50_e)
+    assert q_80 == pytest.approx(q_80_e)
+
+    assert ci_20_80 == pytest.approx(ci_20_80_e, abs=1e-4)
+    assert ci_50_80 == pytest.approx(ci_50_80_e, abs=1e-4)
+    assert ci_80_80 == pytest.approx(ci_80_80_e, abs=1e-4)
 
 
 @pytest.mark.skipif(not HAS_NUMPY, reason="Requires numpy")
@@ -143,3 +204,124 @@ def test_binom_pmf():
     got = np.vectorize(statistics.binom_pmf)(n, k, p)
 
     assert np.allclose(got, expected, rtol=1e-12, atol=0)
+
+
+@pytest.mark.skipif(not HAS_NUMPY, reason="Requires numpy")
+def test_laplace_posterior_ci():
+    # Test the LaplacePosterior confidence intervals
+
+    scale = 2.5
+
+    def get_z_exp(size):
+        """Samples from noise distribution assumed in LaplacePosterior"""
+        z = np.random.exponential(scale, size=size)
+        z *= 2 * np.random.randint(0, 2, size=len(z)) - 1
+        return z
+
+    def get_z_normal(size):
+        """Samples from noise distribution not assumed in LaplacePosterior"""
+        z = np.random.normal(0, scale, size=size)
+        return z
+
+    np.random.seed(41)
+
+    def estimator(z, alpha):
+        c = statistics.LaplacePosterior(z.tolist())
+        a, b = c.ppf(alpha/2), c.ppf(1 - alpha/2)
+        a = min(c.mle, a)  # force MLE inside CI
+        b = max(c.mle, b)
+        return c.mle, (a, b)
+
+    for sampler in [get_z_exp, get_z_normal]:
+        cis = _check_ci(estimator, sampler, nsamples=300)
+        atol = 5/300
+        for size, alpha, alpha_got in cis:
+            if sampler == get_z_exp:
+                # Result should be ok for the assumed distribution
+                rtol = 0.25
+            else:
+                # For other distributions, order of magnitude should match
+                rtol = 2.0
+
+            assert np.allclose(alpha_got, alpha, atol=atol, rtol=rtol)
+
+
+def test_laplace_posterior_basic():
+    # Test the LaplacePosterior mle/cdf/ppf
+
+    # even
+    y = [1, 2, 3, 4, 5, 6][::-1]
+    c = statistics.LaplacePosterior(y)
+    assert abs(c.mle - 3.5) < 1e-8
+
+    # odd
+    y = [1, 2, 3, 4, 5][::-1]
+    c = statistics.LaplacePosterior(y)
+    assert abs(c.mle - 3) < 1e-8
+
+    # check pdf vs cdf
+    sx = 200
+    dx = 1.0/sx
+    cdf = 0
+    for jx in range(-10*sx, 10*sx):
+        cdf += c.pdf(dx*jx) * dx
+        got = c.cdf(dx*jx)
+        assert abs(cdf - got) < 3e-3
+    assert abs(cdf - 1.0) < 1e-3
+
+    # large input (must not cause overflows)
+    y = list(range(500))
+    c = statistics.LaplacePosterior(y)
+    assert abs(c.mle - 249.5) < 1e-8
+    assert abs(c.cdf(249.5) - 0.5) < 1e-8
+
+    # check cdf sanity
+    assert c.cdf(float('inf')) == 1.0
+    assert c.cdf(-float('inf')) == 0.0
+    assert abs(c.cdf(-1e9) - 0) < 1e-6
+    assert abs(c.cdf(1e9) - 1) < 1e-6
+
+    # check ppf
+    for p in [0.0, 1e-3, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999, 1.0]:
+        assert abs(c.cdf(c.ppf(p)) - p) < 1e-3
+
+    t = c.ppf(1.1)
+    assert t != t
+
+    # check zero variance
+    y = [1, 1, 1, 1, 1]
+    c = statistics.LaplacePosterior(y)
+    assert c.mle == 1
+    assert c.pdf(1 - 1e-5) == 0
+    assert c.pdf(1 + 1e-5) == 0
+    assert c.cdf(1 - 1e-5) == 0
+    assert c.cdf(1 + 1e-5) == 1.0
+
+    # one item
+    y = [1]
+    c = statistics.LaplacePosterior(y)
+    assert c.cdf(1 - 1e-5) == 0
+    assert c.cdf(1 + 1e-5) == 1.0
+
+    # zero items
+    with pytest.raises(ValueError):
+        statistics.LaplacePosterior([])
+
+    
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
+def test_laplace_posterior_cdf():
+    # Test the LaplacePosterior cdf vs pdf
+    np.random.seed(1)
+    y = np.random.randn(15).tolist()
+
+    c = statistics.LaplacePosterior(y)
+
+    num_cdf = lambda t: integrate.quad(c.pdf, -np.inf, t, limit=1000)[0]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=integrate.IntegrationWarning)
+
+        for t in np.linspace(-5, 5, 70):
+            x = c.cdf(t)
+            assert abs(x - num_cdf(t)) < 1e-5
+            assert abs(c.ppf(x) - t) < 1e-5


### PR DESCRIPTION
The nonparametric quantile CI estimate is not well determined for small
samples. For those cases (when the esimated CI is infinite), assume the
samples originate from an exponential distribution, and use the
Bayesian credible interval of the location parameter.

Also fix off-by-one issues in quantile_ci