### PR TITLE
Add warning on publish if no branch was found.

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -171,6 +171,14 @@ class Publish(Command):
             for results in cls.iter_results(conf, repo, range_spec):
                 log.dot()
 
+                branches_for_commit = [branch for branch, commits in branches.items() if
+                                       results.commit_hash in commits]
+
+                # Print a warning message if we couldn't find the branch of a commit
+                if not len(branches_for_commit):
+                    msg = "Couldn't find %s in %s branches"
+                    log.warning(msg % (results.commit_hash, branches.keys()))
+
                 for key in results.get_result_keys(benchmarks):
                     b = benchmarks[key]
                     b_params = b['params']
@@ -184,10 +192,7 @@ class Publish(Command):
 
                     benchmark_names.add(key)
 
-                    for branch in [
-                        branch for branch, commits in branches.items()
-                        if results.commit_hash in commits
-                    ]:
+                    for branch in branches_for_commit:
                         cur_params = dict(results.params)
                         cur_params['branch'] = repo.get_branch_name(branch)
 


### PR DESCRIPTION
When the history has been modified (either with draft changesets in hg, or with commit rebasing in git), it is possible that no corresponding branch be found when publishing. There is no real way of automatically fixing the issue, so we at least have to log a warning.

However, it does not seem like there are tests for logs except the console tests for indentation, and I feel like this change warrants one. 
Do you have a preferred method of going about this?