### PR TITLE
Add cleanup= option to util.update_json and use it in Results.update

### DIFF
--- a/asv/results.py
+++ b/asv/results.py
@@ -598,7 +598,7 @@ class Results(object):
 
     @classmethod
     def update(cls, path):
-        util.update_json(cls, path, cls.api_version)
+        util.update_json(cls, path, cls.api_version, cleanup=False)
 
     @property
     def env_name(self):

--- a/asv/util.py
+++ b/asv/util.py
@@ -705,7 +705,7 @@ def load_json(path, api_version=None, cleanup=True):
     return d
 
 
-def update_json(cls, path, api_version):
+def update_json(cls, path, api_version, cleanup=True):
     """
     Perform JSON file format updates.
 
@@ -724,7 +724,7 @@ def update_json(cls, path, api_version):
     # Hide traceback from expected exceptions in pytest reports
     __tracebackhide__ = operator.methodcaller('errisinstance', UserError)
 
-    d = load_json(path)
+    d = load_json(path, cleanup=cleanup)
     if 'version' not in d:
         raise UserError(
             "No version specified in {0}.".format(path))


### PR DESCRIPTION
Results.load in any case works with cleanup=False, so the files are
always loadable with that.

The value cleanup=True has quite large runtime cost, which can be too
bad for "asv update".