### PR TITLE
Flush trailing newlines from console.Log properly

### DIFF
--- a/asv/commands/compare.py
+++ b/asv/commands/compare.py
@@ -10,7 +10,7 @@ from . import Command
 from ..machine import iter_machine_files
 from ..results import iter_results_for_machine_and_hash
 from ..util import human_value, load_json
-from ..console import color_print
+from ..console import log, color_print
 from ..environment import get_environments
 from .. import util
 from .. import statistics
@@ -328,6 +328,8 @@ class Compare(Command):
         titles['red'] = "Benchmarks that have got worse:"
         titles['lightgrey'] = "Benchmarks that are not comparable:"
         titles['all'] = "All benchmarks:"
+
+        log.flush()
 
         for key in keys:
 

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -93,6 +93,8 @@ class Continuous(Command):
         if result:
             return result
 
+        log.flush()
+
         def results_iter(commit_hash):
             for env in run_objs['environments']:
                 machine_name = run_objs['machine_params']['machine']

--- a/asv/console.py
+++ b/asv/console.py
@@ -374,4 +374,14 @@ class Log(object):
         _write_with_fallback(msg, sys.stdout.write, sys.stdout)
         sys.stdout.flush()
 
+    def flush(self):
+        """
+        Flush any trailing newlines. Needs to be called before printing
+        to stdout via other means, after using Log.
+        """
+        if self._needs_newline:
+            color_print('')
+            self._needs_newline = False
+        sys.stdout.flush()
+
 log = Log()

--- a/asv/machine.py
+++ b/asv/machine.py
@@ -12,7 +12,7 @@ import sys
 import textwrap
 
 from . import console
-from .console import color_print
+from .console import log, color_print
 from . import util
 
 
@@ -155,6 +155,8 @@ class Machine(object):
             raise util.UserError(
                 "Run asv at the console the first time to generate "
                 "one, or run `asv machine --yes`.")
+
+        log.flush()
 
         color_print(
             "I will now ask you some questions about this machine to "

--- a/asv/main.py
+++ b/asv/main.py
@@ -38,10 +38,9 @@ def main():
         result = args.func(args)
     except util.UserError as e:
         log.error(six.text_type(e))
-        sys.stdout.write('\n')
         sys.exit(1)
-
-    sys.stdout.write('\n')
+    finally:
+        log.flush()
 
     if result is None:
         result = 0


### PR DESCRIPTION
Log.flush() needs to be called before printing to stdout via other
means, and before exiting.