### PR TITLE
Use pip install --force-reinstall flag

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -660,8 +660,10 @@ class Environment(object):
         """
         cmd = self._install_command
         if cmd is None:
-            # Run pip via python -m pip, avoids shebang length limit on Linux
-            cmd = ["python -mpip install {wheel_file}"]
+            # Run pip via python -m pip, avoids shebang length limit on Linux.
+            # Ensure --force-reinstall so that package being present e.g. on cwd
+            # does not mess things up.
+            cmd = ["python -mpip install --force-reinstall {wheel_file}"]
 
         if cmd:
             commit_name = repo.get_decorated_hash(commit_hash, 8)

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -66,7 +66,7 @@ Airspeed Velocity rebuilds the project as needed, using these commands.
 The defaults are::
 
   "install_command":
-  ["python -mpip install {wheel_file}"],
+  ["python -mpip install --force-reinstall {wheel_file}"],
 
   "uninstall_command":
   ["return-code=any python -mpip uninstall -y {project}"],


### PR DESCRIPTION
Under some conditions, pip appears to wrongly think the packages is
available in the environment, so tell it to install it always.

Closes #805

In the problematic case `asv run -v` says
```
·· Running 'xxx/python -mpip install /home/pauli/tmp/xxx/requests/.asv/env/a80b4bcff004e7d21aafa78a5932418b/asv-build-cache/9742da7f91f595796a412a8150aacc00191be039/requests-2.21.0-py2.py3-none-any.whl'
   OUTPUT -------->
   Requirement already satisfied: requests==2.21.0 from file:///xxx/requests/.asv/env/a80b4bcff004e7d21aafa78a5932418b/asv-build-cache/9742da7f91f595796a412a8150aacc00191be039/requests-2.21.0-py2.py3-none-any.whl in xxx/requests/.asv/env/a80b4bcff004e7d21aafa78a5932418b/project (2.21.0)
```
But I don't know precisely why this occurs (hence no test). However, adding the `--force-reinstall` flag appears to fix it.