### PR TITLE
Add env variable matrix to pass to tests and build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 New Features
 ^^^^^^^^^^^^
+- ``env_matrix`` config value for adding environment variables to build and benchmark commands.
 
 API Changes
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 New Features
 ^^^^^^^^^^^^
-- ``env_matrix`` config value for adding environment variables to build and benchmark commands.
+- Adding environment variables to build and benchmark commands.
 
 API Changes
 ^^^^^^^^^^^

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -13,6 +13,7 @@ import datetime
 
 import six
 
+from asv.environment import get_test_env_vars
 from .console import log
 from . import util
 from . import runner
@@ -198,6 +199,7 @@ class Benchmarks(dict):
                          os.path.abspath(root),
                          os.path.abspath(result_file)],
                         cwd=result_dir,
+                        env=get_test_env_vars(env.env_vars_combination),
                         dots=False)
 
                     try:
@@ -228,6 +230,7 @@ class Benchmarks(dict):
                          os.path.abspath(root)],
                         cwd=result_dir,
                         dots=False,
+                        env=get_test_env_vars(env.env_vars_combination),
                         valid_return_codes=None,
                         return_stderr=True,
                         redirect_stderr=True)

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -13,8 +13,8 @@ import datetime
 
 import six
 
-from asv.environment import get_test_env_vars
 from .console import log
+from .environment import get_test_env_vars
 from . import util
 from . import runner
 from .repo import NoSuchNameError

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -14,7 +14,6 @@ import datetime
 import six
 
 from .console import log
-from .environment import get_test_env_vars
 from . import util
 from . import runner
 from .repo import NoSuchNameError
@@ -193,13 +192,16 @@ class Benchmarks(dict):
                 try:
                     env.install_project(conf, repo, commit_hash)
 
+                    env_vars = dict(os.environ)
+                    env_vars.update(env.env_vars)
+
                     result_file = os.path.join(result_dir, 'result.json')
                     env.run(
                         [runner.BENCHMARK_RUN_SCRIPT, 'discover',
                          os.path.abspath(root),
                          os.path.abspath(result_file)],
                         cwd=result_dir,
-                        env=get_test_env_vars(env.env_vars_combination),
+                        env=env_vars,
                         dots=False)
 
                     try:
@@ -230,7 +232,7 @@ class Benchmarks(dict):
                          os.path.abspath(root)],
                         cwd=result_dir,
                         dots=False,
-                        env=get_test_env_vars(env.env_vars_combination),
+                        env=env_vars,
                         valid_return_codes=None,
                         return_stderr=True,
                         redirect_stderr=True)

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -150,8 +150,7 @@ class Publish(Command):
                     params.setdefault(key, set())
                     params[key].add(val)
 
-                for key, val in six.iteritems(results.env_vars_combination):
-                    build_type, name = key
+                for name, val in six.iteritems(results.env_vars):
                     # Prefix them in case of name collision
                     env_vars["env-{}".format(name)].add(val)
 
@@ -204,9 +203,8 @@ class Publish(Command):
 
                     for branch in branches_for_commit:
                         cur_params = dict(results.params)
-                        cur_env = {'env-{}'.format(name): val for
-                                   (build_type, name), val in
-                                        six.iteritems(results.env_vars_combination)}
+                        cur_env = {'env-{}'.format(name): val
+                                   for name, val in six.iteritems(results.env_vars)}
                         cur_params.update(cur_env)
                         cur_params['branch'] = repo.get_branch_name(branch)
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -424,7 +424,7 @@ class Run(Command):
                             repo.get_date(commit_hash),
                             env.python,
                             env.name,
-                            env.env_vars_combination
+                            env.env_vars
                         )
 
                         if not skip_save:

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -423,7 +423,9 @@ class Run(Command):
                             commit_hash,
                             repo.get_date(commit_hash),
                             env.python,
-                            env.name)
+                            env.name,
+                            env.env_vars_combination
+                        )
 
                         if not skip_save:
                             result.load_data(conf.results_dir)

--- a/asv/config.py
+++ b/asv/config.py
@@ -14,25 +14,15 @@ from . import util
 
 
 def _flatten_env_matrix(env_matrix):
-    if not env_matrix:
-        return env_matrix
+    m = dict(env_matrix)
+    build = m.pop("build", {})
+    non_build = m.pop("non_build", {})
 
-    build = env_matrix.get("build")
-    non_build = env_matrix.get("non_build")
-
-    if build is None and non_build is None:
+    if m:
         raise util.UserError(
-            "Invalid `env_matrix`: "
-            "{} "
-            "at least one of `build` or `non_build` "
-            "should be defined. "
-            "Check your `asv.conf.json`.".format(env_matrix)
-        )
-
-    if build is None:
-        build = {}
-    if non_build is None:
-        non_build = {}
+            "Invalid `env_matrix`: {!r}\n"
+            "Unknown keys: {!r}\n"
+            "Check your `asv.conf.json`.".format(env_matrix, m.keys()))
 
     merged = {('build', var): values for var, values in build.items()}
     merged.update(

--- a/asv/config.py
+++ b/asv/config.py
@@ -13,25 +13,6 @@ from . import util
 # TODO: Some verification of the config values
 
 
-def _flatten_env_matrix(env_matrix):
-    m = dict(env_matrix)
-    build = m.pop("build", {})
-    non_build = m.pop("non_build", {})
-
-    if m:
-        raise util.UserError(
-            "Invalid `env_matrix`: {!r}\n"
-            "Unknown keys: {!r}\n"
-            "Check your `asv.conf.json`.".format(env_matrix, m.keys()))
-
-    merged = {('build', var): values for var, values in build.items()}
-    merged.update(
-        {('non_build', var): values for var, values in non_build.items()}
-    )
-
-    return merged
-
-
 class Config(object):
     """
     Manages the configuration for a benchmark project.
@@ -104,9 +85,5 @@ class Config(object):
             # be listed.
             raise util.UserError(
                 "No branches specified in config file.")
-
-        env_matrix = getattr(conf, "env_matrix", None)
-        if env_matrix:
-            conf.env_matrix = _flatten_env_matrix(env_matrix)
 
         return conf

--- a/asv/config.py
+++ b/asv/config.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, print_function,
 
 import os
 import sys
-from collections import defaultdict
 
 from .console import log
 from . import util
@@ -14,7 +13,7 @@ from . import util
 # TODO: Some verification of the config values
 
 
-def flatten_env_matrix(env_matrix):
+def _flatten_env_matrix(env_matrix):
     if not env_matrix:
         return env_matrix
 
@@ -41,15 +40,6 @@ def flatten_env_matrix(env_matrix):
     )
 
     return merged
-
-
-def normalize_env_matrix(env_matrix):
-    result = defaultdict(dict)
-
-    for (env_type, var_name), values in env_matrix.items():
-        result[env_type][var_name] = values
-
-    return result
 
 
 class Config(object):
@@ -127,6 +117,6 @@ class Config(object):
 
         env_matrix = getattr(conf, "env_matrix", None)
         if env_matrix:
-            conf.env_matrix = flatten_env_matrix(env_matrix)
+            conf.env_matrix = _flatten_env_matrix(env_matrix)
 
         return conf

--- a/asv/config.py
+++ b/asv/config.py
@@ -30,7 +30,6 @@ class Config(object):
         self.exclude = []
         self.include = []
         self.env_dir = "env"
-        self.env_matrix = {}
         self.benchmark_dir = "benchmarks"
         self.results_dir = "results"
         self.html_dir = "html"

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -327,13 +327,10 @@ def get_environments(conf, env_specifiers, verbose=True):
             # Ignore requirement matrix
             requirements_iter = [dict(python=python) for python in pythons]
 
-        env_matrix_combinations = iter_env_matrix_combinations(conf.env_matrix)
-
-        if not env_matrix_combinations:
-            env_matrix_combinations = [{}]
-
         for requirements in requirements_iter:
             python = requirements.pop('python')
+
+            env_matrix_combinations = iter_env_matrix_combinations(conf.env_matrix)
 
             for combination in env_matrix_combinations:
                 try:

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -9,7 +9,6 @@ import tempfile
 
 import six
 
-from asv.environment import get_build_env_vars
 from .. import environment
 from ..console import log
 from .. import util
@@ -60,7 +59,7 @@ class Conda(environment.Environment):
     tool_name = "conda"
     _matches_cache = {}
 
-    def __init__(self, conf, python, requirements, env_vars_combination):
+    def __init__(self, conf, python, requirements, tagged_env_vars):
         """
         Parameters
         ----------
@@ -80,7 +79,7 @@ class Conda(environment.Environment):
         super(Conda, self).__init__(conf,
                                     python,
                                     requirements,
-                                    env_vars_combination)
+                                    tagged_env_vars)
 
     @classmethod
     def matches(cls, python):
@@ -129,7 +128,8 @@ class Conda(environment.Environment):
         log.info("Creating conda environment for {0}".format(self.name))
 
         conda_args, pip_args = self._get_requirements(conda)
-        env = get_build_env_vars(self.env_vars_combination)
+        env = dict(os.environ)
+        env.update(self.build_env_vars)
 
         if not self._conda_environment_file:
             # The user-provided env file is assumed to set the python version

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -9,6 +9,7 @@ import tempfile
 
 import six
 
+from asv.environment import get_build_env_vars
 from .. import environment
 from ..console import log
 from .. import util
@@ -59,7 +60,7 @@ class Conda(environment.Environment):
     tool_name = "conda"
     _matches_cache = {}
 
-    def __init__(self, conf, python, requirements):
+    def __init__(self, conf, python, requirements, env_vars_combination):
         """
         Parameters
         ----------
@@ -76,7 +77,10 @@ class Conda(environment.Environment):
         self._requirements = requirements
         self._conda_channels = conf.conda_channels
         self._conda_environment_file = conf.conda_environment_file
-        super(Conda, self).__init__(conf, python, requirements)
+        super(Conda, self).__init__(conf,
+                                    python,
+                                    requirements,
+                                    env_vars_combination)
 
     @classmethod
     def matches(cls, python):
@@ -125,6 +129,7 @@ class Conda(environment.Environment):
         log.info("Creating conda environment for {0}".format(self.name))
 
         conda_args, pip_args = self._get_requirements(conda)
+        env = get_build_env_vars(self.env_vars_combination)
 
         if not self._conda_environment_file:
             # The user-provided env file is assumed to set the python version
@@ -152,13 +157,15 @@ class Conda(environment.Environment):
             try:
                 env_file_name = self._conda_environment_file or env_file.name
                 util.check_output([conda] + ['env', 'create', '-f', env_file_name,
-                                             '-p', self._path, '--force'])
+                                             '-p', self._path, '--force'], 
+                                  env=env)
 
                 if self._conda_environment_file and (conda_args or pip_args):
                     # Add extra packages
                     env_file_name = env_file.name
                     util.check_output([conda] + ['env', 'update', '-f', env_file_name,
-                                                 '-p', self._path])
+                                                 '-p', self._path],
+                                      env=env)
             except Exception:
                 if env_file_name != env_file.name:
                     log.info("conda env create/update failed: in {} with file {}".format(self._path, env_file_name))

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -24,7 +24,7 @@ class Virtualenv(environment.Environment):
     """
     tool_name = "virtualenv"
 
-    def __init__(self, conf, python, requirements, env_vars_combination):
+    def __init__(self, conf, python, requirements, tagged_env_vars):
         """
         Parameters
         ----------
@@ -51,7 +51,7 @@ class Virtualenv(environment.Environment):
         super(Virtualenv, self).__init__(conf,
                                          python,
                                          requirements,
-                                         env_vars_combination)
+                                         tagged_env_vars)
 
         try:
             import virtualenv
@@ -103,7 +103,7 @@ class Virtualenv(environment.Environment):
         return environment.get_env_name(self.tool_name,
                                         python,
                                         self._requirements,
-                                        self.env_vars_combination)
+                                        self.env_vars)
 
     @classmethod
     def matches(self, python):
@@ -133,6 +133,9 @@ class Virtualenv(environment.Environment):
         Then, all of the requirements are installed into
         it using `pip install`.
         """
+        env = dict(os.environ)
+        env.update(self.build_env_vars)
+
         log.info("Creating virtualenv for {0}".format(self.name))
         util.check_call([
             sys.executable,
@@ -140,7 +143,7 @@ class Virtualenv(environment.Environment):
             '--no-site-packages',
             "-p",
             self._executable,
-            self._path])
+            self._path], env=env)
 
         log.info("Installing requirements for {0}".format(self.name))
         self._install_requirements()
@@ -151,13 +154,16 @@ class Virtualenv(environment.Environment):
         else:
             pip_args = ['install', '-v', 'wheel', 'pip>=8']
 
-        if 'COV_CORE_SOURCE' in os.environ:
+        env = dict(os.environ)
+        env.update(self.build_env_vars)
+
+        if 'COV_CORE_SOURCE' in env:
             # To measure coverage of ASV parts run in a subprocess from
             # a temporary virtual environment an interpreter hook needs
             # to be installed for that environment.
             pip_args.append('pytest-cov')
 
-        self._run_pip(pip_args)
+        self._run_pip(pip_args, env=env)
 
         if self._requirements:
             args = ['install', '-v', '--upgrade']
@@ -170,7 +176,7 @@ class Virtualenv(environment.Environment):
                     args.append("{0}=={1}".format(pkg, val))
                 else:
                     args.append(pkg)
-            self._run_pip(args, timeout=self._install_timeout)
+            self._run_pip(args, timeout=self._install_timeout, env=env)
 
     def _run_pip(self, args, **kwargs):
         # Run pip via python -m pip, so that it works on Windows when

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -24,7 +24,7 @@ class Virtualenv(environment.Environment):
     """
     tool_name = "virtualenv"
 
-    def __init__(self, conf, python, requirements):
+    def __init__(self, conf, python, requirements, env_vars_combination):
         """
         Parameters
         ----------
@@ -48,7 +48,10 @@ class Virtualenv(environment.Environment):
         self._executable = executable
         self._python = python
         self._requirements = requirements
-        super(Virtualenv, self).__init__(conf, python, requirements)
+        super(Virtualenv, self).__init__(conf,
+                                         python,
+                                         requirements,
+                                         env_vars_combination)
 
         try:
             import virtualenv
@@ -97,7 +100,10 @@ class Virtualenv(environment.Environment):
         if self._python.startswith('pypy'):
             # get_env_name adds py-prefix
             python = python[2:]
-        return environment.get_env_name(self.tool_name, python, self._requirements)
+        return environment.get_env_name(self.tool_name,
+                                        python,
+                                        self._requirements,
+                                        self.env_vars_combination)
 
     @classmethod
     def matches(self, python):

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -103,7 +103,7 @@ class Virtualenv(environment.Environment):
         return environment.get_env_name(self.tool_name,
                                         python,
                                         self._requirements,
-                                        self.env_vars)
+                                        self._tagged_env_vars)
 
     @classmethod
     def matches(self, python):

--- a/asv/results.py
+++ b/asv/results.py
@@ -16,8 +16,8 @@ import datetime
 import six
 from six.moves import zip as izip
 
-from asv.config import flatten_env_matrix, normalize_env_matrix
 from . import environment
+from .config import flatten_env_matrix, normalize_env_matrix
 from .console import log
 from .machine import Machine
 from . import statistics

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -230,10 +230,7 @@ def run_benchmarks(benchmarks, env, results=None,
     else:
         previous_result_keys = set()
 
-    log.info("Benchmarking {0} with env {1}".format(
-        env.name,
-        env.env_vars
-    ))
+    log.info("Benchmarking {0}".format(env.name))
 
     partial_info_time = None
     indent = log.indent()

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -21,8 +21,8 @@ import traceback
 
 import six
 
-from asv.environment import get_build_env_vars, get_test_env_vars
 from .console import log
+from .environment import get_build_env_vars, get_test_env_vars
 from .results import Results, format_benchmark_result
 from . import statistics
 from . import util

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -74,30 +74,22 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     //
+    // The ``@env`` and ``@env_nobuild`` keys contain the matrix of environment
+    // variables to pass to build and benchmark commands.
+    // An environment will be created for every combination of the cartesian
+    // product of the "@env" variables in this matrix.
+    // Variables in "@env_nobuild" will be passed to every environment during the
+    // benchmark phase, but will not trigger creation of new environments.
+    // A value of ``null`` means that the variable will not be set for the
+    // current combination.
+    //
     // "matrix": {
     //     "numpy": ["1.6", "1.7"],
     //     "six": ["", null],        // test with and without six installed
     //     "pip+emcee": [""],   // emcee is only available for install with pip.
+    //     "@env": {"ENV_VAR_1": ["val1", "val2"]},
+    //     "@env_nobuild": {"ENV_VAR_2": ["val3", null]},
     // },
-
-
-    // The matrix of environment variables to pass to build and test commands.
-    // An environment will be created for every combination of the cartesian
-    // product of the "build" variables in this matrix.
-    //
-    //    "env_matrix": {
-    //        "build": {
-    //            "ENV_VAR_1": ["val1", "val2"],
-    //            "ENV_VAR_2": ["val3", null],
-    //        },
-    //        "no_build": {
-    //            "ENV_VAR_3": ["val4", "val5"],
-    //        }
-    //    }
-    // Variables in "no_build" will be passed to every environment during the
-    // test phase, but will not trigger a new build.
-    // A value of ``null`` means that the variable will not be set for the
-    // current combination.
 
     // Combinations of libraries/python versions can be excluded/included
     // from the set to test. Each entry is a dictionary containing additional
@@ -119,15 +111,20 @@
     // - sys_platform
     //     Platform, as in sys.platform. Possible values for the common
     //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    // - @env
+    //     Environment variables
+    // - @env_nobuild
+    //     Non-build environment variables
     //
     // "exclude": [
     //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
     //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    //     {"@env": {"ENV_VAR_1": "val2"}}, // skip val2 for ENV_VAR_1
     // ],
     //
     // "include": [
     //     // additional env for python2.7
-    //     {"python": "2.7", "numpy": "1.8"},
+    //     {"python": "2.7", "numpy": "1.8", "@env_nobuild": {"FOO": "123"}},
     //     // additional env if run on windows+conda
     //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
     // ],

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -80,6 +80,25 @@
     //     "pip+emcee": [""],   // emcee is only available for install with pip.
     // },
 
+
+    // The matrix of environment variables to pass to build and test commands.
+    // An environment will be created for every combination of the cartesian
+    // product of the "build" variables in this matrix.
+    //
+    //    "env_matrix": {
+    //        "build": {
+    //            "ENV_VAR_1": ["val1", "val2"],
+    //            "ENV_VAR_2": ["val3", null],
+    //        },
+    //        "no_build": {
+    //            "ENV_VAR_3": ["val4", "val5"],
+    //        }
+    //    }
+    // Variables in "no_build" will be passed to every environment during the
+    // test phase, but will not trigger a new build.
+    // A value of ``null`` means that the variable will not be set for the
+    // current combination.
+
     // Combinations of libraries/python versions can be excluded/included
     // from the set to test. Each entry is a dictionary containing additional
     // key-value pairs to include/exclude.

--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -827,7 +827,16 @@ $(document).ready(function() {
         var to_load = collect_graphs(current_benchmark, state, benchmark_param_selection);
         var failures = 0;
         var count = 1;
-
+        
+        if (to_load.length === 0) {
+            $('#main-graph').html("<div style='display: flex;" +
+                "justify-content: center;" +
+                " align-items: center; height: 100%;'>" +
+                "<p style='font-size: 2rem;'>No graphs to load.</p>" +
+                "</div>")
+            return
+        }
+    
         current_revisions = [];
         $.each(to_load, function(i, item) {
             $.asv.load_graph_data(

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -234,6 +234,52 @@ the project being benchmarked may specify in its ``setup.py`` file.
     name with ``pip+``. For example, ``emcee`` is only available from ``pip``,
     so the package name to be used is ``pip+emcee``.
 
+
+``env_matrix``
+--------------
+
+Defines a matrix of environment variables to pass to build and test commands.
+An environment will be created for every combination of the cartesian
+product of the "build" variables in this matrix::
+
+    "env_matrix": {
+        "build": {
+            "ENV_VAR_1": ["val1", "val2"],
+            "ENV_VAR_2": ["val3", null],
+        },
+        "no_build": {
+            "ENV_VAR_3": ["val4", "val5"],
+        }
+    }
+
+
+Variables in "no_build" will be passed to every environment during the test
+phase, but will not trigger a new build.
+A value of ``null`` means that the variable will not be set for the current
+combination.
+
+The above matrix will result in 4 different builds with the following
+additional environment variables and values:
+
+  - [("ENV_VAR_1", "val1"), ("ENV_VAR_2", "val3")]
+  - [("ENV_VAR_1", "val1")]
+  - [("ENV_VAR_1", "val2"), ("ENV_VAR_2", "val3")]
+  - [("ENV_VAR_1", "val2")]
+
+It will generate 8 different test environments based on those 4 builds with
+the following environment variables and values:
+
+  - [("ENV_VAR_1", "val1"), ("ENV_VAR_2", "val3"), ("ENV_VAR_3", "val4")]
+  - [("ENV_VAR_1", "val1"), ("ENV_VAR_2", "val3"), ("ENV_VAR_3", "val5")]
+  - [("ENV_VAR_1", "val1"), ("ENV_VAR_3", "val4")]
+  - [("ENV_VAR_1", "val1"), ("ENV_VAR_3", "val5")]
+  - [("ENV_VAR_1", "val2"), ("ENV_VAR_2", "val3"), ("ENV_VAR_3", "val4")]
+  - [("ENV_VAR_1", "val2"), ("ENV_VAR_2", "val3"), ("ENV_VAR_3", "val5")]
+  - [("ENV_VAR_1", "val2"), ("ENV_VAR_3", "val4")]
+  - [("ENV_VAR_1", "val2"), ("ENV_VAR_3", "val5")]
+
+
+
 ``exclude``
 -----------
 Combinations of libraries, Python versions, or platforms to be

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -35,7 +35,8 @@ A benchmark suite directory has the following layout.  The
     reasonable limits.
 
     - ``asv-env-info.json``: Contains information about the
-      environment, mainly the Python version and dependencies used.
+      environment, mainly the Python version, dependencies and
+      build environment variables used.
 
     - ``project/``: An environment-specific clone of the project
       repository.  Each environment has its own clone so that builds

--- a/docs/source/env_vars.rst
+++ b/docs/source/env_vars.rst
@@ -1,5 +1,5 @@
 ASV environment variables
--------------------------
+=========================
 
 Benchmarking and build commands are run with the following environment
 variables available:
@@ -24,3 +24,10 @@ behavior are also set:
 - ``PIP_USER``: ``false``
 - ``PYTHONNOUSERSITE``: ``True`` (for conda environments only)
 - ``PYTHONPATH``: unset (if really needed, can be overridden by setting ``ASV_PYTHONPATH``)
+
+
+Custom environment variables
+----------------------------
+
+You can send custom environment variables to build and benchmarking commands
+by configuring the ``env_matrix`` setting in ``asv.conf.json``.

--- a/docs/source/env_vars.rst
+++ b/docs/source/env_vars.rst
@@ -30,4 +30,4 @@ Custom environment variables
 ----------------------------
 
 You can send custom environment variables to build and benchmarking commands
-by configuring the ``env_matrix`` setting in ``asv.conf.json``.
+by configuring the ``matrix`` setting in ``asv.conf.json``.

--- a/test/benchmark/time_secondary.py
+++ b/test/benchmark/time_secondary.py
@@ -4,7 +4,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import os
 import sys
+
 if sys.version_info[0] == 3:
     xrange = range
 
@@ -46,3 +48,11 @@ def track_value():
 
 def test_shared_code():
     assert shared_function() == 42
+
+
+def track_environment_value():
+    v = os.environ.get('SOME_TEST_VAR', '0')
+    try:
+        return int(v)
+    except (ValueError, TypeError):
+        return 0

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -66,7 +66,7 @@ def test_discover_benchmarks(benchmarks_fixture):
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                                        regex='secondary')
-    assert len(b) == 3
+    assert len(b) == 4
 
     old_branches = conf.branches
     conf.branches = ["master", "some-missing-branch"]  # missing branches ignored
@@ -106,7 +106,7 @@ def test_discover_benchmarks(benchmarks_fixture):
     assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1, 2, 3]
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
-    assert len(b) == 46
+    assert len(b) == 47
 
     assert 'named.OtherSuite.track_some_func' in b
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -128,8 +128,8 @@ def test_presence_checks(tmpdir):
         env.run(['-c', 'import os'])
 
 
-def _sorted(lst):
-    return list(sorted(lst, key=repr))
+def _sorted_dict_list(lst):
+    return list(sorted(lst, key=lambda x: list(sorted(x.items()))))
 
 
 def test_matrix_expand_basic():
@@ -144,9 +144,9 @@ def test_matrix_expand_basic():
         'pkg5': []
     }
 
-    combinations = _sorted(environment.iter_matrix(
+    combinations = _sorted_dict_list(environment.iter_matrix(
         conf.environment_type, conf.pythons, conf))
-    expected = _sorted([
+    expected = _sorted_dict_list([
         {('python', None): '2.6', ('req', 'pkg2'): '', ('req', 'pkg3'): '',
          ('req', 'pkg4'): '1.2', ('req', 'pkg5'): ''},
         {('python', None): '2.6', ('req', 'pkg2'): '', ('req', 'pkg3'): '',
@@ -172,9 +172,9 @@ def test_matrix_expand_include():
         {'environment_type': 'something', 'python': '2.7', 'b': '5'},
     ]
 
-    combinations = _sorted(environment.iter_matrix(
+    combinations = _sorted_dict_list(environment.iter_matrix(
         conf.environment_type, conf.pythons, conf))
-    expected = _sorted([
+    expected = _sorted_dict_list([
         {('python', None): '2.6', ('req', 'a'): '1'},
         {('python', None): '3.5', ('req', 'b'): '2'},
         {('python', None): '2.7', ('req', 'b'): '3'},
@@ -199,9 +199,9 @@ def test_matrix_expand_include_detect_env_type():
         {'sys_platform': sys.platform, 'python': PYTHON_VER1},
     ]
 
-    combinations = _sorted(environment.iter_matrix(
+    combinations = _sorted_dict_list(environment.iter_matrix(
         conf.environment_type, conf.pythons, conf))
-    expected = _sorted([
+    expected = _sorted_dict_list([
         {('python', None): PYTHON_VER1},
     ])
     assert combinations == expected
@@ -225,9 +225,9 @@ def test_matrix_expand_exclude():
         {'python': '2.7', 'b': None},
         {'python': '2.6', 'a': '1'},
     ]
-    combinations = _sorted(environment.iter_matrix(
+    combinations = _sorted_dict_list(environment.iter_matrix(
         conf.environment_type, conf.pythons, conf))
-    expected = _sorted([
+    expected = _sorted_dict_list([
         {('python', None): '2.7', ('req', 'a'): '1', ('req', 'b'): '1'},
         {('python', None): '2.7', ('req', 'b'): '2'}
     ])
@@ -237,9 +237,9 @@ def test_matrix_expand_exclude():
     conf.exclude = [
         {'python': '.*', 'b': None},
     ]
-    combinations = _sorted(environment.iter_matrix(
+    combinations = _sorted_dict_list(environment.iter_matrix(
         conf.environment_type, conf.pythons, conf))
-    expected = _sorted([
+    expected = _sorted_dict_list([
         {('python', None): '2.6', ('req', 'a'): '1', ('req', 'b'): '1'},
         {('python', None): '2.7', ('req', 'a'): '1', ('req', 'b'): '1'},
         {('python', None): '2.7', ('req', 'b'): '2'}
@@ -250,7 +250,7 @@ def test_matrix_expand_exclude():
     conf.exclude = [
         {'environment_type': 'some.*'},
     ]
-    combinations = _sorted(environment.iter_matrix(
+    combinations = _sorted_dict_list(environment.iter_matrix(
         conf.environment_type, conf.pythons, conf))
     expected = [
         {('python', None): '2.7', ('req', 'b'): '2'}
@@ -261,7 +261,7 @@ def test_matrix_expand_exclude():
     conf.exclude = [
         {'sys_platform': sys.platform},
     ]
-    combinations = _sorted(environment.iter_matrix(
+    combinations = _sorted_dict_list(environment.iter_matrix(
         conf.environment_type, conf.pythons, conf))
     expected = [
         {('python', None): '2.7', ('req', 'b'): '2'}
@@ -272,9 +272,9 @@ def test_matrix_expand_exclude():
     conf.exclude = [
         {'python': '(?!2.6).*'}
     ]
-    combinations = _sorted(environment.iter_matrix(
+    combinations = _sorted_dict_list(environment.iter_matrix(
         conf.environment_type, conf.pythons, conf))
-    expected = _sorted([
+    expected = _sorted_dict_list([
         {('python', None): '2.6', ('req', 'a'): '1', ('req', 'b'): '1'},
         {('python', None): '2.6', ('req', 'a'): '1'},
         {('python', None): '2.7', ('req', 'b'): '2'}
@@ -310,8 +310,8 @@ def test_iter_env_matrix_combinations():
                     for item in expected]
         for m in expected:
             m['python', None] = "2.6"
-        result = _sorted(environment.iter_matrix(conf.environment_type, conf.pythons, conf))
-        assert result == _sorted(expected)
+        result = _sorted_dict_list(environment.iter_matrix(conf.environment_type, conf.pythons, conf))
+        assert result == _sorted_dict_list(expected)
 
 
 @pytest.mark.skipif((not HAS_CONDA), reason="Requires conda")
@@ -886,7 +886,7 @@ def test__parse_exclude_include_rule():
     ]
     for rule, expected in cases:
         parsed = environment._parse_exclude_include_rule(rule)
-        assert _sorted(parsed) == _sorted(expected)
+        assert parsed == expected
 
 
 def test__parse_matrix_entries():

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -13,6 +13,8 @@ import json
 from asv import config
 from asv import environment
 from asv import util
+from asv.config import flatten_env_matrix, normalize_env_matrix
+from asv.environment import iter_env_matrix_combinations
 from asv.repo import get_repo
 from asv.util import shlex_quote as quote
 
@@ -275,6 +277,118 @@ def test_matrix_expand_exclude():
         {'python': '2.7', 'b': '2'}
     ])
     assert combinations == expected
+
+
+@pytest.mark.parametrize(
+    ['env_matrix', 'expected'],
+    [
+        pytest.param(
+            {
+                'var0': ['val0', 'val1'],
+                'var1': ['val2', 'val3'],
+            },
+            [
+                {
+                    'var0': 'val0',
+                    'var1': 'val2',
+                },
+                {
+                    'var0': 'val0',
+                    'var1': 'val3',
+                },
+                {
+                    'var0': 'val1',
+                    'var1': 'val2',
+                },
+                {
+                    'var0': 'val1',
+                    'var1': 'val3',
+                },
+            ],
+            id="Basic combination"
+        ),
+        pytest.param(
+            {
+                'var0': ['val0', 'val1'],
+                'var1': ['val2', None],
+            },
+            [
+                {
+                    'var0': 'val0',
+                    'var1': 'val2',
+                },
+                {
+                    'var0': 'val0',
+                },
+                {
+                    'var0': 'val1',
+                    'var1': 'val2',
+                },
+                {
+                    'var0': 'val1',
+                },
+            ],
+            id="None variable"
+        ),
+        pytest.param(
+            {
+                'var0': ['val0', 'val1'],
+            },
+            [
+                {
+                    'var0': 'val0',
+                },
+                {
+                    'var0': 'val1',
+                },
+            ],
+            id="Single variable"
+        ),
+        pytest.param(
+            {},
+            [{}],
+            id="Empty matrix"
+        ),
+    ]
+)
+def test_successful_env_matrix(env_matrix, expected):
+    result = _sorted_dict_list(iter_env_matrix_combinations(env_matrix))
+    assert result == _sorted_dict_list(expected)
+
+
+expected_error_message = "Invalid value in `env_matrix`: " \
+                         "values should be non-empty lists. " \
+                         "Check your `asv.conf.json`."
+
+
+@pytest.mark.parametrize(
+    ['env_matrix', 'exception', 'exception_message'],
+    [
+        pytest.param(
+            {
+                'key': None
+            },
+            util.UserError,
+            expected_error_message,
+            id="None value"
+        ),
+        pytest.param(
+            {
+                'key': []
+            },
+            util.UserError,
+            expected_error_message,
+            id="Empty value"
+        ),
+    ]
+)
+def test_invalid_env_matrix(env_matrix, exception, exception_message):
+    with pytest.raises(exception) as exc_info:
+        list(iter_env_matrix_combinations(env_matrix))
+
+    # Don't assert inside the `pytest.raises` in case
+    # we try to catch an assertion error
+    assert exception_message in str(exc_info.value)
 
 
 @pytest.mark.skipif((not HAS_CONDA), reason="Requires conda")
@@ -783,3 +897,168 @@ def test_install_success(tmpdir):
     env.install_project(conf, repo, commit_hash)
 
     env.run(['-c', 'import asv_test_repo as t, sys; sys.exit(0 if t.dummy_value == 0 else 1)'])
+
+
+@pytest.mark.parametrize(
+    ['build_vars', 'non_build_vars', 'environ_count', 'build_count'],
+    [
+        pytest.param(
+            {},
+            {},
+            1,
+            1,
+            id="Empty matrix"
+        ),
+        pytest.param(
+            {"var1": ["val1"]},
+            {},
+            1,
+            1,
+            id="One variable, one value"
+        ),
+        pytest.param(
+            {"var1": ["val1", "val2", "val3"]},
+            {},
+            3,
+            3,
+            id="One variable, multiple values"
+        ),
+        pytest.param(
+            {"var1": ["val1", "val2"], "var2": ['val3', 'val4']},
+            {},
+            4,
+            4,
+            id="Two variables, two values each."
+        ),
+        pytest.param(
+            {"var1": ["val1", "val2"], "var2": ['val3', None]},
+            {},
+            4,
+            4,
+            id="Two variables, two values each with one `None`."
+        ),
+        pytest.param(
+            {"var1": ["val1", "val2"]},
+            {"var2": ['val3', None]},
+            4,
+            2,
+            id="One build, one non_build, two values each with one `None`."
+        ),
+        pytest.param(
+            {"var1": ["val1", "val2"], "var2": ['val3', 'val4']},
+            {"var3": ['val5', None]},
+            8,
+            4,
+            id="Two build, one non_build, two values each, one `None`."
+        ),
+    ]
+)
+def test_environment_env_matrix(build_vars,
+                                non_build_vars,
+                                environ_count,
+                                build_count):
+    conf = config.Config()
+
+    conf.environment_type = 'existing'
+    conf.env_matrix = flatten_env_matrix({
+        "build": build_vars,
+        "non_build": non_build_vars,
+    })
+    environments = list(environment.get_environments(conf, None))
+
+    assert len(environments) == environ_count
+    assert len(set(e.name for e in environments)) == build_count
+
+
+@pytest.mark.parametrize(
+    ['env_matrix', 'normalized'],
+    [
+        pytest.param(
+            {
+                "build": {
+                    "ENV1": ["val"],
+                    "ENV2": ["val2"]
+                }
+            },
+            {
+                ("build", "ENV1"): ["val"],
+                ("build", "ENV2"): ["val2"]
+            }
+        ),
+        pytest.param(
+            {
+                "build": {
+                    "ENV1": ["val"],
+                    "ENV2": ["val2"]
+                },
+                "non_build": {
+                    "ENV3": ["val3", "val4"],
+                    "ENV4": ["val5"]
+                }
+            },
+            {
+                ("build", "ENV1"): ["val"],
+                ("build", "ENV2"): ["val2"],
+                ("non_build", "ENV3"): ["val3", "val4"],
+                ("non_build", "ENV4"): ["val5"],
+            }
+        ),
+    ]
+)
+def test_flatten_env_matrix(env_matrix, normalized):
+    assert flatten_env_matrix(env_matrix) == normalized
+
+@pytest.mark.parametrize(
+    ['env_matrix'],
+    [
+        pytest.param(
+            {
+                "build": {
+                    "ENV1": ["val"],
+                    "ENV2": ["val2"]
+                }
+            },
+        ),
+        pytest.param(
+            {
+                "build": {
+                    "ENV1": ["val"],
+                    "ENV2": ["val2"]
+                },
+                "non_build": {
+                    "ENV3": ["val3", "val4"],
+                    "ENV4": ["val5"]
+                }
+            },
+        ),
+    ]
+)
+def test_normalize_flatten_env_matrix(env_matrix):
+    assert normalize_env_matrix(flatten_env_matrix(
+        env_matrix
+    )) == env_matrix
+
+
+@pytest.mark.parametrize(
+    ['normalized'],
+    [
+        pytest.param(
+            {
+                ("build", "ENV1"): ["val"],
+                ("build", "ENV2"): ["val2"]
+            },
+        ),
+        pytest.param(
+            {
+                ("build", "ENV1"): ["val"],
+                ("build", "ENV2"): ["val2"],
+                ("non_build", "ENV3"): ["val3", "val4"],
+                ("non_build", "ENV4"): ["val5"],
+            },
+        ),
+    ]
+)
+def test_flatten_normalize_env_matrix(normalized):
+    assert flatten_env_matrix(normalize_env_matrix(
+        normalized
+    )) == normalized

--- a/test/test_repo_template/setup.py
+++ b/test/test_repo_template/setup.py
@@ -1,4 +1,8 @@
+import os
 from setuptools import setup
+
+with open('asv_test_repo/build_time_env.py', 'w') as f:
+    f.write("env = {{}}\n".format(repr(dict(os.environ))))
 
 setup(name='asv_test_repo',
       version="{version}",

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -30,7 +30,8 @@ def test_results(tmpdir):
             hex(i),
             i * 1000000,
             '2.7',
-            'some-environment-name')
+            'some-environment-name',
+            {})
 
         x1 = float(i * 0.001)
         x2 = float(i * 0.001)
@@ -67,7 +68,13 @@ def test_results(tmpdir):
         assert r2.commit_hash == r.commit_hash
         assert r2._filename == r._filename
 
-        r3 = results.Results(r.params, r._requirements, r.commit_hash, r.date, r._python, r.env_name)
+        r3 = results.Results(r.params,
+                             r._requirements,
+                             r.commit_hash,
+                             r.date,
+                             r._python,
+                             r.env_name,
+                             {})
         r3.load_data(resultsdir)
 
         for rr in [r2, r3]:
@@ -154,8 +161,13 @@ def test_json_timestamp(tmpdir):
     stamp1 = datetime.datetime(1971, 1, 1)
     stamp2 = datetime.datetime.utcnow()
 
-    r = results.Results({'machine': 'mach'}, {}, 'aaaa', util.datetime_to_timestamp(stamp0),
-                        'py', 'env')
+    r = results.Results({'machine': 'mach'},
+                        {},
+                        'aaaa',
+                        util.datetime_to_timestamp(stamp0),
+                        'py',
+                        'env',
+                        {})
     value = runner.BenchmarkResult(
         result=[42],
         samples=[None],
@@ -205,10 +217,10 @@ def test_iter_results(capsys, tmpdir):
 
 
 def test_filename_format():
-    r = results.Results({'machine': 'foo'}, [], "commit", 0, "", "env")
+    r = results.Results({'machine': 'foo'}, [], "commit", 0, "", "env", {})
     assert r._filename == join("foo", "commit-env.json")
 
-    r = results.Results({'machine': 'foo'}, [], "hash", 0, "", "a"*128)
+    r = results.Results({'machine': 'foo'}, [], "hash", 0, "", "a"*128, {})
     assert r._filename == join("foo", "hash-env-e510683b3f5ffe4093d021808bc6ff70.json")
 
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -292,8 +292,8 @@ def test_env_matrix_value(basic_conf):
 
     conf.matrix = {}
 
-    def check_env_matrix(matrix):
-        conf.env_matrix = matrix
+    def check_env_matrix(env_build, env_nobuild):
+        conf.matrix = {"@env": env_build, "@env_nobuild": env_nobuild}
 
         tools.run_asv_with_conf(conf, 'run', "master^!",
                                 '--bench', 'time_secondary.track_environment_value',
@@ -311,5 +311,5 @@ def test_env_matrix_value(basic_conf):
         data = util.load_json(result_fn2)
         assert data['results']['time_secondary.track_environment_value'] == 2
 
-    check_env_matrix({'non_build': {'SOME_TEST_VAR': ['1', '2']}})
-    check_env_matrix({'build': {'SOME_TEST_VAR': ['1', '2']}})
+    check_env_matrix({}, {'SOME_TEST_VAR': ['1', '2']})
+    check_env_matrix({'SOME_TEST_VAR': ['1', '2']}, {})

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -313,3 +313,14 @@ def test_env_matrix_value(basic_conf):
 
     check_env_matrix({}, {'SOME_TEST_VAR': ['1', '2']})
     check_env_matrix({'SOME_TEST_VAR': ['1', '2']}, {})
+
+
+def test_parallel(basic_conf, dummy_packages):
+    tmpdir, local, conf, machine_file = basic_conf
+
+    conf.matrix["@env"] = {"SOME_TEST_VAR": ["1", "2"]}
+    conf.matrix["@env_nobuild"] = {"SOME_OTHER_TEST_VAR": ["1", "2"]}
+
+    tools.run_asv_with_conf(conf, 'run', "master^!",
+                            '--bench', 'time_secondary.track_environment_value',
+                            '--parallel=2', _machine_file=machine_file)

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -243,7 +243,7 @@ def test_forkserver(tmpdir):
     with open(os.path.join('benchmark', 'unimportable.py'), 'w') as f:
         f.write("raise RuntimeError('not importable')")
 
-    env = environment.ExistingEnvironment(conf, sys.executable, {})
+    env = environment.ExistingEnvironment(conf, sys.executable, {}, {})
     spawner = runner.ForkServer(env, os.path.abspath('benchmark'))
 
     result_file = os.path.join(tmpdir, 'run-result')
@@ -297,7 +297,7 @@ def test_forkserver_preimport(tmpdir):
     d['repo'] = 'None'
     conf = config.Config.from_json(d)
 
-    env = environment.ExistingEnvironment(conf, sys.executable, {})
+    env = environment.ExistingEnvironment(conf, sys.executable, {}, {})
 
     #
     # Normal benchmark suite

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -76,7 +76,7 @@ def _rebuild_basic_html(basedir):
             'repo': join(basedir, 'repo'),
             'dvcs': 'git',
             'project': 'asv',
-            'matrix': {},
+            'matrix': {"@env": {"SOME_TEST_VAR": ["1"]}},
             'regressions_first_commits': {
                 '.*': first_tested_commit_hash
             },

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -89,6 +89,8 @@ def basic_conf(tmpdir, dummy_packages):
 def test_run_publish(capfd, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
 
+    conf.matrix["@env"] = {"SOME_TEST_VAR": ["1"]}
+
     # Tests a typical complete run/publish workflow
     tools.run_asv_with_conf(conf, 'run', "master~5..master", '--steps=2',
                             '--quick', '--show-stderr', '--profile',
@@ -112,7 +114,9 @@ def test_run_publish(capfd, basic_conf):
                               'asv_dummy_test_package_1',
                               'asv_dummy_test_package_2-' + tools.DUMMY2_VERSIONS[1],
                               'branch-master',
-                              'cpu-Blazingly fast', 'machine-orangutan',
+                              'cpu-Blazingly fast',
+                              'env-SOME_TEST_VAR-1',
+                              'machine-orangutan',
                               'os-GNU_Linux', 'python-*', 'ram-128GB',
                               'params_examples.time_skip.json'))[0]
     with open(filename, 'r') as fp:

--- a/test/tools.py
+++ b/test/tools.py
@@ -478,7 +478,7 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
         if isinstance(value, dict):
             params = value["params"]
         result = Results({"machine": "tarzan"}, {}, commit,
-                         repo.get_date_from_name(commit), "2.7", None)
+                         repo.get_date_from_name(commit), "2.7", None, {})
         value = runner.BenchmarkResult(
             result=[value],
             samples=[None],


### PR DESCRIPTION
Hello,

This PR introduces support for environment variables, as askied in #165 .
When discussing the feature during the [Mercurial mini-sprint](https://octobus.net/blog/2019-04-17-mercurial-mini-sprint-2019-04.html) we held in Paris earlier this month, it became apparent that there would be a need for specifying whether or not a given environment variable should result in an additional build. Thus, environment variables can be defined as being "build" or "non_build". 
This decision has shaken up at least of core feature of ASV: how to identify an `Environment`, in that multiple `Environment`s can henceforth refer to the same build on the file system, allowing for quicker build time and less disk usage waste.
 
This PR is very close to completion (5 tests failing... I haven't been able to figure out why as of yet), but since I'm most likely not going to have time to finish it for a few weeks I figured I'd create it to kick-start the discussion that I'm sure will need to happen.

Closes: #165