### PR TITLE
Treat different machine/env combinations separately in comparison tables 

### DIFF
--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -34,13 +34,28 @@ def add_global_arguments(parser, suppress_defaults=True):
         **suppressor)
 
 
-def add_factor(parser):
+def add_compare(parser, only_changed_default=False, sort_default='name'):
     parser.add_argument(
         '--factor', "-f", type=float, default=1.1,
         help="""The factor above or below which a result is considered
         problematic.  For example, with a factor of 1.1 (the default
         value), if a benchmark gets 10%% slower or faster, it will
         be displayed in the results list.""")
+
+    parser.add_argument(
+        '--split', '-s', action='store_true',
+        help="""Split the output into a table of benchmarks that have
+        improved, stayed the same, and gotten worse.""")
+
+    parser.add_argument(
+        '--only-changed', action='store_true', default=only_changed_default,
+        help="""Whether to show only changed results.""")
+
+    parser.add_argument('--no-only-changed', dest='only_changed', action='store_false')
+
+    parser.add_argument(
+        '--sort', action='store', type=str, choices=('name', 'ratio'),
+        default=sort_default, help="""Sort order""")
 
 
 def add_show_stderr(parser):

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -43,7 +43,7 @@ class Continuous(Command):
             run only once.  This is useful to find basic errors in the
             benchmark functions faster.  The results are unlikely to
             be useful, and thus are not saved.""")
-        common_args.add_factor(parser)
+        common_args.add_compare(parser, sort_default='ratio', only_changed_default=True)
         common_args.add_show_stderr(parser)
         common_args.add_bench(parser)
         common_args.add_machine(parser)
@@ -55,7 +55,9 @@ class Continuous(Command):
     @classmethod
     def run_from_conf_args(cls, conf, args, **kwargs):
         return cls.run(
-            conf=conf, branch=args.branch, base=args.base, factor=args.factor,
+            conf=conf, branch=args.branch, base=args.base,
+            factor=args.factor, split=args.split,
+            only_changed=args.only_changed, sort=args.sort,
             show_stderr=args.show_stderr, bench=args.bench, attribute=args.attribute,
             machine=args.machine,
             env_spec=args.env_spec, record_samples=args.record_samples,
@@ -63,7 +65,9 @@ class Continuous(Command):
         )
 
     @classmethod
-    def run(cls, conf, branch=None, base=None, factor=None, show_stderr=False, bench=None,
+    def run(cls, conf, branch=None, base=None,
+            factor=None, split=False, only_changed=True, sort='ratio',
+            show_stderr=False, bench=None,
             attribute=None, machine=None, env_spec=None, record_samples=False, quick=False,
             _machine_file=None):
         repo = get_repo(conf)
@@ -112,8 +116,8 @@ class Continuous(Command):
         status = Compare.print_table(conf, parent, head,
                                      resultset_1=results_iter(parent),
                                      resultset_2=results_iter(head),
-                                     factor=factor, split=False, only_changed=True,
-                                     sort_by_ratio=True)
+                                     factor=factor, split=split,
+                                     only_changed=only_changed, sort=sort)
         worsened, improved = status
 
         color_print("")

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -107,7 +107,7 @@ class Continuous(Command):
 
                     value = result.get_result_value(name, params)
                     stats = result.get_result_stats(name, params)
-                    yield name, params, value, stats, version
+                    yield name, params, value, stats, version, machine_name, env.name
 
         status = Compare.print_table(conf, parent, head,
                                      resultset_1=results_iter(parent),

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -186,7 +186,7 @@ def get_env_name(tool_name, python, requirements):
     return util.sanitize_filename('-'.join(name))
 
 
-def get_environments(conf, env_specifiers):
+def get_environments(conf, env_specifiers, verbose=True):
     """
     Iterator returning `Environment` objects for all of the
     permutations of the given versions of Python and a matrix of
@@ -202,18 +202,20 @@ def get_environments(conf, env_specifiers):
         it. If *python_spec* is missing, use those listed in the
         configuration file. Alternatively, can be the name given
         by *Environment.name* if the environment is in the matrix.
+    verbose : bool, optional
+        Whether to display warnings about unknown environment types etc.
 
     """
 
     if not env_specifiers:
         all_environments = ()
         env_specifiers = [conf.environment_type]
-        if not conf.environment_type:
+        if not conf.environment_type and verbose:
             log.warn(
                 "No `environment_type` specified in asv.conf.json. "
                 "This will be required in the future.")
     else:
-        all_environments = list(get_environments(conf, None))
+        all_environments = list(get_environments(conf, None, verbose=verbose))
 
     for env_spec in env_specifiers:
         env_name_found = False
@@ -257,7 +259,8 @@ def get_environments(conf, env_specifiers):
 
                 yield cls(conf, python, requirements)
             except EnvironmentUnavailable as err:
-                log.warn(str(err))
+                if verbose:
+                    log.warn(str(err))
 
 
 def get_environment_class(conf, python):

--- a/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8-foo.json
+++ b/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8-foo.json
@@ -1,0 +1,22 @@
+{
+    "commit_hash": "fcf8c079fae7ebad9f27bd31a819f0e4fdd85b99", 
+    "date": 1367127519000, 
+    "params": {
+        "arch": "x86_64", 
+        "cpu": "Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)", 
+        "machine": "cheetah", 
+        "numpy": "1.8", 
+        "os": "Linux (Fedora 20)", 
+        "python": "2.7", 
+        "ram": "8.2G"
+    }, 
+    "python": "2.7", 
+    "requirements": {
+        "numpy": "1.8",
+        "foo": ""
+    }, 
+    "results": {
+        "time_quantity.time_quantity_array_conversion": 1234
+    },
+    "version": 1
+}

--- a/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
@@ -2,7 +2,6 @@
     "commit_hash": "fcf8c079fae7ebad9f27bd31a819f0e4fdd85b99", 
     "date": 1367127519000, 
     "params": {
-        "Cython": null, 
         "arch": "x86_64", 
         "cpu": "Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)", 
         "machine": "cheetah", 
@@ -13,7 +12,6 @@
     }, 
     "python": "2.7", 
     "requirements": {
-        "Cython": null, 
         "numpy": "1.8"
     }, 
     "results": {

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -153,7 +153,7 @@ def test_compare(capsys, tmpdir):
 
     # Check print_table output as called from Continuous
     status = Compare.print_table(conf, '22b920c6', 'fcf8c079', factor=2, machine='cheetah',
-                                 split=False, only_changed=True, sort_by_ratio=True,
+                                 split=False, only_changed=True, sort='ratio',
                                  env_names=["py2.7-numpy1.8"])
     worsened, improved = status
     assert worsened
@@ -163,6 +163,6 @@ def test_compare(capsys, tmpdir):
 
     # Check table with multiple environments
     status = Compare.print_table(conf, '22b920c6', 'fcf8c079', factor=2, machine='cheetah',
-                                 split=False, only_changed=True, sort_by_ratio=True)
+                                 split=False, only_changed=True, sort='ratio')
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE_ONLY_CHANGED_MULTIENV.strip()

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -112,6 +112,24 @@ REFERENCE_ONLY_CHANGED = """
 -          69.1μs           18.3μs     0.27  time_units.time_unit_to
 """
 
+REFERENCE_ONLY_CHANGED_MULTIENV = """
+       before           after         ratio
+     [22b920c6]       [fcf8c079]
+!             n/a           failed      n/a  params_examples.ParamSuite.track_value [cheetah/py2.7-numpy1.8]
+!           454μs           failed      n/a  time_coordinates.time_latitude [cheetah/py2.7-numpy1.8]
+!           3.00s           failed      n/a  time_other.time_parameterized(3) [cheetah/py2.7-numpy1.8]
++           934μs            108ms   115.90  time_quantity.time_quantity_init_array [cheetah/py2.7-numpy1.8]
++          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion [cheetah/py2.7-numpy1.8]
++           372μs           11.5ms    30.81  time_units.time_unit_parse [cheetah/py2.7-numpy1.8]
++           125μs           3.81ms    30.42  time_units.time_simple_unit_parse [cheetah/py2.7-numpy1.8]
++          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin [cheetah/py2.7-numpy1.8]
++         1.00±0s          3.00±0s     3.00  time_ci_small [cheetah/py2.7-numpy1.8]
++           1.00s            3.00s     3.00  time_with_version_match [cheetah/py2.7-numpy1.8]
++           1.00s            3.00s     3.00  time_with_version_mismatch_bench [cheetah/py2.7-numpy1.8]
+-          69.1μs           18.3μs     0.27  time_units.time_unit_to [cheetah/py2.7-numpy1.8]
+"""
+
+
 def test_compare(capsys, tmpdir):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
@@ -123,22 +141,28 @@ def test_compare(capsys, tmpdir):
          'environment_type': "shouldn't matter what"})
 
     tools.run_asv_with_conf(conf, 'compare', '22b920c6', 'fcf8c079', '--machine=cheetah',
-                            '--factor=2')
+                            '--factor=2', '--environment=py2.7-numpy1.8')
 
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE.strip()
 
     tools.run_asv_with_conf(conf, 'compare', '22b920c6', 'fcf8c079', '--machine=cheetah',
-                            '--factor=2', '--split')
-
+                            '--factor=2', '--split', '--environment=py2.7-numpy1.8')
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE_SPLIT.strip()
 
     # Check print_table output as called from Continuous
     status = Compare.print_table(conf, '22b920c6', 'fcf8c079', factor=2, machine='cheetah',
-                                 split=False, only_changed=True, sort_by_ratio=True)
+                                 split=False, only_changed=True, sort_by_ratio=True,
+                                 env_names=["py2.7-numpy1.8"])
     worsened, improved = status
     assert worsened
     assert improved
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE_ONLY_CHANGED.strip()
+
+    # Check table with multiple environments
+    status = Compare.print_table(conf, '22b920c6', 'fcf8c079', factor=2, machine='cheetah',
+                                 split=False, only_changed=True, sort_by_ratio=True)
+    text, err = capsys.readouterr()
+    assert text.strip() == REFERENCE_ONLY_CHANGED_MULTIENV.strip()


### PR DESCRIPTION
Make "asv continuous" and "asv compare" commands consider results from
different machines and environments as uncomparable separate benchmarks
by default.

Add environment selector option to "asv compare". Similarly to --machine, allow selecting the environments to compare.

Unify compare/continuous comparison table printing options. Make command line options controlling result formatting for Compare and Continuous the same (but with different default values).