### PR TITLE
Allow `asv run` to consume list of hashes from a file

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -64,12 +64,15 @@ class Run(Command):
             repository, this is passed as the first argument to ``git
             log``.  See 'specifying ranges' section of the
             `gitrevisions` manpage for more info.  Also accepts the
-            special values 'NEW', 'ALL', and 'EXISTING'. 'NEW' will
-            benchmark all commits since the latest benchmarked on this
-            machine.  'ALL' will benchmark all commits in the project.
-            'EXISTING' will benchmark against all commits for which
-            there are existing benchmarks on any machine. By default,
-            will benchmark the head each configured branches.""")
+            special values 'NEW', 'ALL', 'EXISTING', and 'HASHFILE:xxx'.
+            'NEW' will benchmark all commits since the latest
+            benchmarked on this machine.  'ALL' will benchmark all
+            commits in the project. 'EXISTING' will benchmark against
+            all commits for which there are existing benchmarks on any
+            machine. 'HASHFILE:xxx' will benchmark only a specific set
+            of hashes given in the file named 'xxx', which must have
+            one hash per line. By default, will benchmark the head of
+            each configured of the branches.""")
         parser.add_argument(
             "--steps", "-s", type=common_args.positive_int, default=None,
             help="""Maximum number of steps to benchmark.  This is

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import sys
 import logging
 import traceback
 import itertools
@@ -196,7 +197,9 @@ class Run(Command):
             commit_hashes = repo.get_new_branch_commits(conf.branches, [])
         elif isinstance(range_spec, six.string_types) and range_spec.startswith('HASHFILE:'):
             hashfn = range_spec[9:]
-            if os.path.isfile(hashfn):
+            if hashfn == '-' or hashfn.lower() == 'stdin':
+                hashstr = sys.stdin.read()
+            elif os.path.isfile(hashfn):
                 with open(hashfn, 'r') as f:
                     hashstr = f.read()
             else:

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -198,7 +198,7 @@ class Run(Command):
             commit_hashes = repo.get_new_branch_commits(conf.branches, [])
         elif isinstance(range_spec, six.string_types) and range_spec.startswith('HASHFILE:'):
             hashfn = range_spec[9:]
-            if hashfn == '-' or hashfn.lower() == 'stdin':
+            if hashfn == '-':
                 hashstr = sys.stdin.read()
             elif os.path.isfile(hashfn):
                 with open(hashfn, 'r') as f:
@@ -206,7 +206,7 @@ class Run(Command):
             else:
                 log.error('Requested commit hash file "{}" is not a file'.format(hashfn))
                 return 1
-            commit_hashes = hashstr.strip().split('\n')
+            commit_hashes = [h.strip() for h in hashstr.split("\n") if h.strip()]
         elif isinstance(range_spec, list):
             commit_hashes = range_spec
         else:

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import os
 import sys
 import logging
 import traceback

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -194,6 +194,15 @@ class Run(Command):
         elif range_spec == "ALL":
             # All commits on each configured branches
             commit_hashes = repo.get_new_branch_commits(conf.branches, [])
+        elif isinstance(range_spec, six.string_types) and range_spec.startswith('HASHFILE:'):
+            hashfn = range_spec[9:]
+            if os.path.isfile(hashfn):
+                with open(hashfn, 'r') as f:
+                    hashstr = f.read()
+            else:
+                log.error('Requested commit hash file "{}" is not a file'.format(hashfn))
+                return 1
+            commit_hashes = hashstr.strip().split('\n')
         elif isinstance(range_spec, list):
             commit_hashes = range_spec
         else:

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -105,26 +105,26 @@ single example benchmark file already in
             self.d = {}
             for x in range(500):
                 self.d[x] = None
-    
+
         def time_keys(self):
             for key in self.d.keys():
                 pass
-    
+
         def time_iterkeys(self):
             for key in self.d.iterkeys():
                 pass
-    
+
         def time_range(self):
             d = self.d
             for key in range(500):
                 x = d[key]
-    
+
         def time_xrange(self):
             d = self.d
             for key in xrange(500):
                 x = d[key]
-    
-    
+
+
     class MemSuite:
         def mem_list(self):
             return [0] * 256
@@ -314,6 +314,11 @@ You can benchmark all commits since the last one that was benchmarked
 on this machine.  This is useful for running in nightly cron jobs::
 
     asv run NEW
+
+You can also benchmark a specific set of commits listed explicitly in a file
+(one commit hash per line)::
+
+    asv run HASHFILE:hashestobenchmark.txt
 
 Finally, you can also benchmark all commits that have not yet been benchmarked
 for this machine::
@@ -583,10 +588,10 @@ revisions of the project. You can do so with the ``compare`` command::
 
     $ asv compare v0.1 v0.2
     All benchmarks:
-    
+
            before           after         ratio
          [3bfda9c6]       [bf719488]
-         <v0.1>           <v0.2>    
+         <v0.1>           <v0.2>
                 40.4m            40.4m     1.00  benchmarks.MemSuite.mem_list [amulet.localdomain/virtualenv-py2.7-numpy]
                failed            35.2m      n/a  benchmarks.MemSuite.mem_list [amulet.localdomain/virtualenv-py3.6-numpy]
           11.5±0.08μs         11.0±0μs     0.96  benchmarks.TimeSuite.time_iterkeys [amulet.localdomain/virtualenv-py2.7-numpy]

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -293,6 +293,14 @@ def test_run_spec(basic_conf):
         for range_spec in (None, "NEW", "ALL"):
             _test_run(range_spec, branches, expected_commits)
 
+    # test the HASHFILE version of range_spec'ing
+    expected_commits = (initial_commit, branch_commit)
+    with open(os.path.join(tmpdir, 'hashes_to_benchmark'), 'w') as f:
+        for commit in expected_commits:
+            f.write(commit)
+            f.write('\n')
+    _test_run('HASHFILE:hashes_to_benchmark', [None], expected_commits)
+
 
 def test_run_build_failure(basic_conf):
     tmpdir, local, conf, machine_file = basic_conf


### PR DESCRIPTION
This PR enables the listing of hashes asv should run on by providing a file.  Currently the format is intentionally limited to "one hash per line".  The user says they want to use said file by giving "HASHFILE:xxx.yyy" as the `range` parameter to `asv run`. While not strictly a "range", this seemed ok because "ANY", "EXISTING", etc were already options, so this seems not too much farther from "range" than those.

The use case for this is wanting to compare a specific hand-picked set of commits to so how performance on a particular feature evolves with major known (also probably #561, if I understand the suggestion there correctly). To try to also address the use case #562 is going for, I added "stdin" or "-" as options, in which case stdin is treated as the "hash file", although if that's too hacky I could drop that commit.

I know I could do one of the tricks suggested in #562 instead of this, but those are a lot harder to grok, and also seem to preclude the use of some of the nice multi-commit features of `asv run` like `--parallel` or `--interleave-processes`.

Happy to add docs/etc if need be - just "testing the waters" for now, as I found it quite frustrating to not have an easy way to just run on a list of known hashes.

Closes #562 