### PR TITLE
Make "python -masv.benchmark" usable from command line

### DIFF
--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -390,3 +390,10 @@ def test_code_extraction(tmpdir):
     if sys.version_info[:2] != (3, 2):
         # Python 3.2 doesn't have __qualname__
         assert bench['code'] == expected_code
+
+
+def test_asv_benchmark_timings():
+    # Check the benchmark runner runs
+    util.check_call([sys.executable, '-masv.benchmark', 'timing',
+                     '--setup=import time',
+                     'time.sleep(0)'])


### PR DESCRIPTION
Add a slightly user-friendly 'timing' command, in addition to the
internal commands.

This is likely mainly useful for debugging purposes.