### PR TITLE
BF: catch and log.debug func and exceptions caught while discovering source files for a func

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -304,13 +304,15 @@ def get_source_code(items):
     """
     Extract source code of given items, and concatenate and dedent it.
     """
+    from asv.console import log
     sources = []
     prev_class_name = None
 
     for func in items:
         try:
             lines, lineno = inspect.getsourcelines(func)
-        except TypeError:
+        except (TypeError, IOError) as exc:
+            log.debug("Cannot obtain source information for %s: %s", func, exc)
             continue
 
         if not lines:


### PR DESCRIPTION
In my case my run was failing while I was getting a cryptic traceback with "source code not available",
with only pdb session being possible to tell WTF:

	(Pdb) l 270
	265
	266  	def get_source_code(items):
	267  	    """
	268  	    Extract source code of given items, and concatenate and dedent it.
	269  	    """
	270  	    sources = []
	271  	    prev_class_name = None
	272
	273  	    for func in items:
	274  	        try:
	275  	            lines, lineno = inspect.getsourcelines(func)
	(Pdb)
	276  	        except TypeError:
	277  	            continue
	278  	        except:
	279  	            import pdb; pdb.set_trace()
	280
	281  ->	        if not lines:
	282  	            continue
	283
	284  	        src = "\n".join(line.rstrip() for line in lines)
	285  	        src = textwrap.dedent(src)
	286
	(Pdb) p inspect.getsourcelines(func)
	*** IOError: IOError("source code not available",)
	(Pdb) p func
	<function mem_absent_dataset at 0x7f3c753cbaa0>

and that mem_absent_dataset was picked up from .pyc files left behind from
another branch.  Since there were no .py it could not find source files.

I am not sure how to enable debug output (adding -v -v -v did not help), but I thought
it should be valuable to announce why source code introspection has failed.