### PR TITLE
util: don't round to nearest second in datetime_to_js_timestamp

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -975,26 +975,27 @@ def format_text_table(rows, num_headers=0,
     return "\n".join(result)
 
 
+def _datetime_to_timestamp(dt, divisor):
+    delta = dt - datetime.datetime(1970, 1, 1)
+    microseconds = (delta.days * 86400 + delta.seconds) * 10**6 + delta.microseconds
+    value, remainder = divmod(microseconds, divisor)
+    if remainder >= divisor//2:
+        value += 1
+    return value
+
+
 def datetime_to_timestamp(dt):
     """
     Convert a Python datetime object to a UNIX timestamp.
     """
-    if sys.version_info[:2] < (2, 7):
-        def total_seconds(td):
-            return (td.microseconds +
-                    (td.seconds + td.days * 24 * 3600) * 1e6) / 1e6
-    else:
-        def total_seconds(td):
-            return td.total_seconds()
-
-    return int(total_seconds(dt - datetime.datetime(1970, 1, 1)))
+    return _datetime_to_timestamp(dt, 10**6)
 
 
 def datetime_to_js_timestamp(dt):
     """
     Convert a Python datetime object to a JavaScript timestamp.
     """
-    return 1000 * datetime_to_timestamp(dt)
+    return _datetime_to_timestamp(dt, 10**3)
 
 
 def js_timestamp_to_datetime(ts):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -13,6 +13,8 @@ import pickle
 import multiprocessing
 import threading
 import traceback
+import time
+import datetime
 import six
 import pytest
 
@@ -324,3 +326,38 @@ def test_interpolate_command():
     for value, variables in bad_items:
         with pytest.raises(util.UserError):
             util.interpolate_command(value, variables)
+
+
+def test_datetime_to_js_timestamp():
+    tss = [0, 0.5, -0.5, 12345.6789, -12345.6789,
+           1535910708.7767508]
+    for ts in tss:
+        t = datetime.datetime.utcfromtimestamp(ts)
+        ts2 = util.datetime_to_js_timestamp(t)
+        assert abs(ts * 1000 - ts2) <= 0.5
+
+    # Check sub-second precision
+    ms = 50
+    ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 1000*ms)
+    assert util.datetime_to_js_timestamp(ts) == ms
+
+    # Check rounding
+    ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 500)
+    assert util.datetime_to_js_timestamp(ts) == 1
+    ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 499)
+    assert util.datetime_to_js_timestamp(ts) == 0
+
+
+def test_datetime_to_timestamp():
+    tss = [0, 0.5, -0.5, 12345.6789, -12345.6789,
+           1535910708.7767508]
+    for ts in tss:
+        t = datetime.datetime.utcfromtimestamp(ts)
+        ts2 = util.datetime_to_timestamp(t)
+        assert abs(ts - ts2) <= 0.5
+
+    # Check rounding
+    ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 500000)
+    assert util.datetime_to_timestamp(ts) == 1
+    ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 500000 - 1)
+    assert util.datetime_to_timestamp(ts) == 0


### PR DESCRIPTION
Generate javascript timestamps with full available precision, instead of rounding to nearest second.