### PR TITLE
ENH: When encountering multiple benchmark matches in find/profile, use exact match if unambiguous

### DIFF
--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -100,8 +100,13 @@ class Find(Command):
             log.error("'{0}' benchmark not found".format(bench))
             return 1
         elif len(benchmarks) > 1:
-            log.error("'{0}' matches more than one benchmark".format(bench))
-            return 1
+            exact_matches = benchmarks.filter_out([x for x in benchmarks if x != bench])
+            if len(exact_matches) == 1:
+                log.warning("'{0}' matches more than one benchmark, using exact match".format(bench))
+                benchmarks = exact_matches
+            else:
+                log.error("'{0}' matches more than one benchmark".format(bench))
+                return 1
 
         benchmark_name, = benchmarks.keys()
 

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -182,7 +182,12 @@ class Profile(Command):
             if len(benchmarks) == 0:
                 raise util.UserError("'{0}' benchmark not found".format(benchmark))
             elif len(benchmarks) > 1:
-                raise util.UserError("'{0}' matches more than one benchmark".format(benchmark))
+                exact_matches = benchmarks.filter_out([x for x in benchmarks if x != benchmark])
+                if len(exact_matches) == 1:
+                    log.warning("'{0}' matches more than one benchmark, using exact match".format(benchmark))
+                    benchmarks = exact_matches
+                else:
+                    raise util.UserError("'{0}' matches more than one benchmark".format(benchmark))
 
             benchmark_name, = benchmarks.keys()
 


### PR DESCRIPTION
When attempting to run `asv find` or `asv profile` on a suite with benchmarks that contains substrings of other benchmarks (eg, both `time_iter` and `time_iter_preexit`), it is not possible to run the substring benchmark directly due to the following exception:
```
 * 'time_iter' matches more than one benchmark
```
This PR adds support for this case by detecting that it is a full and unique match, issuing a warning, and continuing:
```
 * 'time_iter' matches more than one benchmark, using exact match
```