### PR TITLE
Use pytest-rerunfailures for tests that have timing dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install:
       fi
       $TRAVIS_PYTHON .continuous-integration/download_reqs.py --pip=$HOME/download/pip-cache
     fi
-    $TRAVIS_PIP install selenium six "pytest>=3.5" pytest-xdist feedparser python-hglib;
+    $TRAVIS_PIP install selenium six "pytest>=3.5" pytest-xdist pytest-rerunfailures feedparser python-hglib;
     if [[ "$COVERAGE" != '' ]]; then $TRAVIS_PIP install pytest-cov codecov; fi;
   - $TRAVIS_PYTHON setup.py build_ext -i
   - export PIP_FIND_LINKS=file://$HOME/download/pip-cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
     # Install the build and runtime dependencies of the project.
     - "conda update -q --yes conda"
     - "conda install -q --yes python=%PYTHON_VERSION% conda six pip pytest pytest-xdist lockfile"
+    - "python -mpip install pytest-rerunfailures"
 
     # Pre-download all necessary packages
     - "python .continuous-integration/download_reqs.py --conda --pip=pip-cache"

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -40,6 +40,7 @@ else:
     ON_PYPY = False
 
 
+@pytest.mark.flaky(reruns=1, reruns_delay=5)
 def test_find_benchmarks(tmpdir):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
@@ -114,7 +115,7 @@ def test_find_benchmarks(tmpdir):
         'time_examples.TimeSuite.time_example_benchmark_1']['result'] != [None]
     assert isinstance(times['time_examples.TimeSuite.time_example_benchmark_1']['stats'][0]['std'], float)
     # The exact number of samples may vary if the calibration is not fully accurate
-    assert len(times['time_examples.TimeSuite.time_example_benchmark_1']['samples'][0]) >= 5
+    assert len(times['time_examples.TimeSuite.time_example_benchmark_1']['samples'][0]) >= 4
     # Benchmarks that raise exceptions should have a time of "None"
     assert times[
         'time_secondary.TimeSecondary.time_exception']['result'] == [None]

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -7,10 +7,12 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import sys
 import time
+import pytest
 
 from asv import util
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_timeout():
     timeout_codes = []
     timeout_codes.append(r"""
@@ -83,6 +85,7 @@ sys.exit(1)
         assert False, "Expected exception"
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_output_timeout():
     # Check that timeout is determined based on last output, not based
     # on start time.


### PR DESCRIPTION
When running tests on a heavily loaded system (e.g. in parallel on the CI), timing-based tests can fail even if the timing requirements are quite loose. Try to avoid these failures by using pytest-rerunfailures.