### PR TITLE
 BUG: change default timer to timeit.default_timer to fix resolution on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ New Features
 
 API Changes
 ^^^^^^^^^^^
+- Default timer changed from ``process_time()`` to
+  ``timeit.default_timer()`` to fix resolution issues on Windows.
+  Old behavior can be restored by setting ``Benchmark.timer = time.process_time``
 
 Bug Fixes
 ^^^^^^^^^

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -138,20 +138,17 @@ Timing benchmarks
 - ``timer``: The timing function to use, which can be any source of
   monotonically increasing numbers, such as `time.clock`, `time.time`
   or ``time.process_time``.  If it's not provided, it defaults to
-  ``time.process_time`` (or a backported version of it for versions of
-  Python prior to 3.3), but other useful values are
-  `timeit.default_timer` to use the default ``timeit`` behavior on
-  your version of Python.
+  ``timeit.default_timer``, but other useful values are
+  ``process_time``, for which ``asv`` provides a backported version for
+  versions of Python prior to 3.3.
 
-  On Windows, `time.clock` has microsecond granularity, but
-  `time.time`'s granularity is 1/60th of a second. On Unix,
-  `time.clock` has 1/100th of a second granularity, and `time.time` is
-  much more precise. On either platform, `timeit.default_timer`
-  measures wall clock time, not the CPU time. This means that other
-  processes running on the same computer may interfere with the
-  timing.  That's why the default of ``time.process_time``, which only
-  measures the time used by the current process, is often the best
-  choice.
+  .. versionchanged:: 0.4
+
+     Previously, the default timer measured process time, which was chosen
+     to minimize noise from other processes. However, on Windows, this is
+     only available at a resolution of 15.6ms, which is greater than the
+     recommended benchmark runtime of 10ms. Therefore, we default to the
+     highest resolution clock on any platform.
 
 The ``sample_time``, ``number``, ``repeat``, and ``timer`` attributes
 can be adjusted in the ``setup()`` routine, which can be useful for

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -266,11 +266,17 @@ stolen from IPython's `%timeit
 magic function.  This means that in most cases the benchmark function
 itself will be run many times to achieve accurate timing.
 
-The default timing function is `time.process_time` (POSIX
+The default timing function is `timeit.default_timer`, which uses the
+highest resolution clock available on a given platform to measure the
+elapsed wall time. This has the consequence of being more susceptible
+to noise from other processes, but the increase in resolution is more
+significant for shorter duration tests (particularly on Windows).
+
+Process timing is provided by the function `time.process_time` (POSIX
 ``CLOCK_PROCESS_CPUTIME``), which measures the CPU time used only by
 the current process.  You can change the timer by setting the
-benchmark's ``timer`` attribute, for example to `timeit.default_timer`
-to measure wall clock time.
+benchmark's ``timer`` attribute, for example to `time.process_time`
+to measure process time.
 
 .. note::
 


### PR DESCRIPTION
This PR closes #775 in two different ways:
- The clock used for determining the `number` of runs to target `sample_time` is `time.time()`, which has a resolution of `15.6ms` on Windows. This leads to a lot of error in the proper scaling and is clearly better off being a wall time measurement
- Additionally, we change the default for `Benchmark.timer` to `timeit.default_timer()`. This fixes the poor benchmark resolution on Windows

To see proof of the latter, we can run the following:
```
asv run HEAD^..HEAD --record-samples
```
When testing this change, be careful to not use `asv run` to iterate through commits as it uses `asv/benchmark.py` from HEAD. Instead, step through with `git` and the above command.

For our baseline, we see the following output in `asv`'s own benchmarks:
```
    "results": {
        "step_detect.Simple.time_detect_regressions": {
            "result": [
                0.125
            ],
            "samples": [
                [
                    0.125,
                    0.125,
                    0.125,
                    0.125,
                    0.125,
                    0.125,
                    0.125,
                    0.125,
                    0.125,
                    0.109375
                ]
            ],
            "stats": [
                {
                    "ci_99": [
                        0.109375,
                        0.125
                    ],
                    "max": 0.125,
                    "mean": 0.1234375,
                    "min": 0.109375,
                    "number": 1,
                    "q_25": 0.125,
                    "q_75": 0.125,
                    "repeat": 10,
                    "std": 0.0046875
                }
            ]
        },
        "step_detect.Simple.time_solve_potts_approx": {
            "result": [
                0.015625
            ],
            "samples": [
                [
                    0.015625,
                    0.0,
                    0.015625,
                    0.015625,
                    0.015625,
                    0.015625,
                    0.015625,
                    0.0,
                    0.015625,
                    0.015625
                ]
            ],
            "stats": [
                {
                    "ci_99": [
                        0.0,
                        0.015625
                    ],
                    "max": 0.015625,
                    "mean": 0.0125,
                    "min": 0.0,
                    "number": 1,
                    "q_25": 0.015625,
                    "q_75": 0.015625,
                    "repeat": 10,
                    "std": 0.006250000000000001
                }
            ]
        }
    },
```
As you can see, the quantization of `process_time()` on Windows is *very* clear.

And now with this PR:
```
    "results": {
        "step_detect.Simple.time_detect_regressions": {
            "result": [
                0.1247326135635376
            ],
            "samples": [
                [
                    0.12278103828430176,
                    0.1226201057434082,
                    0.13060903549194336,
                    0.1316690444946289,
                    0.1291341781616211,
                    0.12431907653808594,
                    0.1271800994873047,
                    0.12331914901733398,
                    0.1220710277557373,
                    0.12514615058898926
                ]
            ],
            "stats": [
                {
                    "ci_99": [
                        0.1220710277557373,
                        0.1316690444946289
                    ],
                    "max": 0.1316690444946289,
                    "mean": 0.12588489055633545,
                    "min": 0.1220710277557373,
                    "number": 1,
                    "q_25": 0.12291556596755981,
                    "q_75": 0.128645658493042,
                    "repeat": 10,
                    "std": 0.003353031858757166
                }
            ]
        },
        "step_detect.Simple.time_solve_potts_approx": {
            "result": [
                0.011478066444396973
            ],
            "samples": [
                [
                    0.011333942413330078,
                    0.011632919311523438,
                    0.011541128158569336,
                    0.011580944061279297,
                    0.011635065078735352,
                    0.01182699203491211,
                    0.011229991912841797,
                    0.011066913604736328,
                    0.011046171188354492,
                    0.01141500473022461
                ]
            ],
            "stats": [
                {
                    "ci_99": [
                        0.011046171188354492,
                        0.01182699203491211
                    ],
                    "max": 0.01182699203491211,
                    "mean": 0.011430907249450683,
                    "min": 0.011046171188354492,
                    "number": 1,
                    "q_25": 0.011255979537963867,
                    "q_75": 0.011619925498962402,
                    "repeat": 10,
                    "std": 0.0002458795224520173
                }
            ]
        }
    },
```

In both cases, we see that the standard deviations have decreased - in the latter case, they're reduced by 25x. This effect would be even more pronounced if the mean didn't happen to be close to the `process_time()` quantum.