### PR TITLE
Lookup commit hashes when using asv run HASHFILE:

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -224,7 +224,14 @@ class Run(Command):
             else:
                 log.error('Requested commit hash file "{}" is not a file'.format(hashfn))
                 return 1
-            commit_hashes = [h.strip() for h in hashstr.split("\n") if h.strip()]
+            commit_hashes = []
+            for h in hashstr.split("\n"):
+                h = h.strip()
+                if h:
+                    try:
+                        commit_hashes.append(repo.get_hash_from_name(h))
+                    except NoSuchNameError:
+                        log.warning("Unknown commit hash {0} in input file".format(h))
         elif isinstance(range_spec, list):
             commit_hashes = range_spec
         else:

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -127,8 +127,10 @@ def test_run_spec(basic_conf):
     expected_commits = (initial_commit, branch_commit)
     with open(os.path.join(tmpdir, 'hashes_to_benchmark'), 'w') as f:
         for commit in expected_commits:
-            f.write(commit)
-            f.write('\n')
+            f.write(commit + "\n")
+        f.write("master~1\n")
+        f.write("some-bad-hash-that-will-be-ignored\n")
+        expected_commits += (dvcs.get_hash("master~1"),)
     _test_run('HASHFILE:hashes_to_benchmark', [None], expected_commits)
 
 


### PR DESCRIPTION
The hashfile is user-provided input that needs to be normalized to valid
repository commit hashes.