### PR TITLE
Allow appending samples to previous benchmark results

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -283,7 +283,7 @@ class Benchmarks(dict):
                                  "regenerate benchmarks.json".format(str(err)))
 
     def run_benchmarks(self, env, show_stderr=False, quick=False, profile=False,
-                       extra_params=None):
+                       extra_params=None, prev_samples=None):
         """
         Run all of the benchmarks in the given `Environment`.
 
@@ -307,6 +307,10 @@ class Benchmarks(dict):
 
         extra_params : dict, optional
             Override values for benchmark attributes.
+
+        prev_samples : dict, optional
+            Previous benchmark result sets.
+            ``prev_samples[benchmark_name] = [(samples, number), ...]``
 
         Returns
         -------
@@ -335,7 +339,8 @@ class Benchmarks(dict):
                                       show_stderr=show_stderr,
                                       quick=quick,
                                       extra_params=extra_params,
-                                      profile=profile).run(env)
+                                      profile=profile,
+                                      prev_samples=prev_samples).run(env)
 
     def skip_benchmarks(self, env):
         """

--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -192,6 +192,17 @@ def add_parallel(parser):
         number of cores on this machine.""")
 
 
+def add_record_samples(parser):
+    parser.add_argument(
+        "--record-samples", action="store_true",
+        help="""Store raw measurement samples, not only statistics""")
+    parser.add_argument(
+        "--append-samples", action="store_true",
+        help="""Combine new measurement samples with previous results,
+        instead of discarding old results. Implies --record-samples.
+        The previous run must also have been run with --record/append-samples.""")
+
+
 def positive_int(string):
     try:
         value = int(string)

--- a/asv/commands/compare.py
+++ b/asv/commands/compare.py
@@ -69,8 +69,13 @@ def _is_result_better(a, b, a_stats, b_stats, factor, use_stats=True):
 
     """
 
-    if use_stats and a_stats and b_stats:
-        # Return False if estimates don't differ
+    if use_stats and a_stats and b_stats and (
+            a_stats.get('repeat', 0) != 1 and b_stats.get('repeat', 0) != 1):
+        # Return False if estimates don't differ.
+        #
+        # Special-case the situation with only one sample, in which
+        # case we do the comparison only based on `factor` as there's
+        # not enough data to do statistics.
         if not statistics.is_different(a_stats, b_stats):
             return False
 

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -34,9 +34,7 @@ class Continuous(Command):
         parser.add_argument(
             'branch', default=None,
             help="""The commit/branch to test. By default, the first configured branch.""")
-        parser.add_argument(
-            "--record-samples", action="store_true",
-            help="""Store raw measurement samples, not only statistics""")
+        common_args.add_record_samples(parser)
         parser.add_argument(
             "--quick", "-q", action="store_true",
             help="""Do a "quick" run, where each benchmark function is
@@ -61,6 +59,7 @@ class Continuous(Command):
             show_stderr=args.show_stderr, bench=args.bench, attribute=args.attribute,
             machine=args.machine,
             env_spec=args.env_spec, record_samples=args.record_samples,
+            append_samples=args.append_samples,
             quick=args.quick, **kwargs
         )
 
@@ -68,8 +67,8 @@ class Continuous(Command):
     def run(cls, conf, branch=None, base=None,
             factor=None, split=False, only_changed=True, sort='ratio',
             show_stderr=False, bench=None,
-            attribute=None, machine=None, env_spec=None, record_samples=False, quick=False,
-            _machine_file=None):
+            attribute=None, machine=None, env_spec=None, record_samples=False, append_samples=False,
+            quick=False, _machine_file=None):
         repo = get_repo(conf)
         repo.pull()
 
@@ -88,7 +87,7 @@ class Continuous(Command):
         result = Run.run(
             conf, range_spec=commit_hashes, bench=bench, attribute=attribute,
             show_stderr=show_stderr, machine=machine, env_spec=env_spec,
-            record_samples=record_samples, quick=quick,
+            record_samples=record_samples, append_samples=append_samples, quick=quick,
             _returns=run_objs, _machine_file=_machine_file)
         if result:
             return result

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -476,10 +476,11 @@ class LaunchBenchmarkJob(object):
                 result.append(r)
                 stats.append(s)
             else:
+                cur_samples = res.samples
                 result.append(res.result)
                 stats.append(None)
 
-            samples.append(res.samples)
+            samples.append(cur_samples)
             profiles.append(res.profile)
 
             if res.stderr:

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -113,7 +113,7 @@ class BenchmarkRunner(object):
     """
 
     def __init__(self, benchmarks, show_stderr=False, quick=False,
-                 profile=False, extra_params=None):
+                 profile=False, extra_params=None, prev_samples=None):
         """
         Initialize BenchmarkRunner.
 
@@ -129,12 +129,16 @@ class BenchmarkRunner(object):
             Whether to run with profiling data collection
         extra_params : dict, optional
             Attribute overrides for benchmarks.
+        prev_samples : dict, optional
+            Previous benchmark result sets.
+            ``prev_samples[benchmark_name] = [(samples, number), ...]``
 
         """
         self.benchmarks = benchmarks
         self.show_stderr = show_stderr
         self.quick = quick
         self.profile = profile
+        self.prev_samples = prev_samples if prev_samples is not None else {}
         if extra_params is None:
             self.extra_params = {}
         else:
@@ -212,7 +216,8 @@ class BenchmarkRunner(object):
                                      self.profile, self.extra_params,
                                      cache_job=setup_cache_job, prev_job=prev_job,
                                      partial=not is_final,
-                                     selected_idx=self.benchmarks.benchmark_selection.get(name))
+                                     selected_idx=self.benchmarks.benchmark_selection.get(name),
+                                     prev_samples=self.prev_samples.get(name))
             if self._get_processes(benchmark) > 1:
                 prev_runs[name] = job
             yield job
@@ -344,7 +349,8 @@ class LaunchBenchmarkJob(object):
     """
 
     def __init__(self, name, benchmark, benchmark_dir, profile=False, extra_params=None,
-                 cache_job=None, prev_job=None, partial=False, selected_idx=None):
+                 cache_job=None, prev_job=None, partial=False, selected_idx=None,
+                 prev_samples=None):
         """
         Parameters
         ----------
@@ -375,6 +381,9 @@ class LaunchBenchmarkJob(object):
         selected_idx : list of int, optional
             Which items to run in a parametrized bencmark.
 
+        prev_samples : list of (samples, number), optional
+            Previous samples to insert
+
         """
         self.name = name
         self.benchmark = benchmark
@@ -385,6 +394,7 @@ class LaunchBenchmarkJob(object):
         self.prev_job = prev_job
         self.partial = partial
         self.selected_idx = selected_idx
+        self.prev_samples = prev_samples
 
         self.result = None
 
@@ -442,6 +452,12 @@ class LaunchBenchmarkJob(object):
                 if prev_stats is not None:
                     cur_extra_params['number'] = prev_stats['number']
                 prev_samples = self.prev_job.result.samples[param_idx]
+            elif self.prev_samples:
+                # Append to explicitly provided previous results, if any
+                samp, num = self.prev_samples[param_idx]
+                if samp is not None and num is not None:
+                    prev_samples = samp
+                    cur_extra_params['number'] = num
             else:
                 prev_samples = None
 

--- a/asv/statistics.py
+++ b/asv/statistics.py
@@ -33,8 +33,6 @@ def compute_stats(samples, number):
 
     if len(samples) < 1:
         return None, None
-    elif len(samples) == 1:
-        return samples[0], None
 
     Y = list(samples)
 

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -31,7 +31,9 @@ def test_compute_stats():
     np.random.seed(1)
 
     assert statistics.compute_stats([], 1) == (None, None)
-    assert statistics.compute_stats([15.0], 1) == (15.0, None)
+    assert statistics.compute_stats([15.0], 1) == (
+        15.0, {'ci_99': [-inf, inf], 'max': 15.0, 'mean': 15.0, 'min': 15.0,
+               'number': 1, 'q_25': 15.0, 'q_75': 15.0, 'repeat': 1, 'std': 0.0})
 
     for nsamples, true_mean in product([10, 50, 250], [0, 0.3, 0.6]):
         samples = np.random.randn(nsamples) + true_mean

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -376,3 +376,32 @@ def test_benchmark_param_selection(basic_conf):
     tools.run_asv_with_conf(conf, 'run', '--show-stderr',
                             '--bench', 'track_param_selection',
                             _machine_file=machine_file)
+
+
+def test_run_append_samples(basic_conf):
+    tmpdir, local, conf, machine_file = basic_conf
+
+    # Only one environment
+    conf.matrix['colorama'] = conf.matrix['colorama'][:1]
+
+    # Tests multiple calls to "asv run --append-samples"
+    def run_it():
+        tools.run_asv_with_conf(conf, 'run', "master^!",
+                                '--bench', 'time_examples.TimeSuite.time_example_benchmark_1',
+                                '--append-samples', '-a', 'repeat=1', '-a', 'processes=1',
+                                '-a', 'number=1', '-a', 'warmup_time=0',
+                                _machine_file=machine_file)
+
+    run_it()
+
+    result_dir = join(tmpdir, 'results_workflow', 'orangutan')
+    result_fn, = [join(result_dir, fn) for fn in os.listdir(result_dir)
+                  if fn != 'machine.json']
+
+    data = util.load_json(result_fn)
+    assert data['results']['time_examples.TimeSuite.time_example_benchmark_1']['stats'][0] is not None
+    assert len(data['results']['time_examples.TimeSuite.time_example_benchmark_1']['samples'][0]) == 1
+
+    run_it()
+    data = util.load_json(result_fn)
+    assert len(data['results']['time_examples.TimeSuite.time_example_benchmark_1']['samples'][0]) == 2


### PR DESCRIPTION
Add options `--append-samples` for appending new samples to previous measurement results from `asv run/continuous`.