### PR TITLE
Fix off-by-one error in update mechanism

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -836,7 +836,7 @@ def update_json(cls, path, api_version):
             "No version specified in {0}.".format(path))
 
     if d['version'] < api_version:
-        for x in six.moves.xrange(d['version'] + 1, api_version):
+        for x in six.moves.xrange(d['version'] + 1, api_version + 1):
             d = getattr(cls, 'update_to_{0}'.format(x), lambda x: x)(d)
         write_json(path, d, api_version)
     elif d['version'] > api_version:


### PR DESCRIPTION
While trying to use the `update` command for a custom format, I found
that my update_to_2 was not called, because the range excludes the end
version when it should include it.