### PR TITLE
BUG: handle setup_cache correctly in `asv check`

### DIFF
--- a/test/benchmark/cache_examples.py
+++ b/test/benchmark/cache_examples.py
@@ -86,4 +86,3 @@ time_fail_second_run.number = 1
 time_fail_second_run.repeat = 1
 time_fail_second_run.warmup_time = 0
 time_fail_second_run.processes = 2
-

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -97,3 +97,9 @@ def track_bytes():
     return 1000000
 
 track_bytes.unit = "bytes"
+
+
+def track_wrong_number_of_args(a, b):
+    return 0
+
+track_wrong_number_of_args.params = [[1, 2]]

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -73,7 +73,7 @@ def test_discover_benchmarks(benchmarks_fixture):
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                                        regex='example')
     conf.branches = old_branches
-    assert len(b) == 29
+    assert len(b) == 30
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                               regex='time_example_benchmark_1')
@@ -106,7 +106,7 @@ def test_discover_benchmarks(benchmarks_fixture):
     assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1, 2, 3]
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
-    assert len(b) == 40
+    assert len(b) == 41
 
     assert 'named.OtherSuite.track_some_func' in b
 

--- a/test/test_check.py
+++ b/test/test_check.py
@@ -23,5 +23,6 @@ def test_check(capsys, basic_conf):
 
     text, err = capsys.readouterr()
 
-    assert re.search(r"cache_examples\.[A-Za-z]+\.track_[a-z]+: call: wrong number of arguments", text)
+    assert re.search(r"params_examples\.track_wrong_number_of_args: call: "
+                     r"wrong number of arguments.*: expected 1, has 2", text)
     assert text.count("wrong number of arguments") == 1


### PR DESCRIPTION
The number of arguments with setup_cache depends on whether it returns
None or not, hence, unless we run setup_cache (which asv check won't do)
we cannot know it.  So check a range instead.