### PR TITLE
Smooth up asv 0.2->0.3 update UX for benchmarks.json

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -316,7 +316,7 @@ class Benchmarks(dict):
     """
     Manages and runs the set of benchmarks in the project.
     """
-    api_version = 1
+    api_version = 2
 
     def __init__(self, conf, benchmarks, regex=None):
         """

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -530,6 +530,9 @@ class Benchmarks(dict):
             benchmarks = six.itervalues(d)
             return cls(conf, benchmarks)
         except util.UserError as err:
+            if "asv update" in str(err):
+                # Don't give conflicting instructions
+                raise
             raise util.UserError("{}\nUse `asv run --bench just-discover` to "
                                  "regenerate benchmarks.json".format(str(err)))
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -192,10 +192,10 @@ class Run(Command):
                                          commit_hashes, regex=bench)
         benchmarks.save()
         if len(benchmarks) == 0:
-            log.error("No benchmarks selected")
             if bench == ["just-discover"]:
                 return 0
             else:
+                log.error("No benchmarks selected")
                 return 1
 
         steps = len(commit_hashes) * len(benchmarks) * len(environments)

--- a/asv/util.py
+++ b/asv/util.py
@@ -720,8 +720,10 @@ def update_json(cls, path, api_version):
         write_json(path, d, api_version)
     elif d['version'] > api_version:
         raise UserError(
-            "version of {0} is newer than understood by this version of "
-            "asv. Upgrade asv in order to use or add to these results.")
+            "{0} is stored in a format that is newer than "
+            "what this version of asv understands. "
+            "Upgrade asv in order to use or add to "
+            "these results.".format(path))
 
 
 def iter_chunks(s, n):

--- a/test/example_results/benchmarks.json
+++ b/test/example_results/benchmarks.json
@@ -389,5 +389,5 @@
         "unit": "unit",
         "version": "1"
     },
-    "version": 1
+    "version": 2
 }

--- a/test/tools.py
+++ b/test/tools.py
@@ -410,7 +410,7 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
             "param_names": param_names or [],
             "version": benchmark_version,
         }
-    }, api_version=1)
+    }, api_version=2)
     return conf
 
 


### PR DESCRIPTION
Benchmark versioning changes necessitate regeneration of the
benchmarks.json file.

Bump the file API version to ensure users cannot miss this by accident.

Fixes: gh-658