### PR TITLE
step_detect: remove ad-hoc restriction interval size>=2

### DIFF
--- a/asv/step_detect.py
+++ b/asv/step_detect.py
@@ -566,6 +566,10 @@ def solve_potts_autogamma(y, beta=None, **kw):
 
     gamma_0 = dist(0, n-1)
 
+    if gamma_0 == 0:
+        # Zero variance
+        gamma_0 = 1.0
+
     best_r = [None]
     best_v = [None]
     best_d = [None]

--- a/asv/step_detect.py
+++ b/asv/step_detect.py
@@ -405,7 +405,7 @@ def detect_regressions(steps, threshold=0):
 # Fitting piecewise constant functions to noisy data
 #
 
-def solve_potts(y, gamma, p=2, min_size=2, max_size=None,
+def solve_potts(y, gamma, p=2, min_size=1, max_size=None,
                 min_pos=None, max_pos=None, mu_dist=None):
     """Fit penalized stepwise constant function (Potts model) to data.
 
@@ -615,7 +615,7 @@ def solve_potts_autogamma(y, beta=None, **kw):
     return best_r[0], best_v[0], best_d[0], best_gamma[0]
 
 
-def solve_potts_approx(y, gamma=None, p=2, min_size=2, **kw):
+def solve_potts_approx(y, gamma=None, p=2, min_size=1, **kw):
     """
     Fit penalized stepwise constant function (Potts model) to data
     approximatively, in linear time.

--- a/test/test_step_detect.py
+++ b/test/test_step_detect.py
@@ -127,6 +127,13 @@ def test_autocorrelated():
     assert right == [500, 1000]
 
 
+def test_zero_variance():
+    # Should not choke on this data
+    y = [1.0]*1000
+    right, values, dists, gamma = solve_potts_autogamma(y, p=1)
+    assert right == [1000]
+
+
 @pytest.mark.skipif(not HAVE_NUMPY, reason="test needs numpy")
 def test_detect_regressions(use_rangemedian):
     try:


### PR DESCRIPTION
Allow length-1 intervals in step detection.

The Bayes criterion is supposed to select the interval cost correctly,
so this sort of ad-hoc restrictions are not necessary.