### PR TITLE
CLN: fix solve_potts_approx benchmark

### DIFF
--- a/benchmarks/step_detect.py
+++ b/benchmarks/step_detect.py
@@ -17,4 +17,4 @@ class Simple:
             step_detect.detect_regressions(self.y)
 
     def time_solve_potts_approx(self):
-        step_detect.solve_potts_approx(self.y, 0.3, p=1)
+        step_detect.solve_potts_approx(self.y, [1] * len(self.y), gamma=0.3)


### PR DESCRIPTION
API seems to have changed in `solve_potts_approx()` at some point, leading to a benchmark failure.