### PR TITLE
Update project credits and authors

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2013, Michael Droettboom, Space Telescope Science Institute
+Copyright (c) 2011-2018, Michael Droettboom, Space Telescope Science Institute, Pauli Virtanen
 
 All rights reserved.
 

--- a/README.rst
+++ b/README.rst
@@ -30,4 +30,4 @@ By using the following markdown::
 License: `BSD three-clause license
 <http://opensource.org/licenses/BSD-3-Clause>`__.
 
-Author: Michael Droettboom
+Authors: Michael Droettboom, Pauli Virtanen

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,7 +61,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'airspeed velocity'
-copyright = u'2013, Michael Droettboom'
+copyright = u'2013-2018, Michael Droettboom, Pauli Virtanen'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/credits.txt
+++ b/docs/source/credits.txt
@@ -1,6 +1,9 @@
+- Michael Droettboom (founder)
 - Pauli Virtanen
+- Philippe Pepiot
 - Thomas Robitaille
 - Richard Hattersley
+- Antoine Pitrou
 - Matthew Turk
 - Antoine Pitrou
 - Christoph Deil
@@ -11,3 +14,30 @@
 - MinRK
 - Christopher Whelan
 - Robert T. McGibbon
+- Juan Nunez-Iglesias
+- Andrew Nelson
+- Andreas Fragner
+- Aaron Meurer
+- Boris Feld
+- Erik M. Bray
+- Kacper Kowalik
+- Tyler Reddy
+- Yaroslav Halchenko
+- @wrwrwr
+- Antony Lee
+- Arne Neumann
+- Colin Carroll
+- Edison Gustavo Muenz
+- Elliott Sales de Andrade
+- Eric Dill
+- Hans Moritz Günther
+- John Kirkham
+- Josh Soref
+- Kacper Kowalik (Xarthisius)
+- MinRK
+- Nathan Goldbaum
+- Thomas Pfaff
+- Tom Augspurger
+- @Warbo
+- Wojtek Ruszczewski
+- @jbrockmendel

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,7 +38,4 @@ Development: https://github.com/airspeed-velocity/asv
 Credits
 -------
 
-Michael Droettboom would like to thank the following contributors to
-asv:
-
 .. include:: credits.txt


### PR DESCRIPTION
Do some shameless self-promotion.
Sync project credit list with current `git shortlog`.

@mdboom: looks ok?