### PR TITLE
Update jQuery and flot

### DIFF
--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -285,7 +285,7 @@ $(document).ready(function() {
         }
 
         var previous_hover = null;
-        $("#main-graph").bind("plothover", function (event, pos, item) {
+        $("#main-graph").on("plothover", function (event, pos, item) {
             if (item) {
                 if (previous_hover != item.datapoint) {
                     previous_hover = item.datapoint;
@@ -307,7 +307,7 @@ $(document).ready(function() {
            hash in another tab. */
         var previous_click;
         var previous_hash;
-        $("#main-graph").bind("plotclick", function (event, pos, item) {
+        $("#main-graph").on("plotclick", function (event, pos, item) {
             if (item) {
                 if (previous_click != item.datapoint) {
                     previous_click = item.datapoint;
@@ -1233,8 +1233,8 @@ $(document).ready(function() {
             overview = $.plot(overview_div, graphs, overview_options);
         }
 
-        graph_div.unbind("plotselected");
-        graph_div.bind("plotselected", function (event, ranges) {
+        graph_div.off("plotselected");
+        graph_div.on("plotselected", function (event, ranges) {
             // do the zooming
             var new_options = $.extend(true, {}, options, {
                 xaxis: {
@@ -1257,8 +1257,8 @@ $(document).ready(function() {
             }
         });
 
-        overview_div.unbind("plotselected");
-        overview_div.bind("plotselected", function (event, ranges) {
+        overview_div.off("plotselected");
+        overview_div.on("plotselected", function (event, ranges) {
             plot.setSelection(ranges);
             // Update things that depend on the range
             update_tags();

--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -123,7 +123,7 @@ $(document).ready(function() {
         benchmark_graph_display_ready = true;
 
         /* When the window resizes, redraw the graphs */
-        $(window).resize(function() {
+        $(window).on('resize', function() {
             update_graphs();
         });
 
@@ -178,7 +178,7 @@ $(document).ready(function() {
                 stack.push($(top.children()[1]));
                 cursor.push(parts[j]);
 
-                $(top.children()[0]).click(function () {
+                $(top.children()[0]).on('click', function () {
                     $(this).parent().children('ul.tree').toggle(150);
                     var caret = $(this).children('b');
                     if (caret.attr('class') == 'caret') {

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -13,19 +13,19 @@
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"
-            src="vendor/jquery.flot-0.8.2.min.js"
+            src="vendor/jquery.flot-0.8.3.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"
-            src="vendor/jquery.flot-0.8.2.time.min.js"
+            src="vendor/jquery.flot-0.8.3.time.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"
-            src="vendor/jquery.flot-0.8.2.selection.min.js"
+            src="vendor/jquery.flot-0.8.3.selection.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"
-            src="vendor/jquery.flot-0.8.2.categories.min.js"
+            src="vendor/jquery.flot-0.8.3.categories.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -9,7 +9,7 @@
       }
     </script>
     <script language="javascript" type="text/javascript"
-            src="vendor/jquery-1.11.0.min.js"
+            src="vendor/jquery-3.3.1.min.js"
             onerror="js_load_failure()">
     </script>
     <script language="javascript" type="text/javascript"

--- a/asv/www/regressions.js
+++ b/asv/www/regressions.js
@@ -417,7 +417,7 @@ $(document).ready(function() {
             }
         });
 
-        table.bind('aftertablesort', function (event, data) {
+        table.on('aftertablesort', function (event, data) {
             update_url({'sort': [data.column], 'dir': [data.direction]});
             /* Update appearance */
             table.find('thead th').removeClass('asc');

--- a/asv/www/summarygrid.js
+++ b/asv/www/summarygrid.js
@@ -12,7 +12,7 @@ $(document).ready(function() {
                     (element.offset().top + element.height() >= $(window).scrollTop()));
             if (visible) {
                 func();
-                $(window).unbind('scroll', handler);
+                $(window).off('scroll', handler);
             }
         }
         $(window).on('scroll', handler);

--- a/asv/www/summarygrid.js
+++ b/asv/www/summarygrid.js
@@ -121,7 +121,7 @@ $(document).ready(function() {
         });
 
         summary_display.append(summary_container);
-        $(window).scroll();
+        $(window).trigger('scroll');
 
         summary_loaded = true;
     }

--- a/asv/www/summarylist.js
+++ b/asv/www/summarylist.js
@@ -408,7 +408,7 @@ $(document).ready(function() {
 
         table.stupidtable();
 
-        table.bind('aftertablesort', function (event, data) {
+        table.on('aftertablesort', function (event, data) {
             var info = $.asv.parse_hash_string(window.location.hash);
             info.params['sort'] = [data.column];
             info.params['dir'] = [data.direction];


### PR DESCRIPTION
Running with jQuery-migrate, there are only warnings about `bind`/`unbind` and event shortcuts. I have fixed them in the code here, though there are still some bits that trigger the deprecation in flot (which btw, seems a bit dead?). Based on my reading of the issues, these deprecations are _very_ long term, so the flot ones may not even be anything to worry about.

I tried clicking on everything I could and did not see any regressions. From what I understood of the changelog, the version bump was mostly internal (at least as far as what asv does with it.)

This depends on airspeed-velocity/asv-vendor#1