### PR TITLE
Split large command methods into smaller functions

### DIFF
--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -9,7 +9,7 @@ import six
 
 from . import Command
 from .run import Run
-from .compare import Compare
+from .compare import print_table
 
 from ..repo import get_repo
 from ..console import color_print, log
@@ -87,11 +87,11 @@ class Continuous(Command):
         if result:
             return result
 
-        status = Compare.print_table(conf, parent, head,
-                                     resultset_1=_results_iter(parent, run_objs, result),
-                                     resultset_2=_results_iter(head, run_objs, result),
-                                     factor=factor, split=False, only_changed=True,
-                                     sort_by_ratio=True)
+        status = print_table(conf, parent, head,
+                             resultset_1=_results_iter(parent, run_objs, result),
+                             resultset_2=_results_iter(head, run_objs, result),
+                             factor=factor, split=False, only_changed=True,
+                             sort_by_ratio=True)
         worsened, improved = status
 
         color_print("")

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -87,29 +87,9 @@ class Continuous(Command):
         if result:
             return result
 
-        def results_iter(commit_hash):
-            for env in run_objs['environments']:
-                machine_name = run_objs['machine_params']['machine']
-                filename = results.get_filename(
-                    machine_name, commit_hash, env.name)
-                filename = os.path.join(conf.results_dir, filename)
-                try:
-                    result = results.Results.load(filename, machine_name)
-                except util.UserError as err:
-                    log.warn(six.text_type(err))
-                    continue
-
-                for name, benchmark in six.iteritems(run_objs['benchmarks']):
-                    params = benchmark['params']
-                    version = benchmark['version']
-
-                    value = result.get_result_value(name, params)
-                    stats = result.get_result_stats(name, params)
-                    yield name, params, value, stats, version
-
         status = Compare.print_table(conf, parent, head,
-                                     resultset_1=results_iter(parent),
-                                     resultset_2=results_iter(head),
+                                     resultset_1=_results_iter(parent, run_objs, result),
+                                     resultset_2=_results_iter(head, run_objs, result),
                                      factor=factor, split=False, only_changed=True,
                                      sort_by_ratio=True)
         worsened, improved = status
@@ -123,3 +103,40 @@ class Continuous(Command):
             color_print("BENCHMARKS NOT SIGNIFICANTLY CHANGED.", 'green')
 
         return worsened
+
+
+def _results_iter(commit_hash, run_objs, result):
+    """
+    Iterate over results for the given commit_hash.
+
+    Parameters
+    ----------
+    commit_hash : str
+    run_objs : dict
+    result : results.Results
+
+    Yields
+    ------
+    name : str
+    params : list
+    value : object
+    stats : list
+    version : str
+    """
+    for env in run_objs['environments']:
+        machine_name = run_objs['machine_params']['machine']
+        filename = results.get_filename(machine_name, commit_hash, env.name)
+        filename = os.path.join(conf.results_dir, filename)
+        try:
+            result = results.Results.load(filename, machine_name)
+        except util.UserError as err:
+            log.warn(six.text_type(err))
+            continue
+
+        for name, benchmark in six.iteritems(run_objs['benchmarks']):
+            params = benchmark['params']
+            version = benchmark['version']
+
+            value = result.get_result_value(name, params)
+            stats = result.get_result_stats(name, params)
+            yield name, params, value, stats, version

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -108,8 +108,8 @@ class Continuous(Command):
                     yield name, params, value, stats, version
 
         status = print_table(conf, parent, head,
-                             resultset_1=_results_iter(parent, run_objs, result),
-                             resultset_2=_results_iter(head, run_objs, result),
+                             resultset_1=_results_iter(parent),
+                             resultset_2=_results_iter(head),
                              factor=factor, split=False, only_changed=True,
                              sort_by_ratio=True)
         worsened, improved = status


### PR DESCRIPTION
The most important change here is making `Compare.print_table` into a module function.  Calling `print_function` from `Continuous` instead of `Compare.print_function` makes it much easier to reason about the dependencies in the code.