### PR TITLE
 Keep track of installed commit_hash and do not reinstall needlessly

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -403,8 +403,10 @@ class Environment(object):
 
     def _set_installed_commit_hash(self, commit_hash):
         # Save status
+        install_checksum = self._get_install_checksum()
         hash_file = os.path.join(self._path, 'asv-install-status.json')
-        util.write_json(hash_file, {'commit_hash': commit_hash}, api_version=1)
+        data = {'commit_hash': commit_hash, 'install_checksum': install_checksum}
+        util.write_json(hash_file, data, api_version=1)
 
     def _get_installed_commit_hash(self):
         hash_file = os.path.join(self._path, 'asv-install-status.json')
@@ -416,7 +418,20 @@ class Environment(object):
             except util.UserError as exc:
                 pass
 
+        # If configuration changed, force reinstall
+        install_checksum = self._get_install_checksum()
+        if data.get('install_checksum', None) != install_checksum:
+            return None
+
         return data.get('commit_hash', None)
+
+    def _get_install_checksum(self):
+        return [self._repo_subdir,
+                self._install_timeout,
+                self._project,
+                self._build_command,
+                self._install_command,
+                self._uninstall_command]
 
     @property
     def installed_commit_hash(self):

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -381,6 +381,9 @@ class Environment(object):
         self._env_vars['ASV_ENV_DIR'] = self._path
         self._env_vars['ASV_ENV_TYPE'] = self.tool_name
 
+        installed_commit_hash = self._get_installed_commit_hash()
+        self._set_commit_hash(installed_commit_hash)
+
     def _set_commit_hash(self, commit_hash):
         if commit_hash is None:
             self._env_vars.pop('ASV_COMMIT', None)
@@ -397,6 +400,27 @@ class Environment(object):
             self._env_vars.pop('ASV_BUILD_CACHE_DIR', None)
         else:
             self._env_vars['ASV_BUILD_CACHE_DIR'] = cache_dir
+
+    def _set_installed_commit_hash(self, commit_hash):
+        # Save status
+        hash_file = os.path.join(self._path, 'asv-install-status.json')
+        util.write_json(hash_file, {'commit_hash': commit_hash}, api_version=1)
+
+    def _get_installed_commit_hash(self):
+        hash_file = os.path.join(self._path, 'asv-install-status.json')
+
+        data = {}
+        if os.path.isfile(hash_file):
+            try:
+                data = util.load_json(hash_file, api_version=1, cleanup=False)
+            except util.UserError as exc:
+                pass
+
+        return data.get('commit_hash', None)
+
+    @property
+    def installed_commit_hash(self):
+        return self._get_installed_commit_hash()
 
     @classmethod
     def matches(self, python):
@@ -582,6 +606,13 @@ class Environment(object):
         else:
             build_dir = self._build_root
 
+        # Check first if anything needs to be done
+        installed_commit_hash = self._get_installed_commit_hash()
+        if installed_commit_hash == commit_hash:
+            self._set_commit_hash(installed_commit_hash)
+            self._set_build_dirs(None, None)
+            return
+
         # Checkout first, so that uninstall can access build_dir
         # (for e.g. Makefiles)
         self.checkout_project(repo, commit_hash)
@@ -605,6 +636,9 @@ class Environment(object):
         # Mark cached build as valid
         self._cache.finalize_cache_dir(commit_hash)
 
+        # Mark installation as updated
+        self._set_installed_commit_hash(commit_hash)
+
     def _install_project(self, repo, commit_hash, build_dir):
         """
         Run install commands
@@ -623,6 +657,9 @@ class Environment(object):
         """
         Run uninstall commands
         """
+        # Mark installation invalid first
+        self._set_installed_commit_hash(None)
+
         cmd = self._uninstall_command
         if cmd is None:
             # Run pip via python -m pip, avoids shebang length limit on Linux
@@ -747,6 +784,10 @@ class ExistingEnvironment(Environment):
 
         super(ExistingEnvironment, self).__init__(conf, executable, requirements)
         self._env_vars.pop('ASV_ENV_DIR')
+
+    @property
+    def installed_commit_hash(self):
+        return None
 
     @classmethod
     def matches(cls, python):

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -681,7 +681,6 @@ def test_custom_commands(tmpdir):
 
     assert os.path.isfile(install_file)
     assert os.path.isfile(cache_file)
-    env._set_installed_commit_hash(None)
 
     # Bad install command should cause a failure
     conf.install_command = ['python -c "import sys; sys.exit(1)"']
@@ -722,8 +721,16 @@ def test_installed_commit_hash(tmpdir):
     env = get_env()
     assert env.installed_commit_hash == commit_hash
     assert env._env_vars.get('ASV_COMMIT') == commit_hash
+
+    # Configuration change results to reinstall
+    env._project = "something"
+    assert env.installed_commit_hash == None
+
+    # Uninstall resets hash (but not ASV_COMMIT)
+    env = get_env()
     env._uninstall_project()
     assert env.installed_commit_hash == None
+    assert env._env_vars.get('ASV_COMMIT') != None
 
     env = get_env()
     assert env.installed_commit_hash == None

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -659,6 +659,7 @@ def test_custom_commands(tmpdir):
     env.install_project(conf, repo, commit_hash)
     assert os.path.isfile(install_file)
     assert not os.listdir(cache_dir)
+    env._set_installed_commit_hash(None)
 
     # It should succed with nonzero cache size
     conf.build_cache_size = 1
@@ -680,9 +681,50 @@ def test_custom_commands(tmpdir):
 
     assert os.path.isfile(install_file)
     assert os.path.isfile(cache_file)
+    env._set_installed_commit_hash(None)
 
     # Bad install command should cause a failure
     conf.install_command = ['python -c "import sys; sys.exit(1)"']
     env = get_env()
     with pytest.raises(util.ProcessError):
         env.install_project(conf, repo, commit_hash)
+
+
+def test_installed_commit_hash(tmpdir):
+    tmpdir = six.text_type(tmpdir)
+    tmpdir = six.text_type(tmpdir)
+
+    dvcs = generate_test_repo(tmpdir, [0], dvcs_type='git')
+    commit_hash = dvcs.get_branch_hashes()[0]
+
+    conf = config.Config()
+    conf.env_dir = os.path.join(tmpdir, "env")
+    conf.pythons = [PYTHON_VER1]
+    conf.repo = os.path.abspath(dvcs.path)
+    conf.matrix = {}
+    conf.build_cache_size = 0
+
+    repo = get_repo(conf)
+
+    def get_env():
+        return list(environment.get_environments(conf, None))[0]
+
+    env = get_env()
+    env.create()
+
+    # Check updating installed_commit_hash
+    assert env.installed_commit_hash == None
+    assert env._env_vars.get('ASV_COMMIT') == None
+    env.install_project(conf, repo, commit_hash)
+    assert env.installed_commit_hash == commit_hash
+    assert env._env_vars.get('ASV_COMMIT') == commit_hash
+
+    env = get_env()
+    assert env.installed_commit_hash == commit_hash
+    assert env._env_vars.get('ASV_COMMIT') == commit_hash
+    env._uninstall_project()
+    assert env.installed_commit_hash == None
+
+    env = get_env()
+    assert env.installed_commit_hash == None
+    assert env._env_vars.get('ASV_COMMIT') == None


### PR DESCRIPTION
Avoid reinstalling project if the same commit hash is already installed in the environment.