### PR TITLE
In discovery, treat suite import failure similarly as build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ before_install:
     set -e
     mkdir -p $HOME/download
     pushd $HOME/download
-    wget -nc https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
+    wget -nc https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux64.tar.gz
     mkdir $HOME/geckodriver
-    tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C $HOME/geckodriver
+    tar -xzf geckodriver-v0.22.0-linux64.tar.gz -C $HOME/geckodriver
     popd
     export PATH="$PATH:$HOME/geckodriver"
 


### PR DESCRIPTION
Instead of giving up benchmark discovery on import failure, treat it
similarly as build failures.

Also try branch commits immediately if the first user-provided benchmark
commit fails to work, and try rest of the commits only after those.