### PR TITLE
Add a 'hide-legend' graph option

### DIFF
--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -21,8 +21,8 @@ $(document).ready(function() {
     var select_reference = false;
     /* The reference value */
     var reference = 1.0;
-    /* Whether to hide the legend */
-    var hide_legend = false;
+    /* Whether to show the legend */
+    var show_legend = true;
     /* Is even commit spacing being used? */
     var even_spacing = false;
     var even_spacing_revisions = [];
@@ -260,10 +260,9 @@ $(document).ready(function() {
             update_state_url({'x-axis-scale': date_scale ? ['date'] : []});
         });
         
-        $('#hide-legend').on('click', function(evt) {
-            hide_legend = !hide_legend;
-            
-            update_state_url({'hide-legend': hide_legend ? [true] : []});
+        $('#show-legend').on('click', function(evt) {
+            show_legend = !show_legend;
+            update_state_url({'show-legend': show_legend ? [] : [false]});
         });
 
         tooltip = $("<div></div>");
@@ -1186,7 +1185,7 @@ $(document).ready(function() {
                 mode: "x"
             },
             legend: {
-                show: !hide_legend,
+                show: show_legend,
                 position: "nw",
                 labelFormatter: function(label, series) {
                     // Ensure HTML escaping
@@ -1394,16 +1393,20 @@ $(document).ready(function() {
             delete params['x-axis-scale'];
         }
     
-        var hide_legend_button = $('#hide-legend')
-        if (params['hide-legend']) {
-            if (params['hide-legend'][0] === 'true') {
-                hide_legend_button.addClass('active');
-                hide_legend = true;
+        var show_legend_button = $('#show-legend')
+        if (params['show-legend']) {
+            if (params['show-legend'][0] === 'false') {
+                show_legend = false;
+                show_legend_button.removeClass('active');
             }
-            delete params['hide-legend'];
+            else {
+                show_legend_button.addClass('active');
+                show_legend = true;
+            }
+            delete params['show-legend'];
         }
         else {
-            hide_legend_button.removeClass('active');
+            show_legend_button.addClass('active');
         }
 
         if (Object.keys(params).length > 0) {

--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -21,6 +21,8 @@ $(document).ready(function() {
     var select_reference = false;
     /* The reference value */
     var reference = 1.0;
+    /* Whether to hide the legend */
+    var hide_legend = false;
     /* Is even commit spacing being used? */
     var even_spacing = false;
     var even_spacing_revisions = [];
@@ -256,6 +258,12 @@ $(document).ready(function() {
             even_spacing = false;
             $('#even-spacing').removeClass('active');
             update_state_url({'x-axis-scale': date_scale ? ['date'] : []});
+        });
+        
+        $('#hide-legend').on('click', function(evt) {
+            hide_legend = !hide_legend;
+            
+            update_state_url({'hide-legend': hide_legend ? [true] : []});
         });
 
         tooltip = $("<div></div>");
@@ -1178,6 +1186,7 @@ $(document).ready(function() {
                 mode: "x"
             },
             legend: {
+                show: !hide_legend,
                 position: "nw",
                 labelFormatter: function(label, series) {
                     // Ensure HTML escaping
@@ -1383,6 +1392,18 @@ $(document).ready(function() {
                 date_scale = true;
             }
             delete params['x-axis-scale'];
+        }
+    
+        var hide_legend_button = $('#hide-legend')
+        if (params['hide-legend']) {
+            if (params['hide-legend'][0] === 'true') {
+                hide_legend_button.addClass('active');
+                hide_legend = true;
+            }
+            delete params['hide-legend'];
+        }
+        else {
+            hide_legend_button.removeClass('active');
         }
 
         if (Object.keys(params).length > 0) {

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -141,10 +141,10 @@
                  title="Space commits by commit date along the x-axis">
                 date scale
               </a>
-              <a id="hide-legend" class="btn btn-default btn-xs" role="button"
+              <a id="show-legend" class="btn btn-default btn-xs" role="button"
                  data-toggle="tooltip" data-placement="right"
-                 title="Hide legend in the graph">
-                hide legend
+                 title="Show legend in the graph">
+                legend
               </a>
             </div>
           </div>

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -141,6 +141,11 @@
                  title="Space commits by commit date along the x-axis">
                 date scale
               </a>
+              <a id="hide-legend" class="btn btn-default btn-xs" role="button"
+                 data-toggle="tooltip" data-placement="right"
+                 title="Hide legend in the graph">
+                hide legend
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Legends of graphs with many lines can take up too much space,
this simple button will hide the graph legend on demand.