### PR TITLE
 Discard PYTHONPATH for commands run in environments

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -748,6 +748,14 @@ class Environment(object):
         else:
             paths.insert(0, os.path.join(self._path, "bin"))
 
+        # Discard PYTHONPATH, which can easily break the environment
+        # isolation
+        if 'ASV_PYTHONPATH' in env:
+            env['PYTHONPATH'] = env['ASV_PYTHONPATH']
+            env.pop('ASV_PYTHONPATH', None)
+        else:
+            env.pop('PYTHONPATH', None)
+
         # When running pip, we need to set PIP_USER to false, as --user (which
         # may have been set from a pip config file) is incompatible with
         # virtualenvs.

--- a/docs/source/env_vars.rst
+++ b/docs/source/env_vars.rst
@@ -16,3 +16,11 @@ variables available:
 
 If there is no asv-managed environment, build, or cache directory, or
 commit hash, those environment variables are unset.
+
+The following environment variables controlling Python and other
+behavior are also set:
+
+- ``PATH``: environment-specific binary directories prepended
+- ``PIP_USER``: ``false``
+- ``PYTHONNOUSERSITE``: ``True`` (for conda environments only)
+- ``PYTHONPATH``: unset (if really needed, can be overridden by setting ``ASV_PYTHONPATH``)


### PR DESCRIPTION
The environments are supposed to be isolated, and hence should ignore PYTHONPATH.
Document the environment variables set.