### PR TITLE
Allow asv find to perform a bisection even if benchmark times out

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,8 @@ API Changes
 
 Bug Fixes
 ^^^^^^^^^
-- When an ``asv find`` step fails due to timeout, assume runtime equal to timeout to allow bisection to proceed
+- When an ``asv find`` step fails due to timeout, assume runtime equal to
+  timeout to allow bisection to proceed (#768)
 
 
 Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ API Changes
 
 Bug Fixes
 ^^^^^^^^^
+- When an ``asv find`` step fails due to timeout, assume runtime equal to timeout to allow bisection to proceed
+
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -144,6 +144,13 @@ class Find(Command):
 
             results[i] = result
 
+            if results[i] == [None]:
+                errcode = res.errcode[benchmark_name]
+                if errcode == util.TIMEOUT_RETCODE:
+                    # If we failed due to timeout, set runtime as the timeout
+                    # to prevent falling back to linear search
+                    results[i] = [benchmarks[benchmark_name]['timeout']]
+            
             return results[i]
 
         def non_null_results(*results):

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -94,6 +94,17 @@ def track_find_test(n):
 track_find_test.params = [1, 2]
 
 
+def time_find_test_timeout():
+    import asv_test_repo, time
+    if asv_test_repo.dummy_value[1] < 0:
+        time.sleep(100)
+
+time_find_test_timeout.timeout = 1.0
+time_find_test_timeout.repeat = 1
+time_find_test_timeout.number = 1
+time_find_test_timeout.warmup_time = 0
+
+
 def track_param_selection(a, b):
     return a + b
 

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -73,7 +73,7 @@ def test_discover_benchmarks(benchmarks_fixture):
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                                        regex='example')
     conf.branches = old_branches
-    assert len(b) == 35
+    assert len(b) == 36
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                               regex='time_example_benchmark_1')
@@ -106,7 +106,7 @@ def test_discover_benchmarks(benchmarks_fixture):
     assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1, 2, 3]
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
-    assert len(b) == 49
+    assert len(b) == 50
 
     assert 'named.OtherSuite.track_some_func' in b
 

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -12,21 +12,27 @@ import pytest
 from asv.util import check_output, which
 
 from . import tools
-from .tools import dummy_packages
-from .test_workflow import basic_conf
+from .test_workflow import generate_basic_conf
 
 
 WIN = (os.name == 'nt')
 
 
-def test_find(capfd, basic_conf):
-    tmpdir, local, conf, machine_file = basic_conf
+def test_find(capfd, tmpdir):
+    values = [
+        (None, None),
+        (1, 1),
+        (3, 1),
+        (None, 1),
+        (6, None),
+        (5, 1),
+        (6, 1),
+        (6, 1),
+        (6, 6),
+        (6, 6),
+    ]
 
-    if WIN and os.path.basename(sys.argv[0]).lower().startswith('py.test'):
-        # Multiprocessing in spawn mode can result to problems with py.test
-        # Find.run calls Setup.run in parallel mode by default
-        pytest.skip("Multiprocessing spawn mode on Windows not safe to run "
-                    "from py.test runner.")
+    tmpdir, local, conf, machine_file = generate_basic_conf(tmpdir, values=values, dummy_packages=False)
 
     # Test find at least runs
     tools.run_asv_with_conf(conf, 'find', "master~5..master", "params_examples.track_find_test",

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import sys
 import os
 from os.path import join
 
@@ -20,7 +21,7 @@ from asv import util
 from asv.commands.run import Run
 
 from . import tools
-from .tools import dummy_packages
+from .tools import dummy_packages, WIN
 from .test_workflow import basic_conf, generate_basic_conf
 
 
@@ -322,6 +323,12 @@ def test_env_matrix_value(basic_conf):
 
 def test_parallel(basic_conf, dummy_packages):
     tmpdir, local, conf, machine_file = basic_conf
+
+    if WIN and os.path.basename(sys.argv[0]).lower().startswith('py.test'):
+        # Multiprocessing in spawn mode can result to problems with py.test
+        # Find.run calls Setup.run in parallel mode by default
+        pytest.skip("Multiprocessing spawn mode on Windows not safe to run "
+                    "from py.test runner.")
 
     conf.matrix = {
         "req": dict(conf.matrix),


### PR DESCRIPTION
Resolves https://github.com/airspeed-velocity/asv/issues/623 by setting the step runtime == timeout, if and only if the failure is the result of a timeout.

This prevents falling back to a linear search on a benchmark that times out, which can take an extremely long time to iterate through in the cases I've encountered.