### PR TITLE
Ignore missing branches in Benchmarks.discover 

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -19,6 +19,7 @@ import six
 from .console import log, truncate_left
 from . import util
 from . import statistics
+from .repo import NoSuchNameError
 
 
 WIN = (os.name == "nt")
@@ -410,7 +411,11 @@ class Benchmarks(dict):
         # discovery usually succeeds
         commit_hashes = list(commit_hashes)
         for branch in conf.branches:
-            branch_hash = repo.get_hash_from_name(branch)
+            try:
+                branch_hash = repo.get_hash_from_name(branch)
+            except NoSuchNameError:
+                continue
+
             if branch_hash not in commit_hashes:
                 commit_hashes.append(branch_hash)
 

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -12,7 +12,7 @@ import os
 import re
 
 from ..console import log
-from ..repo import Repo
+from ..repo import Repo, NoSuchNameError
 from .. import util
 
 
@@ -127,8 +127,15 @@ class Git(Repo):
     def get_hash_from_name(self, name):
         if name is None:
             name = self.get_branch_name()
-        return self._run_git(['rev-parse', name],
-                             dots=False).strip().split()[0]
+
+        try:
+            return self._run_git(['rev-parse', name],
+                                 dots=False).strip().split()[0]
+        except util.ProcessError as err:
+            if err.stdout.strip() == name:
+                # Name does not exist
+                raise NoSuchNameError(name)
+            raise
 
     def get_hash_from_parent(self, name):
         return self.get_hash_from_name(name + '^')

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -8,6 +8,13 @@ from __future__ import (absolute_import, division, print_function,
 from . import util
 
 
+class NoSuchNameError(RuntimeError):
+    """
+    Exception raised if requested branch or commit does not exist.
+    """
+    pass
+
+
 class Repo(object):
     """
     Base class for repository handlers.

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -52,6 +52,7 @@ def test_find_benchmarks(tmpdir):
     d['env_dir'] = "env"
     d['benchmark_dir'] = 'benchmark'
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
+    d['branches'] = ["master", "some-missing-branch"]  # missing branches ignored
     conf = config.Config.from_json(d)
 
     repo = get_repo(conf)


### PR DESCRIPTION
Benchmark discovery uses configured branches only as a fallback.
Failures looking up branch names can be ignored. They can be missing
e.g. in partial git repository clones.

Fixes #631