### PR TITLE
add option for first-parent VCS flag (for publish/gh-pages only)

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -117,8 +117,10 @@ class Git(Repo):
             ['rev-list', '-n', '1', '--format=%at', hash],
             valid_return_codes=(0, 1), dots=False).strip().split()[-1]) * 1000
 
-    def get_hashes_from_range(self, range_spec):
-        args = ['rev-list', '--first-parent']
+    def get_hashes_from_range(self, range_spec, first_parent=True):
+        args = ['rev-list']
+        if first_parent:
+            args.append('--first-parent')
         if range_spec != "":
             args += range_spec.split()
         output = self._run_git(args, valid_return_codes=(0, 1), dots=False)
@@ -172,11 +174,12 @@ class Git(Repo):
     def get_date_from_name(self, name):
         return self.get_date(name + "^{commit}")
 
-    def get_branch_commits(self, branch):
-        return self.get_hashes_from_range(self.get_branch_name(branch))
+    def get_branch_commits(self, branch, first_parent=True):
+        return self.get_hashes_from_range(self.get_branch_name(branch), first_parent=first_parent)
 
     def get_revisions(self, commits):
         revisions = {}
+
         for i, commit in enumerate(self._run_git([
             "rev-list", "--all", "--date-order", "--reverse",
         ]).splitlines()):

--- a/asv/plugins/github.py
+++ b/asv/plugins/github.py
@@ -30,6 +30,18 @@ class GithubPages(Command):
             "--rewrite", action="store_true",
             help=("Rewrite gh-pages branch to contain only a single commit, "
                   "instead of adding a new commit"))
+        parser.add_argument(
+            "--first-parent", action="store_true", default=True, dest="first_parent",
+            help="""Use git's --first-parent or hg's --follow-first options for associating
+            commits with branches.  Each commit will be assigned to the first branch that
+            it occurred on, not to any later branches that may have that commit merged in.""")
+        parser.add_argument(
+            "--no-first-parent", action="store_false", dest="first_parent",
+            help="""Do not use git's --first-parent or hg's --follow-first options for
+            associating commits with branches.  Use this if you have merged older feature
+            branches into your main branch, and you want to show all the old commits in the
+            context of the new branch.  If you have commits that are not appearing in a
+            plot of your main branch, try this.""")
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -37,14 +49,15 @@ class GithubPages(Command):
 
     @classmethod
     def run_from_conf_args(cls, conf, args):
-        return cls.run(conf=conf, no_push=args.no_push, rewrite=args.rewrite)
+        return cls.run(conf=conf, no_push=args.no_push, rewrite=args.rewrite,
+                       first_parent=args.first_parent)
 
     @classmethod
-    def run(cls, conf, no_push, rewrite):
+    def run(cls, conf, no_push, rewrite, first_parent=True):
         git = util.which('git')
 
         # Publish
-        Publish.run(conf)
+        Publish.run(conf, first_parent=first_parent)
 
         cwd = os.path.abspath(os.getcwd())
 

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -170,9 +170,9 @@ class Hg(Repo):
     def get_date_from_name(self, name):
         return self.get_date(name)
 
-    def get_branch_commits(self, branch):
+    def get_branch_commits(self, branch, first_parent=True):
         return self.get_hashes_from_range("ancestors({0})".format(self.get_branch_name(branch)),
-                                          followfirst=True)
+                                          followfirst=first_parent)
 
     def get_revisions(self, commits):
         revisions = {}

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -161,14 +161,14 @@ class Repo(object):
         """
         raise NotImplementedError()
 
-    def get_branch_commits(self, branch):
+    def get_branch_commits(self, branch, first_parent=True):
         """
         Returns the ordered list (last commit first) of all commits in
         `branch` following first parent in case of merge
         """
         raise NotImplementedError()
 
-    def get_new_branch_commits(self, branches, existing):
+    def get_new_branch_commits(self, branches, existing, first_parent=True):
         """
         Return a set of new commits on `branches` that are successors of all
         `existing` commits
@@ -176,7 +176,7 @@ class Repo(object):
         new = set()
         new_commits = []
         for branch in branches:
-            for commit in self.get_branch_commits(branch):
+            for commit in self.get_branch_commits(branch, first_parent=first_parent):
                 if commit in existing:
                     break
                 if commit not in new:
@@ -242,7 +242,7 @@ class NoRepository(Repo):
     def get_branch_commits(self, branch):
         self._raise_error()
 
-    def get_new_branch_commits(self, branches, existing):
+    def get_new_branch_commits(self, branches, existing, first_parent=True):
         self._raise_error()
 
 


### PR DESCRIPTION
Conda's repo strategy is to branch off at releases and keep "merging up" so that master always contains all the commits from the past.  The --first-parent flag passed to git by ASV gets confused by this, and only shows stuff that has actually been committed on master (that's what it's for, I guess).  We wanted a way to not pass that flag, so that all of our commits show up on master.

This PR adds an option to disable passing that flag to git, or its equivalent to mercurial.  The default behavior does not change.  This PR only affects the behavior of the "publish" and "gh-pages" commands.