### PR TITLE
Avoid making long result file names by replacing env name by hash if long

### DIFF
--- a/asv/commands/update.py
+++ b/asv/commands/update.py
@@ -5,11 +5,12 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import os
+import re
 
 from . import Command
 from ..config import Config
 from ..machine import Machine, MachineCollection
-from ..results import Results
+from ..results import Results, get_filename
 from ..benchmarks import Benchmarks
 from ..console import log
 from .. import util
@@ -51,6 +52,20 @@ class Update(Command):
                     pass
                 elif filename.endswith('.json'):
                     Results.update(path)
+
+                    # Rename files if necessary
+                    m = re.match(r'^([0-9a-f]+)-(.*)\.json$', os.path.basename(path), re.I)
+                    if m:
+                        new_path = get_filename(root, m.group(1), m.group(2))
+                        if new_path != path:
+                            try:
+                                if os.path.exists(new_path):
+                                    raise OSError()
+                                os.rename(path, new_path)
+                            except OSError:
+                                log.warn("{}: should be renamed to {}".format(path, new_path))
+                    else:
+                        log.warn("{}: unrecognized file name".format(path))
 
         # Check benchmarks.json
         log.info("Updating benchmarks.json...")

--- a/asv/commands/update.py
+++ b/asv/commands/update.py
@@ -31,12 +31,12 @@ class Update(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, args):
-        return cls.run(args.config)
+    def run_from_args(cls, args, _machine_file=None):
+        return cls.run(args.config, _machine_file=_machine_file)
 
     @classmethod
-    def run(cls, config_path):
-        MachineCollection.update()
+    def run(cls, config_path, _machine_file=None):
+        MachineCollection.update(_path=_machine_file)
         Config.update(config_path)
 
         conf = Config.load(config_path)

--- a/asv/machine.py
+++ b/asv/machine.py
@@ -76,8 +76,11 @@ class MachineCollection(object):
         util.write_json(path, d, cls.api_version)
 
     @classmethod
-    def update(cls):
-        path = cls.get_machine_file_path()
+    def update(cls, _path=None):
+        if _path is None:
+            path = cls.get_machine_file_path()
+        else:
+            path = _path
         if os.path.isfile(path):
             util.update_json(cls, path, cls.api_version)
 

--- a/asv/results.py
+++ b/asv/results.py
@@ -9,6 +9,7 @@ import base64
 import os
 import zlib
 import itertools
+import hashlib
 
 import six
 from six.moves import zip as izip
@@ -146,7 +147,12 @@ def get_filename(machine, commit_hash, env_name):
     """
     Get the result filename for a given machine, commit_hash and
     environment.
+
+    If the environment name is too long, use its hash instead.
     """
+    if env_name and len(env_name) >= 128:
+        env_name = "env-" + hashlib.md5(env_name.encode('utf-8')).hexdigest()
+
     return os.path.join(
         machine,
         "{0}-{1}.json".format(

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -188,3 +188,11 @@ def test_iter_results(capsys, tmpdir):
     assert len(res) == 0
     out, err = capsys.readouterr()
     assert "machine.json" in out
+
+
+def test_filename_format():
+    r = results.Results({'machine': 'foo'}, [], "commit", 0, "", "env")
+    assert r._filename == join("foo", "commit-env.json")
+
+    r = results.Results({'machine': 'foo'}, [], "hash", 0, "", "a"*128)
+    assert r._filename == join("foo", "hash-env-e510683b3f5ffe4093d021808bc6ff70.json")

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import os
+import shutil
+import hashlib
+
+from asv import util
+
+from . import tools
+from .test_publish import generate_result_dir
+
+
+def test_update_simple(monkeypatch, generate_result_dir):
+    conf, repo, commits = generate_result_dir(5 * [1] + 5 * [10])
+
+    basedir = os.path.abspath(os.path.dirname(conf.results_dir))
+    local = os.path.abspath(os.path.dirname(__file__))
+
+    shutil.copyfile(os.path.join(local, 'asv-machine.json'),
+                    os.path.join(basedir, 'asv-machine.json'))
+    machine_file = 'asv-machine.json'
+
+    conf_values = {}
+    for key in ['results_dir', 'html_dir', 'repo', 'project', 'branches']:
+        conf_values[key] = getattr(conf, key)
+
+    util.write_json(os.path.join(basedir, 'asv.conf.json'), conf_values,
+                    api_version=1)
+
+    # Check renaming of long result files
+    machine_dir = os.path.join(basedir, 'results', 'tarzan')
+
+    result_fn = [fn for fn in os.listdir(machine_dir)
+                 if fn != 'machine.json'][0]
+    long_result_fn = 'abbacaca-' + 'a'*128 + '.json'
+    hash_result_fn = ('abbacaca-env-'
+                      + hashlib.md5(b'a'*128).hexdigest()
+                      + '.json')
+
+    shutil.copyfile(os.path.join(machine_dir, result_fn),
+                    os.path.join(machine_dir, long_result_fn))
+
+    # Should succeed
+    monkeypatch.chdir(basedir)
+    tools.run_asv("update", _machine_file=machine_file)
+
+    # Check file rename
+    items = [fn.lower() for fn in os.listdir(machine_dir)]
+    assert long_result_fn not in items
+    assert hash_result_fn in items

--- a/test/tools.py
+++ b/test/tools.py
@@ -59,10 +59,10 @@ except ImportError:
 WAIT_TIME = 20.0
 
 
-def run_asv(*argv):
+def run_asv(*argv, **kwargs):
     parser, subparsers = commands.make_argparser()
     args = parser.parse_args(argv)
-    return args.func(args)
+    return args.func(args, **kwargs)
 
 
 def run_asv_with_conf(conf, *argv, **kwargs):


### PR DESCRIPTION
The result file name lengths should be limited to some reasonable size,
as there can in principle be arbitrary many dependencies.  Replace the
environment name by its hash if it's longer than 128 characters.

The rest of asv code does not assume result files are named in a particular
way, just that the mapping is deterministic and unique (which even MD5 hashes
satisfy for non-attack inputs). 

Fixes gh-621