### PR TITLE
Remove wheel_cache_size mentions, add retro-compatibility and a warning

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -110,7 +110,7 @@
     // `asv` will cache wheels of the recent builds in each
     // environment, making them faster to install next time.  This is
     // number of builds to keep, per environment.
-    // "wheel_cache_size": 0
+    // "build_cache_size": 0
 
     // The commits after which the regression search in `asv publish`
     // should start looking for regressions. Dictionary whose keys are

--- a/asv/config.py
+++ b/asv/config.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import sys
 
+from .console import log
 from . import util
 
 # TODO: Some verification of the config values
@@ -65,6 +66,10 @@ class Config(object):
 
     @classmethod
     def from_json(cls, d):
+        if 'wheel_cache_size' in d:
+            log.warning("`wheel_cache_size` has been renamed to `build_cache_size`. Update your `asv.conf.json` accordingly.")
+            d.setdefault('build_cache_size', d['wheel_cache_size'])
+
         conf = cls()
         conf.__dict__.update(d)
 

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -52,7 +52,7 @@ A benchmark suite directory has the following layout.  The
       <https://ccache.samba.org>`__ is able to cache and reuse many of
       the build products.
 
-    - ``wheels/``: If ``wheel_cache_size`` in ``asv.conf.json`` is set
+    - ``wheels/``: If ``build_cache_size`` in ``asv.conf.json`` is set
       to something other than 0, this contains `Wheels
       <https://pypi.python.org/pypi/wheel>`__ of the last N project
       builds for this environment.  In this way, if a build for a


### PR DESCRIPTION
These changes were forgotten in commit 57c4fe5c01ab445b1d152660c0684d432af71854, this will help reduce confusion due to this incompatible change in the public API.