### PR TITLE
 Implement raw timing benchmarks, run once in a separate process

### DIFF
--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -373,25 +373,40 @@ memory usage you want to track::
 For details, see :doc:`benchmarks`.
 
 
-Imports
-```````
+Raw timing benchmarks
+`````````````````````
 
-To benchmark import times use the ``imp`` prefix::
+For some timing benchmarks, for example measuring the time it takes to
+import a module, it is important that they are run separately in a new
+Python process.
 
-    def imp_inspect():
+Measuring execution time for benchmarks run once in a new Python process
+can be done with ``timeraw_*`` timing benchmarks::
+
+    def timeraw_import_inspect():
+        return """
         import inspect
+        """
+
+Note that these benchmark functions should return a string,
+corresponding to the code that will be run.
 
 Importing a module takes a meaningful amount of time only the first time
 it is executed, therefore a fresh interpreter is used for each iteration of
-the benchmark. The source code of the benchmark function is executed in a
-subprocess; the setup is performed in the base benchmark process, parameters
-and profiling are not supported.
+the benchmark. The string returned by the benchmark function is executed in a
+subprocess.
 
-The ``goal_time``, ``number``, and ``repeat`` arguments have the same meaning
-as in :ref:`timing` benchmarks, but by default ``number`` is set to 1 and
-``repeat`` is adjusted to approximate the goal time. The ``timer`` argument is
-ignored, ``process_time`` is used inside the subprocess (falling back to
-``timeit.default_timer`` under older Pythons).
+Note that the setup and setup_cache are performed in the base benchmark
+process, so that the setup done by them is not available in the benchmark code.
+To perform setup also in the benchmark itself, you can return a second string:
+
+    def timeraw_import_inspect():
+        code = "import inspect"
+        setup = "import ast"
+        return code, setup
+
+The raw timing benchmarks have the same parameters as ordinary timing benchmarks,
+but ``number`` is by default 1, and ``timer`` is ignored.
 
 .. note::
 
@@ -399,12 +414,14 @@ ignored, ``process_time`` is used inside the subprocess (falling back to
    `built-in`_ or brought in by importing the ``timeit`` module (which
    further imports ``gc``, ``sys``, ``time``, and ``itertools``).
 
-.. note::
-
-   Import benchmarks require Python 2.7 or later, the timing is more precise
-   with Python 3.3 or later.
-
 .. _built-in: https://hg.python.org/cpython/file/tip/Modules/Setup.dist
+
+
+Imports
+```````
+
+You can use raw timing benchmarks to measure import times.
+
 
 .. _tracking:
 

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -372,6 +372,40 @@ memory usage you want to track::
 
 For details, see :doc:`benchmarks`.
 
+
+Imports
+```````
+
+To benchmark import times use the ``imp`` prefix::
+
+    def imp_inspect():
+        import inspect
+
+Importing a module takes a meaningful amount of time only the first time
+it is executed, therefore a fresh interpreter is used for each iteration of
+the benchmark. The source code of the benchmark function is executed in a
+subprocess; the setup is performed in the base benchmark process, parameters
+and profiling are not supported.
+
+The ``goal_time``, ``number``, and ``repeat`` arguments have the same meaning
+as in :ref:`timing` benchmarks, but by default ``number`` is set to 1 and
+``repeat`` is adjusted to approximate the goal time. The ``timer`` argument is
+ignored, ``process_time`` is used inside the subprocess (falling back to
+``timeit.default_timer`` under older Pythons).
+
+.. note::
+
+   Timing standard library modules is possible as long as they are not
+   `built-in`_ or brought in by importing the ``timeit`` module (which
+   further imports ``gc``, ``sys``, ``time``, and ``itertools``).
+
+.. note::
+
+   Import benchmarks require Python 2.7 or later, the timing is more precise
+   with Python 3.3 or later.
+
+.. _built-in: https://hg.python.org/cpython/file/tip/Modules/Setup.dist
+
 .. _tracking:
 
 Tracking (Generic)

--- a/test/benchmark/imp_examples.py
+++ b/test/benchmark/imp_examples.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import inspect  # Checked below.
+import sys
+
+
+class ImpSuite(object):
+    def imp_fresh(self):
+        # The test interpreter should not be polluted with anything.
+        import sys
+        assert 'asv' not in sys.modules
+        assert 'inspect' not in sys.modules
+
+    def imp_docstring(self):
+        """
+        Docstrings may be used to comment benchmarks.
+        """
+        pass
+
+    def imp_timeout(self):
+        # Inside the grandchild.
+        while True:
+            pass
+    imp_timeout.timeout = .1
+
+    def imp_count(self):
+        # Using number other than one or a fixed repeat should work.
+        import sys
+        sys.stderr.write('0')
+    imp_count.number = 3
+    imp_count.repeat = 7

--- a/test/benchmark/timeraw_examples.py
+++ b/test/benchmark/timeraw_examples.py
@@ -8,28 +8,33 @@ import inspect  # Checked below.
 import sys
 
 
-class ImpSuite(object):
-    def imp_fresh(self):
+class TimerawSuite(object):
+    def timeraw_fresh(self):
         # The test interpreter should not be polluted with anything.
+        return """
         import sys
         assert 'asv' not in sys.modules
         assert 'inspect' not in sys.modules
-
-    def imp_docstring(self):
         """
-        Docstrings may be used to comment benchmarks.
-        """
-        pass
 
-    def imp_timeout(self):
+    def timeraw_setup(self):
+        # Setup code
+        return "a+1", "a=3"
+
+    def timeraw_timeout(self):
+        return """
         # Inside the grandchild.
         while True:
             pass
-    imp_timeout.timeout = .1
+        """
+    timeraw_timeout.timeout = 0.1
 
-    def imp_count(self):
+    def timeraw_count(self):
         # Using number other than one or a fixed repeat should work.
+        return """
         import sys
         sys.stderr.write('0')
-    imp_count.number = 3
-    imp_count.repeat = 7
+        """
+    timeraw_count.repeat = 7
+    timeraw_count.number = 3
+    timeraw_count.warmup_time = 0

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -118,6 +118,30 @@ def test_discover_benchmarks(benchmarks_fixture):
     assert params[0][1] in ['<function FunctionParamSuite.<lambda>>', '<function <lambda>>']
 
 
+@pytest.mark.skipif(sys.version_info < (2, 7),
+                    reason="Import benchmarks require Python 2.7+")
+def test_imp_benchmark(tmpdir):
+    tmpdir = six.text_type(tmpdir)
+    os.chdir(tmpdir)
+
+    d = {}
+    d.update(ASV_CONF_JSON)
+    d['benchmark_dir'] = BENCHMARK_DIR
+    d['env_dir'] = "env"
+    d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
+    conf = config.Config.from_json(d)
+
+    repo = get_repo(conf)
+    envs = list(environment.get_environments(conf, None))
+
+    b = benchmarks.Benchmarks(conf, repo, envs, regex='ImpSuite')
+    times = b.run_benchmarks(envs[0], show_stderr=True)
+    assert times['imp_examples.ImpSuite.imp_fresh']['result'] is not None
+    assert times['imp_examples.ImpSuite.imp_docstring']['result'] is not None
+    assert 'timed out' in times['imp_examples.ImpSuite.imp_timeout']['stderr']
+    assert '0' * 21 in times['imp_examples.ImpSuite.imp_count']['stderr']
+
+
 def test_invalid_benchmark_tree(tmpdir):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -73,7 +73,7 @@ def test_discover_benchmarks(benchmarks_fixture):
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                                        regex='example')
     conf.branches = old_branches
-    assert len(b) == 31
+    assert len(b) == 35
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
                               regex='time_example_benchmark_1')
@@ -106,7 +106,7 @@ def test_discover_benchmarks(benchmarks_fixture):
     assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1, 2, 3]
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
-    assert len(b) == 42
+    assert len(b) == 46
 
     assert 'named.OtherSuite.track_some_func' in b
 
@@ -117,29 +117,10 @@ def test_discover_benchmarks(benchmarks_fixture):
     # repr is a bit different on py2 vs py3 here
     assert params[0][1] in ['<function FunctionParamSuite.<lambda>>', '<function <lambda>>']
 
-
-@pytest.mark.skipif(sys.version_info < (2, 7),
-                    reason="Import benchmarks require Python 2.7+")
-def test_imp_benchmark(tmpdir):
-    tmpdir = six.text_type(tmpdir)
-    os.chdir(tmpdir)
-
-    d = {}
-    d.update(ASV_CONF_JSON)
-    d['benchmark_dir'] = BENCHMARK_DIR
-    d['env_dir'] = "env"
-    d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
-    conf = config.Config.from_json(d)
-
-    repo = get_repo(conf)
-    envs = list(environment.get_environments(conf, None))
-
-    b = benchmarks.Benchmarks(conf, repo, envs, regex='ImpSuite')
-    times = b.run_benchmarks(envs[0], show_stderr=True)
-    assert times['imp_examples.ImpSuite.imp_fresh']['result'] is not None
-    assert times['imp_examples.ImpSuite.imp_docstring']['result'] is not None
-    assert 'timed out' in times['imp_examples.ImpSuite.imp_timeout']['stderr']
-    assert '0' * 21 in times['imp_examples.ImpSuite.imp_count']['stderr']
+    # Raw timing benchmarks
+    assert b['timeraw_examples.TimerawSuite.timeraw_count']['repeat'] == 7
+    assert b['timeraw_examples.TimerawSuite.timeraw_count']['number'] == 3
+    assert b['timeraw_examples.TimerawSuite.timeraw_setup']['number'] == 1
 
 
 def test_invalid_benchmark_tree(tmpdir):

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -431,3 +431,16 @@ def test_run_import_failure(capsys, benchmarks_fixture, launch_method):
 
     text, err = capsys.readouterr()
     assert 'hello import' in text
+
+
+def test_timeraw_benchmark(benchmarks_fixture):
+    conf, repo, envs, commit_hash = benchmarks_fixture
+
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex='TimerawSuite')
+    results = runner.run_benchmarks(b, envs[0], show_stderr=True)
+    times = ResultsWrapper(results, b)
+
+    assert times['timeraw_examples.TimerawSuite.timeraw_fresh'].result is not None
+    assert times['timeraw_examples.TimerawSuite.timeraw_setup'].result is not None
+    assert 'timed out' in times['timeraw_examples.TimerawSuite.timeraw_timeout'].stderr
+    assert '0' * 7 * 3 in times['timeraw_examples.TimerawSuite.timeraw_count'].stderr


### PR DESCRIPTION
Implement running timing benchmark code in fresh Python processes,
suitable for import timing benchmarks. Reuses the existing timing benchmark
code, including statistics collection.

Closes: #487 (superceded)