### PR TITLE
Implement --interleave-processes for spreading processes across commits

### DIFF
--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -41,6 +41,13 @@ class Continuous(Command):
             run only once.  This is useful to find basic errors in the
             benchmark functions faster.  The results are unlikely to
             be useful, and thus are not saved.""")
+        parser.add_argument(
+            "--interleave-processes", action="store_true", default=None,
+            help="""Interleave benchmarks with multiple processes across
+            commits. This can avoid measurement biases from commit ordering,
+            can take longer.""")
+        parser.add_argument(
+            "--no-interleave-processes", action="store_false", dest="interleave_processes")
         common_args.add_compare(parser, sort_default='ratio', only_changed_default=True)
         common_args.add_show_stderr(parser)
         common_args.add_bench(parser)
@@ -60,7 +67,7 @@ class Continuous(Command):
             machine=args.machine,
             env_spec=args.env_spec, record_samples=args.record_samples,
             append_samples=args.append_samples,
-            quick=args.quick, **kwargs
+            quick=args.quick, interleave_processes=args.interleave_processes, **kwargs
         )
 
     @classmethod
@@ -68,7 +75,7 @@ class Continuous(Command):
             factor=None, split=False, only_changed=True, sort='ratio',
             show_stderr=False, bench=None,
             attribute=None, machine=None, env_spec=None, record_samples=False, append_samples=False,
-            quick=False, _machine_file=None):
+            quick=False, interleave_processes=None, _machine_file=None):
         repo = get_repo(conf)
         repo.pull()
 
@@ -88,6 +95,7 @@ class Continuous(Command):
             conf, range_spec=commit_hashes, bench=bench, attribute=attribute,
             show_stderr=show_stderr, machine=machine, env_spec=env_spec,
             record_samples=record_samples, append_samples=append_samples, quick=quick,
+            interleave_processes=interleave_processes,
             _returns=run_objs, _machine_file=_machine_file)
         if result:
             return result

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -277,7 +277,16 @@ class Run(Command):
         else:
             run_round_set = [None]
 
-        for run_rounds, commit_hash in itertools.product(run_round_set, commit_hashes):
+        def iter_rounds_commits():
+            for run_rounds in run_round_set:
+                if interleave_processes and run_rounds[0] % 2 == 0:
+                    for commit_hash in commit_hashes[::-1]:
+                        yield run_rounds, commit_hash
+                else:
+                    for commit_hash in commit_hashes:
+                        yield run_rounds, commit_hash
+
+        for run_rounds, commit_hash in iter_rounds_commits():
             if commit_hash in skipped_benchmarks:
                 for env in environments:
                     for bench in benchmarks:

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -281,14 +281,22 @@ class Run(Command):
             if commit_hash in skipped_benchmarks:
                 for env in environments:
                     for bench in benchmarks:
-                        log.step()
+                        if interleave_processes:
+                            log.step()
+                        else:
+                            for j in range(max_processes):
+                                log.step()
                 continue
 
             for env in environments:
                 skip_list = skipped_benchmarks[(commit_hash, env.name)]
                 for bench in benchmarks:
                     if bench in skip_list:
-                        log.step()
+                        if interleave_processes:
+                            log.step()
+                        else:
+                            for j in range(max_processes):
+                                log.step()
 
             active_environments = [env for env in environments
                                    if set(six.iterkeys(benchmarks))

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -307,8 +307,9 @@ class Run(Command):
 
             if commit_hash:
                 if interleave_processes:
-                    round_info = " ({}/{})".format(max_processes - run_rounds[0] + 1,
-                                                   max_processes)
+                    round_info = " (round {}/{})".format(
+                        max_processes - run_rounds[0] + 1,
+                        max_processes)
                 else:
                     round_info = ""
 

--- a/asv/results.py
+++ b/asv/results.py
@@ -402,6 +402,19 @@ class Results(object):
         # Remove version (may be missing)
         self._benchmark_version.pop(key, None)
 
+    def remove_samples(self, key, selected_idx=None):
+        """
+        Remove measurement samples from the selected benchmark.
+        """
+        if key not in self._results:
+            raise ValueError(key)
+
+        if selected_idx is None:
+            self._samples[key] = None
+        elif self._samples[key] is not None:
+            for j in selected_idx:
+                self._samples[key][j] = None
+
     def add_result(self, benchmark, result,
                    started_at=None, ended_at=None,
                    record_samples=False,

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -210,3 +210,30 @@ def test_filename_format():
 
     r = results.Results({'machine': 'foo'}, [], "hash", 0, "", "a"*128)
     assert r._filename == join("foo", "hash-env-e510683b3f5ffe4093d021808bc6ff70.json")
+
+
+def test_remove_samples():
+    benchmark1 = {'name': 'a', 'version': '1', 'params': []}
+    benchmark2 = {'name': 'b', 'version': '1', 'params': [['1', '2', '3']]}
+
+    r = results.Results.unnamed()
+
+    v1 = runner.BenchmarkResult(result=[True], samples=[[1]], number=[1],
+                                profile=None, errcode=0, stderr='')
+    v2 = runner.BenchmarkResult(result=[True]*3, samples=[[1],[2],[3]], number=[1,1,1],
+                                profile=None, errcode=0, stderr='')
+
+    r.add_result(benchmark1, v1, record_samples=True)
+    r.add_result(benchmark2, v2, record_samples=True)
+
+    assert r.get_result_samples(benchmark1['name'], benchmark1['params']) == v1.samples
+    assert r.get_result_samples(benchmark2['name'], benchmark2['params']) == v2.samples
+
+    r.remove_samples(benchmark1['name'])
+    assert r.get_result_samples(benchmark1['name'], benchmark1['params']) == [None]
+
+    r.remove_samples(benchmark2['name'], selected_idx=[1])
+    assert r.get_result_samples(benchmark2['name'], benchmark2['params']) == [[1], None, [3]]
+
+    r.remove_samples(benchmark2['name'])
+    assert r.get_result_samples(benchmark2['name'], benchmark2['params']) == [None, None, None]

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -4,18 +4,21 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import re
 import glob
 import os
-from os.path import abspath, dirname, join, isfile, relpath
 import shutil
 import sys
 import datetime
+import json
 
 import six
-import json
 import pytest
 
+from os.path import abspath, dirname, join, isfile, relpath
+
 from asv import config, environment, util
+from asv.results import iter_results_for_machine
 from asv.util import check_output, which
 
 from . import tools
@@ -179,12 +182,25 @@ def test_continuous(capfd, basic_conf):
     tools.run_asv_with_conf(conf, 'continuous', "master^", '--show-stderr',
                             '--bench=params_examples.track_find_test',
                             '--bench=params_examples.track_param',
+                            '--bench=time_examples.TimeSuite.time_example_benchmark_1',
+                            '--attribute=repeat=1', '--attribute=number=1',
+                            '--attribute=warmup_time=0',
                             *env_spec, _machine_file=machine_file)
 
     text, err = capfd.readouterr()
     assert "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY" in text
     assert "+           1.00s            6.00s     6.00  params_examples.track_find_test(2)" in text
     assert "params_examples.ClassOne" in text
+
+    # Check processes were interleaved (timing benchmark was run twice)
+    assert re.search(r"For.*commit hash [a-f0-9]+ \(1/2\)", text, re.M)
+
+    result_found = False
+    for results in iter_results_for_machine(conf.results_dir, "orangutan"):
+        result_found = True
+        stats = results.get_result_stats('time_examples.TimeSuite.time_example_benchmark_1', [])
+        assert stats[0]['repeat'] == 2
+    assert result_found
 
 
 def test_find(capfd, basic_conf):

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -193,7 +193,7 @@ def test_continuous(capfd, basic_conf):
     assert "params_examples.ClassOne" in text
 
     # Check processes were interleaved (timing benchmark was run twice)
-    assert re.search(r"For.*commit hash [a-f0-9]+ \(1/2\)", text, re.M)
+    assert re.search(r"For.*commit hash [a-f0-9]+ \(round 1/2\)", text, re.M)
 
     result_found = False
     for results in iter_results_for_machine(conf.results_dir, "orangutan"):


### PR DESCRIPTION
Interleaving commits can reduce bias in measurements due to commit
ordering, which affects e.g. CPU heating etc.

Turn it on by default for "asv continuous".

Closes gh-595