### PR TITLE
Rename load_json cleanup= option to js_comments=

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -299,7 +299,7 @@ class Benchmarks(dict):
             path = cls.get_benchmark_file_path(conf.results_dir)
             if not os.path.isfile(path):
                 raise util.UserError("Benchmark list file {} missing!".format(path))
-            d = util.load_json(path, cleanup=False, api_version=cls.api_version)
+            d = util.load_json(path, api_version=cls.api_version)
             benchmarks = six.itervalues(d)
             return cls(conf, benchmarks, regex=regex)
         except util.UserError as err:

--- a/asv/commands/update.py
+++ b/asv/commands/update.py
@@ -37,7 +37,6 @@ class Update(Command):
     @classmethod
     def run(cls, config_path, _machine_file=None):
         MachineCollection.update(_path=_machine_file)
-        Config.update(config_path)
 
         conf = Config.load(config_path)
 

--- a/asv/config.py
+++ b/asv/config.py
@@ -56,7 +56,7 @@ class Config(object):
         if not os.path.isfile(path):
             raise util.UserError("Config file {0} not found.".format(path))
 
-        d = util.load_json(path, cls.api_version)
+        d = util.load_json(path, cls.api_version, js_comments=True)
         try:
             return cls.from_json(d)
         except ValueError:
@@ -79,13 +79,3 @@ class Config(object):
                 "No branches specified in config file.")
 
         return conf
-
-    @classmethod
-    def update(cls, path=None):
-        if not path:
-            path = "asv.conf.json"
-
-        if not os.path.isfile(path):
-            raise util.UserError("Config file {0} not found.".format(path))
-
-        util.update_json(cls, path, cls.api_version)

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -414,7 +414,7 @@ class Environment(object):
         data = {}
         if os.path.isfile(hash_file):
             try:
-                data = util.load_json(hash_file, api_version=1, cleanup=False)
+                data = util.load_json(hash_file, api_version=1)
             except util.UserError as exc:
                 pass
 

--- a/asv/results.py
+++ b/asv/results.py
@@ -627,7 +627,7 @@ class Results(object):
             If given, check that the results file is for the given machine.
 
         """
-        d = util.load_json(path, cls.api_version, cleanup=False)
+        d = util.load_json(path, cls.api_version)
 
         try:
             obj = cls(
@@ -695,7 +695,7 @@ class Results(object):
 
     @classmethod
     def update(cls, path):
-        util.update_json(cls, path, cls.api_version, cleanup=False)
+        util.update_json(cls, path, cls.api_version)
 
     @property
     def env_name(self):

--- a/asv/util.py
+++ b/asv/util.py
@@ -752,9 +752,20 @@ def write_json(path, data, api_version=None, compact=False):
             json.dump(data, fd)
 
 
-def load_json(path, api_version=None, cleanup=True):
+def load_json(path, api_version=None, js_comments=False):
     """
-    Loads JSON to the given path, ignoring any C-style comments.
+    Loads JSON from the given path.
+
+    Parameters
+    ----------
+    path : str
+        File name
+    api_version : str or None
+        API version indentifier
+    js_comments : bool, optional
+        Whether to allow nonstandard javascript-style comments
+        in the file. Note that this slows down the loading
+        significantly.
     """
     # Hide traceback from expected exceptions in pytest reports
     __tracebackhide__ = operator.methodcaller('errisinstance', UserError)
@@ -768,7 +779,7 @@ def load_json(path, api_version=None, cleanup=True):
     with long_path_open(path, 'r', **open_kwargs) as fd:
         content = fd.read()
 
-    if cleanup:
+    if js_comments:
         content = minify_json.json_minify(content)
         content = content.replace(",]", "]")
         content = content.replace(",}", "}")
@@ -800,7 +811,7 @@ def load_json(path, api_version=None, cleanup=True):
     return d
 
 
-def update_json(cls, path, api_version, cleanup=True):
+def update_json(cls, path, api_version):
     """
     Perform JSON file format updates.
 
@@ -819,7 +830,7 @@ def update_json(cls, path, api_version, cleanup=True):
     # Hide traceback from expected exceptions in pytest reports
     __tracebackhide__ = operator.methodcaller('errisinstance', UserError)
 
-    d = load_json(path, cleanup=cleanup)
+    d = load_json(path)
     if 'version' not in d:
         raise UserError(
             "No version specified in {0}.".format(path))

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -206,7 +206,7 @@ def test_compare_name_lookup(dvcs_type, capsys, tmpdir):
     # Copy to different commit
     fn_1 = os.path.join(dst, 'feea15ca-py2.7-Cython-numpy1.8.json')
     fn_2 = os.path.join(dst, commit_hash[:8] + '-py2.7-Cython-numpy1.8.json')
-    data = util.load_json(fn_1, cleanup=False)
+    data = util.load_json(fn_1)
     data['commit_hash'] = commit_hash
     util.write_json(fn_2, data)
 

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -57,7 +57,7 @@ def test_publish(tmpdir):
         src = join(RESULT_DIR, 'cheetah', fn)
         dst = join(result_dir, 'cheetah', commit[:8] + fn[8:])
         try:
-            data = util.load_json(src, cleanup=False)
+            data = util.load_json(src)
         except util.UserError:
             # intentionally malformed file, ship it as is
             shutil.copyfile(src, dst)
@@ -100,7 +100,7 @@ def test_publish(tmpdir):
                   'cpu-Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)',
                   'machine-cheetah', 'numpy-1.8', 'os-Linux (Fedora 20)', 'python-2.7', 'ram-8.2G',
                   'time_coordinates.time_latitude.json')
-        data = util.load_json(fn, cleanup=False)
+        data = util.load_json(fn)
         data_commits = [revision_to_hash[x[0]] for x in data]
         if branch == "master":
             assert all(c in master_commits for c in data_commits)

--- a/test/test_quickstart.py
+++ b/test/test_quickstart.py
@@ -24,7 +24,7 @@ def test_quickstart(tmpdir):
 
     assert isfile(join(dest, 'asv.conf.json'))
     assert isfile(join(dest, 'benchmarks', 'benchmarks.py'))
-    conf = util.load_json(join(dest, 'asv.conf.json'))
+    conf = util.load_json(join(dest, 'asv.conf.json'), js_comments=True)
     assert 'env_dir' not in conf
     assert 'html_dir' not in conf
     assert 'results_dir' not in conf
@@ -40,7 +40,7 @@ def test_quickstart(tmpdir):
 
     assert isfile(join(dest, 'asv.conf.json'))
     assert isfile(join(dest, 'benchmarks', 'benchmarks.py'))
-    conf = util.load_json(join(dest, 'asv.conf.json'))
+    conf = util.load_json(join(dest, 'asv.conf.json'), js_comments=True)
     assert conf['env_dir'] != 'env'
     assert conf['html_dir'] != 'html'
     assert conf['results_dir'] != 'results'


### PR DESCRIPTION
The JSON comment syntax is nonstandard, and significantly reduces the
loading speed.

Rename the option and change the default, to ensure is is not used
unnecessarily.

Also remove Config.update --- since update_json throws away the
comments, it's not really possible to update the API number in the
config file.