### PR TITLE
benchmark: use pkgutil to recursively iterate over all modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,10 @@ API Changes
   internal APIs in ``asv`` are not guaranteed to be backward
   compatible.
 
+- The benchmark suite is now required to be structured as a valid
+  Python package.  An ``__init__.py`` file needs to be present in each
+  subdirectory that is a part of the benchmark suite.
+
 Bug Fixes
 ^^^^^^^^^
 


### PR DESCRIPTION
Use a more standard way (pkgutil) to discover all modules in the
benchmark package.

This is a slight change in the API: previously any '.py' files in the
bencmarks directory were discovered, but with this change they are only
discovered insofar as they are in a valid Python package hierarchy.