### PR TITLE
Implement forkserver benchmark runner

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -19,6 +19,8 @@ internal commands:
       Run setup_cache for given benchmark.
   run BENCHMARK_DIR BENCHMARK_ID QUICK PROFILE_PATH RESULT_FILE
       Run a given benchmark, and store result in a file.
+  run_server BENCHMARK_DIR SOCKET_FILENAME
+      Run a Unix socket forkserver.
 """
 
 # !!!!!!!!!!!!!!!!!!!! NOTE !!!!!!!!!!!!!!!!!!!!
@@ -55,6 +57,9 @@ import re
 import textwrap
 import timeit
 import time
+import tempfile
+import struct
+
 
 # The best timer we can use is time.process_time, but it is not
 # available in the Python stdlib until Python 3.3.  This is a ctypes
@@ -227,6 +232,20 @@ except ImportError:  # For Python 2.6
             name = _resolve_name(name[level:], package, level)
         __import__(name)
         return sys.modules[name]
+
+
+def recvall(sock, size):
+    """
+    Receive data of given size from a socket connection
+    """
+    data = b""
+    while len(data) < size:
+        s = sock.recv(size - len(data))
+        data += s
+        if not s:
+            raise RuntimeError("did not receive data from socket "
+                               "(size {}, got only {!r})".format(size, data))
+    return data
 
 
 def _get_attr(source, name, ignore_case=False):
@@ -899,6 +918,123 @@ def main_run(args):
         json.dump(result, fp)
 
 
+def main_run_server(args):
+    import io
+    import signal
+    import socket
+
+    benchmark_dir, socket_name, = args
+
+    # Import benchmark suite before forking
+    update_sys_path(benchmark_dir)
+    for benchmark in disc_benchmarks(benchmark_dir):
+        pass
+
+    # Socket I/O
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(socket_name)
+    s.listen(1)
+
+    # Read and act on commands from socket
+    while True:
+        fd, stdout_file = tempfile.mkstemp()
+        os.close(fd)
+
+        conn, addr = s.accept()
+        try:
+            # Read command
+            read_size, = struct.unpack('<Q', recvall(conn, 8))
+            command_text = recvall(conn, read_size)
+            if sys.version_info[0] >= 3:
+                command_text = command_text.decode('utf-8')
+
+            # Parse command
+            command = json.loads(command_text)
+            if command.pop('action') == 'quit':
+                break
+
+            benchmark_id = command.pop('benchmark_id')
+            params_str = command.pop('params_str')
+            profile_path = command.pop('profile_path')
+            result_file = command.pop('result_file')
+            timeout = command.pop('timeout')
+            cwd = command.pop('cwd')
+            if command:
+                raise RuntimeError('Command contained unknown data: {!r}'.format(command_text))
+
+            # Spawn benchmark
+            run_args = (benchmark_dir, benchmark_id, params_str, profile_path, result_file)
+            pid = os.fork()
+            if pid == 0:
+                exitcode = 1
+                try:
+                    out_fd = os.open(stdout_file, os.O_WRONLY)
+                    try:
+                        os.chdir(cwd)
+                        stdout_fd = sys.stdout.fileno()
+                        stderr_fd = sys.stderr.fileno()
+
+                        # Redirect I/O
+                        sys.stdout.close()
+                        sys.stderr.close()
+                        sys.stdin.close()
+                        os.dup2(out_fd, stdout_fd)
+                        os.dup2(out_fd, stderr_fd)  # redirect stderr to stdout
+                        if sys.version_info[0] >= 3:
+                            sys.stdout = io.TextIOWrapper(os.fdopen(stdout_fd, 'wb'))
+                            sys.stderr = io.TextIOWrapper(os.fdopen(stderr_fd, 'wb'))
+                        else:
+                            sys.stdout = os.fdopen(stdout_fd, 'wb')
+                            sys.stderr = os.fdopen(stderr_fd, 'wb')
+
+                        main_run(run_args)
+                        exitcode = 0
+                    except BaseException as ec:
+                        import traceback
+                        traceback.print_exc()
+                    finally:
+                        sys.stdout.flush()
+                        sys.stderr.flush()
+                finally:
+                    os._exit(exitcode)
+
+            # Wait for results
+            # (Poll in a loop is simplest --- also used by subprocess.py)
+            start_time = time.time()
+            is_timeout = False
+            while True:
+                res, status = os.waitpid(pid, os.WNOHANG)
+                if res != 0:
+                    break
+
+                if timeout is not None and time.time() > start_time + timeout:
+                    # Timeout
+                    if is_timeout:
+                        os.kill(pid, signal.SIGKILL)
+                    else:
+                        os.kill(pid, signal.SIGTERM)
+                    is_timeout = True
+
+                time.sleep(0.05)
+
+            # Report result
+            with io.open(stdout_file, 'r', errors='replace') as f:
+                out = f.read()
+
+            info = {'out': out,
+                    'errcode': -256 if is_timeout else status}
+
+            result_text = json.dumps(info)
+            if sys.version_info[0] >= 3:
+                result_text = result_text.encode('utf-8')
+
+            conn.sendall(struct.pack('<Q', len(result_text)))
+            conn.sendall(result_text)
+        finally:
+            conn.close()
+            os.unlink(stdout_file)
+
+
 def main_timing(argv):
     import argparse
     import asv.statistics
@@ -958,6 +1094,7 @@ commands = {
     'discover': main_discover,
     'setup_cache': main_setup_cache,
     'run': main_run,
+    'run_server': main_run_server,
     'timing': main_timing,
     '-h': main_help,
     '--help': main_help,

--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -937,11 +937,17 @@ def main_run_server(args):
 
     # Read and act on commands from socket
     while True:
-        fd, stdout_file = tempfile.mkstemp()
-        os.close(fd)
+        stdout_file = None
 
-        conn, addr = s.accept()
         try:
+            conn, addr = s.accept()
+        except KeyboardInterrupt:
+            break
+
+        try:
+            fd, stdout_file = tempfile.mkstemp()
+            os.close(fd)
+
             # Read command
             read_size, = struct.unpack('<Q', recvall(conn, 8))
             command_text = recvall(conn, read_size)
@@ -1030,9 +1036,12 @@ def main_run_server(args):
 
             conn.sendall(struct.pack('<Q', len(result_text)))
             conn.sendall(result_text)
+        except KeyboardInterrupt:
+            break
         finally:
             conn.close()
-            os.unlink(stdout_file)
+            if stdout_file is not None:
+                os.unlink(stdout_file)
 
 
 def main_timing(argv):

--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -184,6 +184,16 @@ def add_environment(parser, default_same=False):
         help="Same as --environment=:PYTHON")
 
 
+def add_launch_method(parser):
+    parser.add_argument(
+        "--launch-method",
+        dest="launch_method",
+        action="store",
+        choices=("auto", "spawn", "forkserver"),
+        default="auto",
+        help="How to launch benchmarks. Choices: auto, spawn, forkserver")
+
+
 def add_parallel(parser):
     parser.add_argument(
         "--parallel", "-j", nargs='?', type=int, default=1, const=-1,

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -53,6 +53,7 @@ class Continuous(Command):
         common_args.add_bench(parser)
         common_args.add_machine(parser)
         common_args.add_environment(parser)
+        common_args.add_launch_method(parser)
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
@@ -67,7 +68,8 @@ class Continuous(Command):
             machine=args.machine,
             env_spec=args.env_spec, record_samples=args.record_samples,
             append_samples=args.append_samples,
-            quick=args.quick, interleave_processes=args.interleave_processes, **kwargs
+            quick=args.quick, interleave_processes=args.interleave_processes,
+            launch_method=args.launch_method, **kwargs
         )
 
     @classmethod
@@ -75,7 +77,7 @@ class Continuous(Command):
             factor=None, split=False, only_changed=True, sort='ratio',
             show_stderr=False, bench=None,
             attribute=None, machine=None, env_spec=None, record_samples=False, append_samples=False,
-            quick=False, interleave_processes=None, _machine_file=None):
+            quick=False, interleave_processes=None, launch_method=None, _machine_file=None):
         repo = get_repo(conf)
         repo.pull()
 
@@ -96,6 +98,7 @@ class Continuous(Command):
             show_stderr=show_stderr, machine=machine, env_spec=env_spec,
             record_samples=record_samples, append_samples=append_samples, quick=quick,
             interleave_processes=interleave_processes,
+            launch_method=launch_method,
             _returns=run_objs, _machine_file=_machine_file)
         if result:
             return result

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -54,6 +54,7 @@ class Find(Command):
         common_args.add_show_stderr(parser)
         common_args.add_machine(parser)
         common_args.add_environment(parser)
+        common_args.add_launch_method(parser)
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -64,12 +65,13 @@ class Find(Command):
         return cls.run(
             conf, args.range, args.bench,
             invert=args.invert, show_stderr=args.show_stderr,
-            machine=args.machine, env_spec=args.env_spec, **kwargs
+            machine=args.machine, env_spec=args.env_spec,
+            launch_method=args.launch_method, **kwargs
         )
 
     @classmethod
     def run(cls, conf, range_spec, bench, invert=False, show_stderr=False,
-            machine=None, env_spec=None, _machine_file=None):
+            machine=None, env_spec=None, _machine_file=None, launch_method=None):
         params = {}
         machine_params = Machine.load(
             machine_name=machine,
@@ -125,8 +127,9 @@ class Find(Command):
 
             env.install_project(conf, repo, commit_hash)
 
-            res = run_benchmarks(
-                benchmarks, env, show_stderr=show_stderr)
+            res = run_benchmarks(benchmarks, env,
+                                 show_stderr=show_stderr,
+                                 launch_method=launch_method)
 
             result = res.get_result_value(benchmark_name,
                                           benchmarks[benchmark_name]['params'])

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -72,6 +72,7 @@ class Profile(Command):
             help="""Forcibly re-run the profile, even if the data
             already exists in the results database.""")
         common_args.add_environment(parser)
+        common_args.add_launch_method(parser)
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -89,11 +90,12 @@ class Profile(Command):
         return cls.run(
             conf=conf, benchmark=args.benchmark, revision=args.revision,
             gui=args.gui, output=args.output, force=args.force,
-            env_spec=args.env_spec, **kwargs)
+            env_spec=args.env_spec, launch_method=args.launch_method,
+            **kwargs)
 
     @classmethod
     def run(cls, conf, benchmark, revision=None, gui=None, output=None,
-            force=False, env_spec=None,
+            force=False, env_spec=None, launch_method=None,
             _machine_file=None):
         cls.find_guis()
 
@@ -190,7 +192,8 @@ class Profile(Command):
                 env.install_project(conf, repo, commit_hash)
 
                 results = run_benchmarks(
-                    benchmarks, env, show_stderr=True, quick=False, profile=True)
+                    benchmarks, env, show_stderr=True, quick=False, profile=True,
+                    launch_method=launch_method)
 
                 profile_data = results.get_profile(benchmark_name)
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -87,6 +87,7 @@ class Run(Command):
             benchmark functions faster.  The results are unlikely to
             be useful, and thus are not saved.""")
         common_args.add_environment(parser)
+        common_args.add_launch_method(parser)
         parser.add_argument(
             "--dry-run", "-n", action="store_true",
             default=None,
@@ -137,6 +138,7 @@ class Run(Command):
             skip_existing_commits=args.skip_existing_commits,
             record_samples=args.record_samples, append_samples=args.append_samples,
             pull=not args.no_pull, interleave_processes=args.interleave_processes,
+            launch_method=args.launch_method,
             **kwargs
         )
 
@@ -145,7 +147,8 @@ class Run(Command):
             show_stderr=False, quick=False, profile=False, env_spec=None,
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
             skip_failed=False, skip_existing_commits=False, record_samples=False,
-            append_samples=False, pull=True, interleave_processes=False, _returns={}):
+            append_samples=False, pull=True, interleave_processes=False,
+            launch_method=None, _returns={}):
         machine_params = Machine.load(
             machine_name=machine,
             _path=_machine_file, interactive=True)
@@ -387,7 +390,8 @@ class Run(Command):
                                 profile=profile, extra_params=attribute,
                                 record_samples=(record_samples or force_record_samples),
                                 append_samples=(append_samples or force_append_samples),
-                                run_rounds=run_rounds)
+                                run_rounds=run_rounds,
+                                launch_method=launch_method)
                         else:
                             skip_benchmarks(benchmark_set, env, results=result)
 

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -360,7 +360,9 @@ def get_spawner(env, benchmark_dir, launch_method):
     has_fork = hasattr(os, 'fork') and hasattr(socket, 'AF_UNIX')
 
     if launch_method in (None, 'auto'):
-        if has_fork:
+        # Don't use ForkServer as default on OSX, because many Apple
+        # things are not fork-safe
+        if has_fork and sys.platform not in ('darwin',):
             launch_method = "forkserver"
         else:
             launch_method = "spawn"

--- a/asv/util.py
+++ b/asv/util.py
@@ -1112,3 +1112,17 @@ def namedtuple_with_doc(name, slots, doc):
         return cls
     else:
         return type(str(name), (cls,), {'__doc__': doc})
+
+
+def recvall(sock, size):
+    """
+    Receive data of given size from a socket connection
+    """
+    data = b""
+    while len(data) < size:
+        s = sock.recv(size - len(data))
+        data += s
+        if not s:
+            raise RuntimeError("did not receive data from socket "
+                               "(size {}, got only {!r})".format(size, data))
+    return data

--- a/asv/util.py
+++ b/asv/util.py
@@ -363,7 +363,7 @@ def check_call(args, valid_return_codes=(0,), timeout=600, dots=True,
 
 def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
                  display_error=True, shell=False, return_stderr=False,
-                 env=None, cwd=None, redirect_stderr=False):
+                 env=None, cwd=None, redirect_stderr=False, return_popen=False):
     """
     Runs the given command in a subprocess, raising ProcessError if it
     fails.  Returns stdout as a string on success.
@@ -407,6 +407,9 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
     redirect_stderr : bool, optional
         Whether to redirect stderr to stdout. In this case the returned
         ``stderr`` (when return_stderr == True) is an empty string.
+
+    return_popen : bool, optional
+        Whether to return immediately after subprocess.Popen.
 
     Returns
     -------
@@ -466,6 +469,9 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
             kwargs['preexec_fn'] = lambda: os.setpgid(0, 0)
 
     proc = subprocess.Popen(args, **kwargs)
+
+    if return_popen:
+        return proc
 
     last_dot_time = time.time()
     stdout_chunks = []

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -147,6 +147,14 @@ def test_stderr_redirect():
     assert retcode == 0
 
 
+def test_popen():
+    # Check that timeout=None is allowed.
+    popen = util.check_output([sys.executable, "-c", "pass"], return_popen=True)
+    popen.wait()
+
+    assert popen.returncode == 0
+
+
 # This *does* seem to work, only seems untestable somehow...
 # def test_dots(capsys):
 #     code = r"""


### PR DESCRIPTION
The forkserver is a benchmark.py run mode, which listens on an unix
socket for benchmarks to run, an fork()s a new process for each one.
It runs benchmark discovery on startup, so that it avoids spending time
on importing the libraries used on each benchmark run, potentially
saving a lot of time in total.

- [x] fix Ctrl-C handling
