### PR TITLE
Add a min_repeat benchmark attribute

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -82,7 +82,7 @@ def run_benchmark(benchmark, root, env, show_stderr=False,
         - `samples`: List of lists of sampled raw data points, if benchmark produces
           those and was successful.
 
-        - `number`: Repeact count associated with each sample.
+        - `number`: Repeat count associated with each sample.
 
         - `stats`: List of results of statistical analysis of data.
 

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -331,6 +331,10 @@ by the ``number`` and ``repeat`` attributes, as explained below.
   each sample takes approximatively ``sample_time`` seconds.  If not
   specified, ``sample_time`` defaults to 0.1 seconds.
 
+- ``min_repeat``: ``asv`` will ensure to produce at least ``min_repeat``
+  samples whatever the ``sample_time`` and ``timeout`` values. If not
+  specified, ``min_repeat`` defaults to 0.
+
 - ``timer``: The timing function to use, which can be any source of
   monotonically increasing numbers, such as `time.clock`, `time.time`
   or ``time.process_time``.  If it's not provided, it defaults to
@@ -349,7 +353,7 @@ by the ``number`` and ``repeat`` attributes, as explained below.
   measures the time used by the current process, is often the best
   choice.
 
-The ``sample_time``, ``number``, ``repeat``, and ``timer`` attributes
+The ``sample_time``, ``number``, ``repeat``, ``min_repeat`` and ``timer`` attributes
 can be adjusted in the ``setup()`` routine, which can be useful for
 parameterized benchmarks.
 

--- a/test/benchmark/time_examples.py
+++ b/test/benchmark/time_examples.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import time
 import sys
 if sys.version_info[0] == 3:
     xrange = range
@@ -98,3 +99,20 @@ class TimeWithBadTimer(object):
 
     def time_it(self):
         pass
+
+
+class TimeWithMinRepeat(object):
+    # benchmark with number 1 (use case is to call setup/teardown at each
+    # repeat) and benchmark duration > sample_time, with min_repeat 3 we should
+    # repeat this benchmark 3 times.
+    number = 1
+    sample_time = 0.1
+    repeat = 10
+    min_repeat = 3
+
+    def time_it(self):
+        time.sleep(0.5)
+
+
+class TimeWithMinRepeatNoWarmup(TimeWithMinRepeat):
+    warmup_time = 0

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -65,7 +65,7 @@ def test_find_benchmarks(tmpdir):
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                                        regex='example')
-    assert len(b) == 26
+    assert len(b) == 28
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                               regex='time_example_benchmark_1')
@@ -98,7 +98,7 @@ def test_find_benchmarks(tmpdir):
     assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1, 2, 3]
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
-    assert len(b) == 36
+    assert len(b) == 38
 
     assert 'named.OtherSuite.track_some_func' in b
 
@@ -134,6 +134,8 @@ def test_find_benchmarks(tmpdir):
     assert times['time_examples.time_with_warnings']['errcode'] != 0
 
     assert times['time_examples.TimeWithBadTimer.time_it']['result'] == [0.0]
+    assert len(times['time_examples.TimeWithMinRepeat.time_it']['samples'][0]) == 3
+    assert len(times['time_examples.TimeWithMinRepeatNoWarmup.time_it']['samples'][0]) == 3
 
     assert times['params_examples.track_param']['params'] == [["<class 'benchmark.params_examples.ClassOne'>",
                                                                "<class 'benchmark.params_examples.ClassTwo'>"]]


### PR DESCRIPTION
When sample_time is lower than a single benchmark we run only one
sample. For some benchmark it's hard to set sample time to a proper
value to have at least a sufficient number of samples (depending on
hardware / parameterization etc).
Add a min_repeat benchmark attribute to ensure we return a value
computed on at least a given number of samples.

Closes #653
