### PR TITLE
Change suggested badge colour

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,11 +21,11 @@ The latest release can be installed from PyPI using::
 Are you using ``asv``?  Consider adding a badge to your project's
 README like this:
 
-.. image:: http://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat
+.. image:: http://img.shields.io/badge/benchmarked%20by-asv-blue.svg?style=flat
 
 By using the following markdown::
 
-  [![asv](http://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat)](http://your-url-here/)
+  [![asv](http://img.shields.io/badge/benchmarked%20by-asv-blue.svg?style=flat)](http://your-url-here/)
 
 License: `BSD three-clause license
 <http://opensource.org/licenses/BSD-3-Clause>`__.


### PR DESCRIPTION
I suggest to change the suggested badge-color from green to blue. Red-green is often used to show if tests or builds were successful or not (readthedocs, travis, etc), and red-orange-green is often used to show the status (coveralls, codacy). However, the asv-badge is a static link, indicating that it is benchmarked with asv. So I suggest to show it in blue, as for instance used by Zenodo for its doi, or py pypi and conda for the version number; static info.

From [![asv](http://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat)](http://your-url-here/) to [![asv](http://img.shields.io/badge/benchmarked%20by-asv-blue.svg?style=flat)](http://your-url-here/).

Of course, any user can adjust the badge to his likes anyway, but I thought it would be better to have blue in the suggested markdown.