### PR TITLE
allow specifying a conda environment file for dependency management

### DIFF
--- a/asv/config.py
+++ b/asv/config.py
@@ -41,6 +41,7 @@ class Config(object):
         self.regressions_thresholds = {}
         self.plugins = []
         self.conda_channels = []
+        self.conda_environment_file = None
         self.build_command = None
         self.install_command = None
         self.uninstall_command = None

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -124,11 +124,18 @@ class Conda(environment.Environment):
 
         log.info("Creating conda environment for {0}".format(self.name))
 
-        if not self._conda_environment_file:
+        if self._conda_environment_file:
+            # user-provided file
+            env_file = None
+            env_file_name = self._conda_environment_file
+        else:
             # create a temporary environment.yml file
             # and use that to generate the env for benchmarking
             env_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".yml")
-            try:
+            env_file_name = env_file.name
+
+        try:
+            if env_file is not None:
                 env_file.write('name: {0}\n'
                                'channels:\n'.format(self.name))
                 env_file.writelines(('   - %s\n' % ch for ch in self._conda_channels))
@@ -148,24 +155,19 @@ class Conda(environment.Environment):
 
                 env_file.close()
 
-                util.check_output([conda] + ['env', 'create', '-f', env_file.name,
-                                             '-p', self._path, '--force'])
-            except Exception as exc:
-                if os.path.isfile(env_file.name):
-                    with open(env_file.name, 'r') as f:
-                        text = f.read()
-                    log.info("conda env create failed: in {} with:\n{}".format(self._path, text))
-                raise
-            finally:
+            util.check_output([conda] + ['env', 'create', '-f', env_file_name,
+                                         '-p', self._path, '--force'])
+        except Exception:
+            if env_file is None:
+                log.info("conda env create failed: in {} with file {}".format(self._path, env_file_name))
+            elif os.path.isfile(env_file_name):
+                with open(env_file_name, 'r') as f:
+                    text = f.read()
+                log.info("conda env create failed: in {} with:\n{}".format(self._path, text))
+            raise
+        finally:
+            if env_file is not None:
                 os.unlink(env_file.name)
-        else:
-            try:
-                util.check_output([conda] + ['env', 'create', '-f', self._conda_environment_file,
-                                             '-p', self._path, '--force'])
-            except Exception as exc:
-                log.info("conda env create failed: in {} with environment file: {}".format(
-                    self._path, self._conda_environment_file))
-                raise
 
     def _get_requirements(self, conda):
         if self._requirements:

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -61,6 +61,10 @@
     // dependency packages in the specified order
     // "conda_channels": ["conda-forge", "defaults"],
 
+    // A conda environment file that is used for the dependencies instead of
+    // other dependencies mechanisms in this file.
+    // "conda_environment_file": "environment.yml",
+
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list or empty string indicates to just test against the default

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -61,8 +61,7 @@
     // dependency packages in the specified order
     // "conda_channels": ["conda-forge", "defaults"],
 
-    // A conda environment file that is used for the dependencies instead of
-    // other dependencies mechanisms in this file.
+    // A conda environment file that is used for environment creation.
     // "conda_environment_file": "environment.yml",
 
     // The matrix of dependencies to test.  Each key is the name of a

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -172,6 +172,16 @@ following:
   already be installed, and it will not be possible to benchmark
   multiple revisions of the project.
 
+``conda_environment_file``
+-------------------------
+A path to a ``conda`` environment file to use as source for the
+dependencies. For example::
+
+    "conda_environment_file": "environment.yml"
+
+Using this option will cause ``asv`` to ignore all other ways of
+specifying dependencies.
+
 ``conda_channels``
 ------------------
 A list of ``conda`` channel names (strings) to use in the provided

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -179,8 +179,14 @@ dependencies. For example::
 
     "conda_environment_file": "environment.yml"
 
-Using this option will cause ``asv`` to ignore all other ways of
-specifying dependencies.
+The environment file should generally install ``wheel`` and ``pip``,
+since those are required by the default Asv build commands.  If there
+are packages present in ``matrix``, an additional ``conda env update``
+call is used to install them after the environment is created.
+
+This option will cause ``asv`` to ignore the Python version in the
+environment creation, which is then assumed to be fixed by the
+environment file.
 
 ``conda_channels``
 ------------------

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -10,6 +10,7 @@ import six
 import pytest
 import json
 import shlex
+import tempfile
 
 from asv import config
 from asv import environment
@@ -300,6 +301,36 @@ def test_conda_pip_install(tmpdir, dummy_packages):
         output = env.run(
             ['-c', 'import asv_dummy_test_package_2 as p, sys; sys.stdout.write(p.__version__)'])
         assert output.startswith(six.text_type(env._requirements['pip+asv_dummy_test_package_2']))
+
+
+@pytest.mark.skipif((not HAS_CONDA), reason="Requires conda")
+def test_conda_environment_file(tmpdir, dummy_packages):
+    # test that we can install with pip into a conda environment.
+    conf = config.Config()
+
+    conf.env_dir = six.text_type(tmpdir.join("env"))
+
+    conf.environment_type = "conda"
+    conf.pythons = [PYTHON_VER1]
+    try:
+        env_file_name = tempfile.mkstemp(suffix=".yml")[1]
+        conf.conda_environment_file = env_file_name
+        with open(env_file_name, "w") as temp_environment_file:
+            temp_environment_file.write(
+                    'name: test_conda_envs\ndependencies:\n  - pip:\n    - asv_dummy_test_package_2')
+        environments = list(environment.get_environments(conf, None))
+
+        assert len(environments) == 1 * 1 * 1
+
+        for env in environments:
+            env.create()
+
+            output = env.run(
+                ['-c', 'import asv_dummy_test_package_2 as p, sys; sys.stdout.write(p.__version__)'])
+            assert output.startswith(six.text_type(DUMMY2_VERSIONS[1]))
+    finally:
+        if env_file_name:
+            os.remove(env_file_name)
 
 
 @pytest.mark.skipif((not HAS_CONDA), reason="Requires conda")

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -313,6 +313,9 @@ def test_conda_environment_file(tmpdir, dummy_packages):
     conf.environment_type = "conda"
     conf.pythons = [PYTHON_VER1]
     conf.conda_environment_file = env_file_name
+    conf.matrix = {
+        "asv_dummy_test_package_1": [DUMMY1_VERSION]
+    }
 
     environments = list(environment.get_environments(conf, None))
 
@@ -320,6 +323,10 @@ def test_conda_environment_file(tmpdir, dummy_packages):
 
     for env in environments:
         env.create()
+
+        output = env.run(
+            ['-c', 'import asv_dummy_test_package_1 as p, sys; sys.stdout.write(p.__version__)'])
+        assert output.startswith(six.text_type(DUMMY1_VERSION))
 
         output = env.run(
             ['-c', 'import asv_dummy_test_package_2 as p, sys; sys.stdout.write(p.__version__)'])


### PR DESCRIPTION
Fixes #372.

We have a complex project that is completely managed by conda and duplicating the whole environment section in asv's config makes the benchmarks less maintainable.

I'm not sure if it is acceptable that this configuration value goes around all the dependency management currently implemented in asv. However, projects using conda environment files are already most likely keeping track of all dependencies in that one file.