### PR TITLE
git: don't try to deal with git-name-rev failure types

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -153,11 +153,9 @@ class Git(Repo):
             if not name:
                 return None
         except util.ProcessError as err:
-            if err.retcode == 128:
-                # Nothing found
-                return None
-            raise
- 
+            # Failed to obtain.
+            return None
+
         # Return tags without prefix
         for prefix in ['tags/']:
             if name.startswith(prefix):


### PR DESCRIPTION
The specific exit codes appear to vary, so it's better to not try to
interpret them.