### PR TITLE
ENH: remove memory addresses from param repr()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@ Bug Fixes
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Uniqueness of ``repr()`` for ``param`` objects is now guaranteed
+  by suffixing unique identifier corresponding to order of
+  appearance. (#771)
+- Memory addresses are now stripped from the ``repr()`` of ``param``
+  elements, allowing comparison across multiple runs. (#771)
 
 
 0.4.1 (2019-05-30)

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -97,6 +97,12 @@ The following attributes are applicable to all benchmark types:
 
   Note that ``setup_cache`` is not parameterized.
 
+  For the purposes of identifying benchmarks in the UI, ``repr()`` is called
+  on the elements of ``params``. In the event these strings contain memory
+  addresses, those adresses are stripped to allow comparison across runs.
+  Additionally, if this results in a non-unique mapping, each duplicated
+  element will be suffixed with a distinct integer identifier corresponding
+  to order of appearance.
 
 Timing benchmarks
 `````````````````

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -229,7 +229,9 @@ as skipped for the parameter values in question.
 
 The parameter values can be any Python objects. However, it is often
 best to use only strings or numbers, because these have simple
-unambiguous text representations.
+unambiguous text representations. In the event the ``repr()`` output
+is non-unique, the representations will be made unique by suffixing
+an integer identifier corresponding to the order of appearance.
 
 When you have multiple parameters, the test is run for all
 of their combinations::

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -41,6 +41,15 @@ class ParamSuite:
         del self.value
 
 
+class FunctionParamSuite:
+    params = [track_param,
+              lambda x: x]
+    param_names = ['func']
+
+    def time_func(self, func):
+        return func('foo')
+
+
 class TuningTest:
     params = [1, 2]
     counter = [0, 0]

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -73,7 +73,7 @@ def test_discover_benchmarks(benchmarks_fixture):
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                                        regex='example')
     conf.branches = old_branches
-    assert len(b) == 30
+    assert len(b) == 31
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                               regex='time_example_benchmark_1')
@@ -106,9 +106,16 @@ def test_discover_benchmarks(benchmarks_fixture):
     assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1, 2, 3]
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
-    assert len(b) == 41
+    assert len(b) == 42
 
     assert 'named.OtherSuite.track_some_func' in b
+
+    params = b['params_examples.FunctionParamSuite.time_func']['params']
+    assert len(params) == 1
+    assert len(params[0]) == 2
+    assert params[0][0] == '<function track_param>'
+    # repr is a bit different on py2 vs py3 here
+    assert params[0][1] in ['<function FunctionParamSuite.<lambda>>', '<function <lambda>>']
 
 
 def test_invalid_benchmark_tree(tmpdir):


### PR DESCRIPTION
The `pandas` benchmark suite sometimes uses functions as `params`, which largely works fine. The one issue is that the `repr()` of a function includes its memory address and can change over subsequent `asv` invocations (for normal functions) or even within a single `asv` run (for `lambda` functions). This change in `repr()` impacts the ability to track and compare a benchmark over time, leading to broken `asv compare` functionality like below:

```
Benchmarks that have stayed the same:

       before           after         ratio
     [24ab22f7]       [d7cef344]
              n/a          997±3μs      n/a  ctors.SeriesConstructors.time_series_constructor(<function SeriesConstructors.<lambda> at 0x7f0deb0800d0>, False)
              n/a         1.05±0ms      n/a  ctors.SeriesConstructors.time_series_constructor(<function SeriesConstructors.<lambda> at 0x7f0deb0800d0>, True)
      1.04±0.01ms              n/a      n/a  ctors.SeriesConstructors.time_series_constructor(<function SeriesConstructors.<lambda> at 0x7fd9d0bbc598>, False)
      1.06±0.02ms              n/a      n/a  ctors.SeriesConstructors.time_series_constructor(<function SeriesConstructors.<lambda> at 0x7fd9d0bbc598>, True)
```

This PR modifies `repr()` iff it appears to include a memory address, allowing proper comparison over time. The new output looks like this after a re-run:

```
       before           after         ratio
     [24ab22f7]       [d7cef344]
          995±7μs      1.03±0.02ms     1.04  ctors.SeriesConstructors.time_series_constructor(<function <lambda>>, False)
      1.05±0.01ms      1.09±0.05ms     1.03  ctors.SeriesConstructors.time_series_constructor(<function <lambda>>, True)

```

One unaddressed issue is that any suite with multiple `lambda` functions will now have name collisions in `params`. I intend to address this in `pandas` by creating normal named functions in the relevant suites. Alternative solutions would be to append distinct numbers or hashes to the `repr()`s, or to warn or raise if a user passes multiple `lambda` functions.