### PR TITLE
detect_regression: value 'after' regression is the minimum, not next one

### DIFF
--- a/test/test_step_detect.py
+++ b/test/test_step_detect.py
@@ -170,8 +170,10 @@ def test_detect_regressions(use_rangemedian):
 
         # Check detect_regressions
         new_value, best_value, regression_pos = detect_regressions(steps)
-        assert regression_pos == [(3233 + (seed % 123), (3233 + (seed % 123) + 1), steps_v[1], steps_v[2]),
-                                  (3499 + (seed % 71), 3499 + (seed % 71) + 1, steps_v[4], steps_v[5])]
+        assert regression_pos == [(3233 + (seed % 123), (3233 + (seed % 123) + 1),
+                                   steps_v[1], min(steps_v[2:])),
+                                  (3499 + (seed % 71), 3499 + (seed % 71) + 1,
+                                   steps_v[4], min(steps_v[5:]))]
         assert np.allclose(best_value, 0.7/2 - 0.3, rtol=0.3, atol=0)
         assert np.allclose(new_value, 0.7/2 - 0.3 + 2, rtol=0.3, atol=0)
 
@@ -246,7 +248,7 @@ def test_regression_threshold():
     assert best == 1
     assert pos == [(1, 2, 1.1, 2.0)]
 
-    latest, best, pos = detect_regressions(steps, threshold=0.9)
+    latest, best, pos = detect_regressions(steps, threshold=0.8)
     assert latest == 2
     assert best == 1
     assert pos == [(1, 2, 1.1, 2.0)]

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -217,8 +217,8 @@ def test_web_regressions(browser, basic_html):
         assert re.match(r'^\d\d\d\d-\d\d-\d\d \d\d:\d\d$', cols1[1])
         assert re.match(r'^\d\d\d\d-\d\d-\d\d \d\d:\d\d$', cols2[1])
 
-        assert cols1[2:] == [bad_commit_hash[:8], '3.00x', '1.00', '3.00', 'Ignore']
-        assert cols2[2:] == [bad_commit_hash[:8], '3.00x', '1.00', '3.00', 'Ignore']
+        assert cols1[2:] == [bad_commit_hash[:8], '2.00x', '1.00', '2.00', 'Ignore']
+        assert cols2[2:] == [bad_commit_hash[:8], '2.00x', '1.00', '2.00', 'Ignore']
 
         # Check that the ignore buttons work as expected
         buttons = [button for button in browser.find_elements_by_xpath('//button')


### PR DESCRIPTION
Change the value 'after' a regression to be the minimum of values
following the upward step.

Previously, it was the value immediately after the upward step.
However, typically the important question is how much worse the
situation is, after taking into account any commits trying to rectify
the problem.

Using 'minimum' instead of 'next' value enables better ranking of how
important regressions are in practice.

That the code becomes also simpler is probably a sign that this is the
right thing.