### PR TITLE
Add an option for bypassing commit filtering for asv publish.

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -60,6 +60,9 @@ class Publish(Command):
             '--no-pull', action='store_true', dest='no_pull',
             help="Do not pull the repository")
         parser.add_argument(
+            '--no-commit-filtering', action='store_true', dest='no_commit_filtering',
+            help="Include all commits, instead of filtering. Default is 'False'.")
+        parser.add_argument(
             'range', nargs='?', default=None,
             help="""Optional commit range to consider""")
         parser.add_argument(
@@ -75,7 +78,9 @@ class Publish(Command):
     def run_from_conf_args(cls, conf, args):
         if args.html_dir is not None:
             conf.html_dir = args.html_dir
-        return cls.run(conf=conf, range_spec=args.range, pull=not args.no_pull)
+
+        return cls.run(conf=conf, range_spec=args.range, pull=not args.no_pull,
+                        no_commit_filtering=args.no_commit_filtering)
 
     @staticmethod
     def iter_results(conf, repo, range_spec=None):
@@ -91,7 +96,7 @@ class Publish(Command):
                 yield result
 
     @classmethod
-    def run(cls, conf, range_spec=None, pull=True):
+    def run(cls, conf, range_spec=None, pull=True, no_commit_filtering=False):
         params = {}
         graphs = GraphSet()
         machines = {}
@@ -182,7 +187,7 @@ class Publish(Command):
 
                     for branch in [
                         branch for branch, commits in branches.items()
-                        if results.commit_hash in commits
+                        if no_commit_filtering or results.commit_hash in commits
                     ]:
                         cur_params = dict(results.params)
                         cur_params['branch'] = repo.get_branch_name(branch)

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -168,8 +168,52 @@ def generate_result_dir(request, tmpdir):
                 commit_values[commit] = value
         conf = tools.generate_result_dir(tmpdir, dvcs, commit_values)
         repo = get_repo(conf)
+
         return conf, repo, commits
     return _generate_result_dir
+
+@pytest.fixture(params=[
+    "git",
+    pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib")),
+])
+def generate_branched_result_dir(request, tmpdir):
+    tmpdir = six.text_type(tmpdir)
+    dvcs_type = request.param
+
+    def _generate_branched_result_dir():
+        if dvcs_type == "git":
+            master = "master"
+        elif dvcs_type == "hg":
+            master = "default"
+
+        # from test_repo.py
+        dvcs = tools.generate_repo_from_ops(tmpdir, dvcs_type, [
+            ("commit", 1),
+            ("checkout", "stable", master),
+            ("commit", 2),
+            ("checkout", master),
+            ("commit", 3),
+            ("merge", "stable"),
+            ("commit", 4),
+            ("checkout", "stable"),
+            ("merge", master, "Merge master"),
+            ("commit", 5),
+            ("checkout", master),
+            ("commit", 6),
+        ])
+
+        commits = list(reversed(dvcs.get_branch_hashes()))
+        commit_values = {}
+        for i, commit in enumerate(commits):
+            commit_values[commit] = i
+
+        conf = tools.generate_result_dir(tmpdir, dvcs, commit_values)
+        conf.branches = ['master']
+        repo = get_repo(conf)
+
+        return conf, repo, commits
+    return _generate_branched_result_dir
+
 
 def _graph_path(dvcs_type):
     if dvcs_type == "git":

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -232,8 +232,21 @@ def test_publish_range_spec(generate_result_dir):
     ):
         tools.run_asv_with_conf(conf, "publish", range_spec)
         data = util.load_json(join(conf.html_dir, 'index.json'))
+
         assert set(data['revision_to_hash'].values()) == expected
 
+@pytest.mark.parametrize('filter_commits', (False, True))
+def test_publish_filtered(filter_commits, generate_branched_result_dir):
+    conf, repo, commits = generate_branched_result_dir()
+
+    args = [] if filter_commits else ['--no-commit-filtering']
+    tools.run_asv_with_conf(conf, "publish", *args)
+
+    data = util.load_json(join(conf.html_dir, _graph_path(repo.dvcs)))
+    if filter_commits:
+        assert len(data) == 5
+    else:
+        assert len(data) == 6
 
 def test_regression_simple(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 5 * [10])


### PR DESCRIPTION
Hello!

My team's been using asv for our project for the last couple of months and we really love it. However, we've noticed a problem where our graphs would occasionally lose all of their past data despite the results files still remaining present. Some investigation revealed the culprit: `asv publish` was filtering out benchmarks from commits that didn't appear via `git rev-parse --first-parent branch`. Our repo has a structure such that a condition like that doesn't make sense for us, so we'd rather just have all benchmarks shown.

As for the option's name, I went with "no-commit-filtering" to maintain the same naming scheme as "no-pull", but am happy to change it to whatever y'all think makes sense.