### PR TITLE
Make _write_with_fallback more well-defined

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -1358,9 +1358,9 @@ def main_timing(argv):
 
     if not args.json:
         asv.console.color_print(formatted, 'red')
-        asv.console.color_print("", 'default')
-        asv.console.color_print("\n".join("{}: {}".format(k, v) for k, v in sorted(stats.items())), 'default')
-        asv.console.color_print("samples: {}".format(result['samples']), 'default')
+        asv.console.color_print(u"", 'default')
+        asv.console.color_print(u"\n".join(u"{}: {}".format(k, v) for k, v in sorted(stats.items())), 'default')
+        asv.console.color_print(u"samples: {}".format(result['samples']), 'default')
     else:
         json.dump({'result': value,
                    'samples': result['samples'],

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -84,21 +84,6 @@ def test_parallelfailure():
         pass
 
 
-def test_write_unicode_to_ascii():
-    def get_fake_encoding():
-        return 'ascii'
-
-    original_getpreferredencoding = locale.getpreferredencoding
-    locale.getpreferredencoding = get_fake_encoding
-
-    try:
-        buff = io.BytesIO()
-        console.color_print("μs", file=buff)
-        assert buff.getvalue() == b'us\n'
-    finally:
-        locale.getpreferredencoding = original_getpreferredencoding
-
-
 def test_which_path(tmpdir):
     dirname = os.path.abspath(os.path.join(str(tmpdir), 'name with spaces'))
     fn = 'asv_test_exe_1234.exe'


### PR DESCRIPTION
Clarify the way encodings are handled when printing text to streams on
Python3.