### PR TITLE
Write results files with compact json

### DIFF
--- a/asv/results.py
+++ b/asv/results.py
@@ -596,7 +596,7 @@ class Results(object):
             'benchmark_version': self._benchmark_version,
         }
 
-        util.write_json(path, data, self.api_version)
+        util.write_json(path, data, self.api_version, compact=True)
 
     def load_data(self, result_dir):
         """


### PR DESCRIPTION
This is ~50% space saving. These files are often not read by humans, so
requiring a json pretty-printer for that is likely ok.