### PR TITLE
More compact results json format

### DIFF
--- a/asv/commands/show.py
+++ b/asv/commands/show.py
@@ -205,6 +205,9 @@ class Show(Command):
         stats = result.get_result_stats(benchmark['name'], benchmark['params'])
 
         def get_stat_info(key):
+            if key == 'ci_99':
+                return [(x.get('ci_99_a'), x.get('ci_99_b')) if x is not None else None
+                        for x in stats]
             return [x.get(key) if x is not None else None for x in stats]
 
         for key in ['repeat', 'number', 'ci_99', 'mean', 'std', 'min', 'max']:

--- a/asv/commands/update.py
+++ b/asv/commands/update.py
@@ -31,14 +31,12 @@ class Update(Command):
         return parser
 
     @classmethod
-    def run_from_args(cls, args, _machine_file=None):
-        return cls.run(args.config, _machine_file=_machine_file)
+    def run_from_conf_args(cls, conf, args, _machine_file=None):
+        return cls.run(conf, _machine_file=_machine_file)
 
     @classmethod
-    def run(cls, config_path, _machine_file=None):
+    def run(cls, conf, _machine_file=None):
         MachineCollection.update(_path=_machine_file)
-
-        conf = Config.load(config_path)
 
         log.info("Updating results data...")
 
@@ -50,7 +48,12 @@ class Update(Command):
                 elif filename == "benchmarks.json":
                     pass
                 elif filename.endswith('.json'):
-                    Results.update(path)
+                    try:
+                        Results.update(path)
+                    except util.UserError as err:
+                        # Conversion failed: just skip the file
+                        log.warning("{}: {}".format(path, err))
+                        continue
 
                     # Rename files if necessary
                     m = re.match(r'^([0-9a-f]+)-(.*)\.json$', os.path.basename(path), re.I)

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -114,6 +114,8 @@ class Regressions(OutputPublisher):
 
             # Time when the benchmark was run
             for benchmark_name, timestamp in six.iteritems(results.started_at):
+                if timestamp is None:
+                    continue
                 key = (benchmark_name, revision)
                 run_timestamps[key] = timestamp
 

--- a/asv/results.py
+++ b/asv/results.py
@@ -12,6 +12,7 @@ import zlib
 import itertools
 import hashlib
 import datetime
+import collections
 
 import six
 from six.moves import zip as izip
@@ -588,34 +589,64 @@ class Results(object):
         path = os.path.join(result_dir, self._filename)
 
         results = {}
-        for key in six.iterkeys(self._samples):
-            # Save omitting default values
-            value = {'result': self._results[key]}
-            if self._samples[key] and any(x is not None for x in self._samples[key]):
-                value['samples'] = self._samples[key]
-            if self._stats[key] and any(x is not None for x in self._stats[key]):
-                value['stats'] = self._stats[key]
-            if self._benchmark_params[key]:
-                value['params'] = self._benchmark_params[key]
-            if list(value.keys()) == ['result']:
-                value = value['result']
-                if isinstance(value, list) and len(value) == 1:
-                    value = value[0]
-            results[key] = value
 
-        data = {
-            'results': results,
-            'env_vars': self._env_vars,
-            'params': self._params,
-            'requirements': self._requirements,
-            'commit_hash': self._commit_hash,
-            'date': self._date,
-            'env_name': self._env_name,
-            'python': self._python,
-            'profiles': self._profiles,
+        simple_dict = {
+            'result': self._results,
+            'params': self._benchmark_params,
+            'version': self._benchmark_version,
             'started_at': self._started_at,
             'duration': self._duration,
-            'benchmark_version': self._benchmark_version,
+            'samples': self._samples,
+            'profile': self._profiles,
+        }
+        all_keys = ['result', 'params', 'version', 'started_at', 'duration',
+                    'stats_ci_99_a', 'stats_ci_99_b', 'stats_q_25', 'stats_q_75',
+                    'stats_min', 'stats_max', 'stats_mean', 'stats_std',
+                    'stats_number', 'stats_repeat', 'samples', 'profile']
+
+        for name in six.iterkeys(self._results):
+            row = []
+
+            for key in all_keys:
+                if key in simple_dict:
+                    value = simple_dict[key].get(name)
+                else:
+                    assert key[:6] == 'stats_'
+                    z = self._stats[name]
+                    if z is None:
+                        value = None
+                    else:
+                        value = [x.get(key[6:]) if x is not None else None
+                                 for x in z]
+
+                if key != 'params':
+                    if isinstance(value, list) and all(x is None for x in value):
+                        value = None
+                    value = util.truncate_float_list(value)
+
+                row.append(value)
+
+            while row and row[-1] is None:
+                row.pop()
+
+            results[name] = row
+
+        other_durations = {}
+        for key, value in six.iteritems(self._duration):
+            if key.startswith('<'):
+                other_durations[key] = value
+
+        data = {
+            'commit_hash': self._commit_hash,
+            'env_name': self._env_name,
+            'date': self._date,
+            'params': self._params,
+            'python': self._python,
+            'requirements': self._requirements,
+            'env_vars': self._env_vars,
+            'result_keys': all_keys,
+            'results': results,
+            'durations': other_durations,
         }
 
         util.write_json(path, data, self.api_version, compact=True)
@@ -659,11 +690,7 @@ class Results(object):
                 d['commit_hash'],
                 d['date'],
                 d['python'],
-                d.get('env_name',
-                      environment.get_env_name('',
-                                               d['python'],
-                                               d['requirements'],
-                                               {})),
+                d['env_name'],
                 d['env_vars'],
             )
 
@@ -671,36 +698,43 @@ class Results(object):
             obj._samples = {}
             obj._stats = {}
             obj._benchmark_params = {}
+            obj._profiles = {}
+            obj._started_at = {}
+            obj._duration = d.get('durations', {})
+            obj._benchmark_version = {}
 
-            for key, value in six.iteritems(d['results']):
-                # Backward compatibility
-                if not isinstance(value, dict):
-                    value = {'result': [value], 'samples': None,
-                             'stats': None, 'params': []}
+            simple_keys = {
+                'result': obj._results,
+                'params': obj._benchmark_params,
+                'version': obj._benchmark_version,
+                'started_at': obj._started_at,
+                'duration': obj._duration,
+                'samples': obj._samples,
+                'profile': obj._profiles,
+            }
 
-                if not isinstance(value['result'], list):
-                    value['result'] = [value['result']]
+            for name, key_values in six.iteritems(d['results']):
+                for key, value in zip(d['result_keys'], key_values):
+                    key_dict = simple_keys.get(key)
+                    if key_dict is not None:
+                        key_dict[name] = value
+                        continue
+                    elif key.startswith('stats_'):
+                        if value is not None:
+                            if name not in obj._stats:
+                                obj._stats[name] = [{}]*len(value)
 
-                if 'stats' in value and not isinstance(value['stats'], list):
-                    value['stats'] = [value['stats']]
+                            stats_key = key[6:]
+                            for j, v in enumerate(value):
+                                obj._stats[name][j][stats_key] = v
+                    else:
+                        raise KeyError("unknown data key {}".format(key))
 
-                value.setdefault('samples', None)
-                value.setdefault('stats', None)
-                value.setdefault('params', [])
+                for key_dict in simple_keys.values():
+                    key_dict.setdefault(name, None)
+                obj._stats.setdefault(name, None)
 
-                # Assign results
-                obj._results[key] = value['result']
-                obj._samples[key] = value['samples']
-                obj._stats[key] = value['stats']
-                obj._benchmark_params[key] = value['params']
-
-            if 'profiles' in d:
-                obj._profiles = d['profiles']
             obj._filename = os.path.join(*path.split(os.path.sep)[-2:])
-
-            obj._started_at = d.get('started_at', {})
-            obj._duration = d.get('duration', {})
-            obj._benchmark_version = d.get('benchmark_version', {})
         except KeyError as exc:
             raise util.UserError(
                 "Error loading results file '{0}': missing key {1}".format(
@@ -727,6 +761,10 @@ class Results(object):
     @property
     def env_name(self):
         return self._env_name
+
+    #
+    # Old data format support
+    #
 
     @classmethod
     def update_to_2(cls, d):

--- a/asv/results.py
+++ b/asv/results.py
@@ -622,6 +622,8 @@ class Results(object):
                 if key != 'params':
                     if isinstance(value, list) and all(x is None for x in value):
                         value = None
+
+                if key.startswith('stats_') or key == 'duration':
                     value = util.truncate_float_list(value)
 
                 row.append(value)
@@ -863,7 +865,8 @@ class Results(object):
                         else:
                             value = key_getter(value)
 
-                    value = util.truncate_float_list(value)
+                    if key_name.startswith('stats_') or key_name == 'duration':
+                        value = util.truncate_float_list(value)
 
                     if key_name == 'params' and value is None:
                         value = []

--- a/asv/results.py
+++ b/asv/results.py
@@ -601,7 +601,6 @@ class Results(object):
         }
         all_keys = ['result', 'params', 'version', 'started_at', 'duration',
                     'stats_ci_99_a', 'stats_ci_99_b', 'stats_q_25', 'stats_q_75',
-                    'stats_min', 'stats_max', 'stats_mean', 'stats_std',
                     'stats_number', 'stats_repeat', 'samples', 'profile']
 
         for name in six.iterkeys(self._results):
@@ -836,10 +835,6 @@ class Results(object):
                 ('stats_ci_99_b', stats, lambda z: z['ci_99'][1]),
                 ('stats_q_25', stats, lambda z: z.get('q_25')),
                 ('stats_q_75', stats, lambda z: z.get('q_75')),
-                ('stats_min', stats, lambda z: z.get('min')),
-                ('stats_max', stats, lambda z: z.get('max')),
-                ('stats_mean', stats, lambda z: z.get('mean')),
-                ('stats_std', stats, lambda z: z.get('std')),
                 ('stats_number', stats, lambda z: z.get('number')),
                 ('stats_repeat', stats, lambda z: z.get('repeat')),
                 ('samples', samples, None),

--- a/asv/results.py
+++ b/asv/results.py
@@ -777,10 +777,11 @@ class Results(object):
 
             d2['commit_hash'] = d['commit_hash']
             d2['date'] = d['date']
-            d2['env_name'] = environment.get_env_name('',
-                                                      d['python'],
-                                                      d['requirements'],
-                                                      {})
+            d2['env_name'] = d.get('env_name',
+                                   environment.get_env_name('',
+                                                            d['python'],
+                                                            d['requirements'],
+                                                            {}))
             d2['params'] = d['params']
             d2['python'] = d['python']
             d2['requirements'] = d['requirements']

--- a/asv/results.py
+++ b/asv/results.py
@@ -727,7 +727,8 @@ class Results(object):
 
                             stats_key = key[6:]
                             for j, v in enumerate(value):
-                                obj._stats[name][j][stats_key] = v
+                                if v is not None:
+                                    obj._stats[name][j][stats_key] = v
                     else:
                         raise KeyError("unknown data key {}".format(key))
 

--- a/asv/results.py
+++ b/asv/results.py
@@ -646,7 +646,7 @@ class Results(object):
             'python': self._python,
             'requirements': self._requirements,
             'env_vars': self._env_vars,
-            'result_keys': all_keys,
+            'result_columns': all_keys,
             'results': results,
             'durations': other_durations,
         }
@@ -716,7 +716,7 @@ class Results(object):
             }
 
             for name, key_values in six.iteritems(d['results']):
-                for key, value in zip(d['result_keys'], key_values):
+                for key, value in zip(d['result_columns'], key_values):
                     key_dict = simple_keys.get(key)
                     if key_dict is not None:
                         key_dict[name] = value
@@ -850,7 +850,7 @@ class Results(object):
             for key_dict in (results, benchmark_params):
                 names.update(key_dict.keys())
 
-            d2['result_keys'] = [x[0] for x in getters]
+            d2['result_columns'] = [x[0] for x in getters]
             d2['results'] = {}
 
             for name in sorted(names):

--- a/asv/statistics.py
+++ b/asv/statistics.py
@@ -93,12 +93,15 @@ def get_weight(stats):
     """
     Return a data point weight for the result.
     """
-    if stats is None or 'ci_99_a' not in stats or 'ci_99_b' not in stats:
+    if stats is None:
+        return None
+
+    a = stats.get('ci_99_a')
+    b = stats.get('ci_99_b')
+    if a is None or b is None:
         return None
 
     try:
-        a = stats['ci_99_a']
-        b = stats['ci_99_b']
         return 2 / abs(b - a)
     except ZeroDivisionError:
         return None
@@ -139,6 +142,9 @@ def is_different(samples_a, samples_b, stats_a, stats_b, p_threshold=0.002):
     # 0.00027 <= p <= 0.01.
     ci_a = (stats_a['ci_99_a'], stats_a['ci_99_b'])
     ci_b = (stats_b['ci_99_a'], stats_b['ci_99_b'])
+
+    if None in ci_a or None in ci_b:
+        return (ci_a != ci_b)
 
     if ci_a[1] >= ci_b[0] and ci_a[0] <= ci_b[1]:
         return False

--- a/asv/statistics.py
+++ b/asv/statistics.py
@@ -85,15 +85,12 @@ def get_weight(stats):
     """
     Return a data point weight for the result.
     """
-    if stats is None:
-        return None
-
-    a = stats.get('ci_99_a')
-    b = stats.get('ci_99_b')
-    if a is None or b is None:
+    if stats is None or 'ci_99_a' not in stats or 'ci_99_b' not in stats:
         return None
 
     try:
+        a = stats['ci_99_a']
+        b = stats['ci_99_b']
         return 2 / abs(b - a)
     except ZeroDivisionError:
         return None
@@ -134,9 +131,6 @@ def is_different(samples_a, samples_b, stats_a, stats_b, p_threshold=0.002):
     # 0.00027 <= p <= 0.01.
     ci_a = (stats_a['ci_99_a'], stats_a['ci_99_b'])
     ci_b = (stats_b['ci_99_a'], stats_b['ci_99_b'])
-
-    if None in ci_a or None in ci_b:
-        return (ci_a != ci_b)
 
     if ci_a[1] >= ci_b[0] and ci_a[0] <= ci_b[1]:
         return False

--- a/asv/statistics.py
+++ b/asv/statistics.py
@@ -66,7 +66,8 @@ def compute_stats(samples, number):
 
     result = y_50
 
-    stats = {'ci_99': list(ci_50),
+    stats = {'ci_99_a': ci_50[0],
+             'ci_99_b': ci_50[1],
              'q_25': y_25,
              'q_75': y_75,
              'min': min(Y),
@@ -92,11 +93,13 @@ def get_weight(stats):
     """
     Return a data point weight for the result.
     """
-    if stats is None or 'ci_99' not in stats:
+    if stats is None or 'ci_99_a' not in stats or 'ci_99_b' not in stats:
         return None
 
     try:
-        return 2 / abs(stats['ci_99'][1] - stats['ci_99'][0])
+        a = stats['ci_99_a']
+        b = stats['ci_99_b']
+        return 2 / abs(b - a)
     except ZeroDivisionError:
         return None
 
@@ -134,8 +137,8 @@ def is_different(samples_a, samples_b, stats_a, stats_b, p_threshold=0.002):
     # which generally can be significantly smaller than p <= 0.01
     # depending on the actual data. For normal test (known variance),
     # 0.00027 <= p <= 0.01.
-    ci_a = stats_a['ci_99']
-    ci_b = stats_b['ci_99']
+    ci_a = (stats_a['ci_99_a'], stats_a['ci_99_b'])
+    ci_b = (stats_b['ci_99_a'], stats_b['ci_99_b'])
 
     if ci_a[1] >= ci_b[0] and ci_a[0] <= ci_b[1]:
         return False

--- a/asv/statistics.py
+++ b/asv/statistics.py
@@ -60,20 +60,12 @@ def compute_stats(samples, number):
         ci_50 = (a, b)
 
     # Produce results
-    mean = sum(Y) / len(Y)
-    var = sum((yp - mean)**2 for yp in Y) / len(Y)   # mle
-    std = math.sqrt(var)
-
     result = y_50
 
     stats = {'ci_99_a': ci_50[0],
              'ci_99_b': ci_50[1],
              'q_25': y_25,
              'q_75': y_75,
-             'min': min(Y),
-             'max': max(Y),
-             'mean': mean,
-             'std': std,
              'repeat': len(Y),
              'number': number}
 

--- a/asv/util.py
+++ b/asv/util.py
@@ -865,7 +865,7 @@ def load_json(path, api_version=None, js_comments=False):
     return d
 
 
-def update_json(cls, path, api_version):
+def update_json(cls, path, api_version, compact=False):
     """
     Perform JSON file format updates.
 
@@ -892,7 +892,7 @@ def update_json(cls, path, api_version):
     if d['version'] < api_version:
         for x in six.moves.xrange(d['version'] + 1, api_version + 1):
             d = getattr(cls, 'update_to_{0}'.format(x), lambda x: x)(d)
-        write_json(path, d, api_version)
+        write_json(path, d, api_version, compact=compact)
     elif d['version'] > api_version:
         raise UserError(
             "{0} is stored in a format that is newer than "
@@ -1367,6 +1367,21 @@ def interpolate_command(command, variables):
         break
 
     return result, env, return_codes, cwd
+
+
+def truncate_float_list(item, digits=5):
+    """
+    Truncate floating-point numbers (in a possibly nested list)
+    to given significant digits, for a shorter base-10
+    representation.
+    """
+    if isinstance(item, float):
+        fmt = '{{:.{}e}}'.format(digits - 1)
+        return float(fmt.format(item))
+    elif isinstance(item, list):
+        return [truncate_float_list(x, digits) for x in item]
+    else:
+        return item
 
 
 _global_locks = {}

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -124,15 +124,15 @@ A benchmark suite directory has the following layout.  The
       - ``durations``: Duration information for build and setup-cache timings.
 
       - ``result_columns``: List of column names for the ``results`` dictionary.
-        It is ``["result", "samples", "params", "started_at", "duration",
-        "version", "profile", "stats_ci_99_a", "stats_ci_99_b", "stats_q_25",
-        "stats_q_75", "stats_min", "stats_max", "stats_mean", "stats_std",
-        "stats_number", "stats_repeat"]`` currently.
+        It is ``["result", "params", "version", "started_at", "duration",
+        "stats_ci_99_a", "stats_ci_99_b", "stats_q_25", "stats_q_75",
+        "stats_number", "stats_repeat", "samples", "profile"]`` currently.
 
       - ``results``: A dictionary from benchmark names to benchmark
         results. The keys are benchmark names, and values are lists
-        such that ``dict(zip(result_keys, results[benchmark_name]))``
-        pairs the appropriate keys with the values.
+        such that ``dict(zip(result_columns, results[benchmark_name]))``
+        pairs the appropriate keys with the values; in particular,
+        trailing columns with missing values can be dropped.
 
         Some items, marked with "(param-list)" below, are lists
         with items corresponding to results from a parametrized benchmark
@@ -141,8 +141,17 @@ A benchmark suite directory has the following layout.  The
 
         Values except ``params`` can be ``null``, indicating missing data.
 
-        Floating-point numbers are truncated to 5 significant base-10 digits
-        when saving, in order to produce smaller JSON files.
+        Floating-point numbers in ``stats_*`` and ``duration`` are truncated
+        to 5 significant base-10 digits when saving, in order to produce smaller
+        JSON files.
+
+        - ``result``: (param-list) contains the summarized result value(s) of
+          the benchmark. The values are float, NaN or null.
+
+          The values are either numbers indicating result from
+          successful run, ``null`` indicating a failed benchmark,
+          or ``NaN`` indicating a benchmark explicitly skipped by the
+          benchmark suite.
 
         - ``params``: contains a copy of the parameter values of the
           benchmark, as described above. If the user has modified the benchmark
@@ -166,23 +175,16 @@ A benchmark suite directory has the following layout.  The
 
         - ``duration``: float, indicating the duration of a benchmark run in seconds.
 
+        - ``stats_*``: (param-list) dictionary containing various statistical
+          indicators. Possible ``*`` are ``ci_99_a``, ``ci_99_b`` (confidence interval
+          estimate lower/upper values), ``q_25`` (lower quartile),
+          ``q_75`` (upper quartile), ``repeat``, and ``number``.
+
         - ``profile``: string, zlib-compressed and base64-encoded
           Python profile dump.
 
-        - ``result``: (param-list) contains the summarized result value(s) of
-          the benchmark. The values are float, NaN or null.
-
-          The values are either numbers indicating result from
-          successful run, ``null`` indicating a failed benchmark,
-          or ``NaN`` indicating a benchmark explicitly skipped by the
-          benchmark suite.
-
         - ``samples``: (param-list) List of samples obtained for a benchmark.
           The samples are in the order they were measured in.
-
-        - ``stats_*``: (param-list) dictionary containing various statistical
-          indicators. Possible ``*`` are ``ci_99_a``, ``ci_99_b`` (confidence interval
-          estimate lower/upper values), ``repeat``, and ``number``.
 
 - ``$html_dir/``: The output of ``asv publish``, that turns the raw
   results in ``$results_dir/`` into something viewable in a web

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -123,7 +123,7 @@ A benchmark suite directory has the following layout.  The
 
       - ``durations``: Duration information for build and setup-cache timings.
 
-      - ``result_keys``: List of column names for the ``results`` dictionary.
+      - ``result_columns``: List of column names for the ``results`` dictionary.
         It is ``["result", "samples", "params", "started_at", "duration",
         "version", "profile", "stats_ci_99_a", "stats_ci_99_b", "stats_q_25",
         "stats_q_75", "stats_min", "stats_max", "stats_mean", "stats_std",

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -99,11 +99,15 @@ A benchmark suite directory has the following layout.  The
 
     - ``HASH-pythonX.X-depA-depB.json``: Each JSON file within a
       particular machine represents a run of benchmarks for a
-      particular project commit in a particular environment.  Useful
-      keys include:
+      particular project commit in a particular environment.  Contains
+      the keys:
+
+      - ``version``: the value ``2``.
 
       - ``commit_hash``: The project commit that the benchmarks were
         run on.
+
+      - ``env_name``: Name of the environment the benchmarks were run in.
 
       - ``date``: A JavaScript date stamp of the date of the commit
         (not when the benchmarks were run).
@@ -111,21 +115,34 @@ A benchmark suite directory has the following layout.  The
       - ``params``: Information about the machine the benchmarks were
         run on.
 
+      - ``python``: Python version of the environment.
+
+      - ``requirements``: Requirements dictionary of the environment.
+
+      - ``env_vars``: Environment variable dictionary of the environment.
+
+      - ``durations``: Duration information for build and setup-cache timings.
+
+      - ``result_keys``: List of column names for the ``results`` dictionary.
+        It is ``["result", "samples", "params", "started_at", "duration",
+        "version", "profile", "stats_ci_99_a", "stats_ci_99_b", "stats_q_25",
+        "stats_q_75", "stats_min", "stats_max", "stats_mean", "stats_std",
+        "stats_number", "stats_repeat"]`` currently.
+
       - ``results``: A dictionary from benchmark names to benchmark
-        results. The item can also be directly the float/list of result
-        values instead of a dictionary.
+        results. The keys are benchmark names, and values are lists
+        such that ``dict(zip(result_keys, results[benchmark_name]))``
+        pairs the appropriate keys with the values.
 
-        The dictionary form can have the following keys:
+        Some items, marked with "(param-list)" below, are lists
+        with items corresponding to results from a parametrized benchmark
+        (see ``params`` below). Non-parametrized benchmarks then have lists
+        with a single item.
 
-        - ``result``: contains the summarized result value(s) of
-          the benchmark. For a non-parameterized benchmark, the value is
-          the result: float, NaN or null. For parameterized
-          benchmarks, it is a list of such values (see ``params`` below).
+        Values except ``params`` can be ``null``, indicating missing data.
 
-          The values are either numbers indicating result from
-          successful run, ``null`` indicating a failed benchmark,
-          or ``NaN`` indicating a benchmark explicitly skipped by the
-          benchmark suite.
+        Floating-point numbers are truncated to 5 significant base-10 digits
+        when saving, in order to produce smaller JSON files.
 
         - ``params``: contains a copy of the parameter values of the
           benchmark, as described above. If the user has modified the benchmark
@@ -137,35 +154,35 @@ A benchmark suite directory has the following layout.  The
           i.e., the results appear in cartesian product order, with
           the last parameters varying fastest.
 
-          This key is omitted if the benchmark is not parameterized.
+          For non-parametrized benchmarks, ``[]``.
 
-        - ``samples``: contains the raw data samples produced.
-          For a non-parameterized benchmark, the result is a single
-          list of float values. For parameterized benchmarks,
-          it is a list of such lists (see below).
+        - ``version``: string, a benchmark version identifier.  Results whose version
+          is not equal to the current version of the benchmark are ignored.
+          If the value is missing, no version comparisons are done
+          (backward compatibility).
+
+        - ``started_at``: Javascript timestamp indicating start time of latest
+          benchmark run.
+
+        - ``duration``: float, indicating the duration of a benchmark run in seconds.
+
+        - ``profile``: string, zlib-compressed and base64-encoded
+          Python profile dump.
+
+        - ``result``: (param-list) contains the summarized result value(s) of
+          the benchmark. The values are float, NaN or null.
+
+          The values are either numbers indicating result from
+          successful run, ``null`` indicating a failed benchmark,
+          or ``NaN`` indicating a benchmark explicitly skipped by the
+          benchmark suite.
+
+        - ``samples``: (param-list) List of samples obtained for a benchmark.
           The samples are in the order they were measured in.
 
-          This key is omitted if there are no samples recorded.
-
-        - ``stats``: dictionary containing results of statistical
-          analysis. Contains keys ``ci_99`` (confidence interval
-          estimate for the result), ``q_25``, ``q_75`` (percentiles),
-          ``min``, ``max``, ``mean``, ``std``, ``repeat``, and
-          ``number``.
-
-          This key is omitted if there is no statistical analysis.
-
-      - ``started_at``: A dictionary from benchmark names to JavaScript
-        time stamps indicating the start time of the last benchmark run.
-
-      - ``duration``: A dictionary from benchmark names to number of seconds
-        (float) indicating the total duration of the last run of benchmarks.
-
-      - ``benchmark_version``: A dictionary from benchmark names to benchmark
-        version identifier (an arbitrary string). Results whose version
-        is not equal to the version of the benchmark are ignored.
-        If the value is missing, no version comparisons are done
-        (backward compatibility).
+        - ``stats_*``: (param-list) dictionary containing various statistical
+          indicators. Possible ``*`` are ``ci_99_a``, ``ci_99_b`` (confidence interval
+          estimate lower/upper values), ``repeat``, and ``number``.
 
 - ``$html_dir/``: The output of ``asv publish``, that turns the raw
   results in ``$results_dir/`` into something viewable in a web

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -17,6 +17,7 @@ from asv import util
 from asv.commands.compare import Compare
 
 from . import tools
+from .tools import example_results
 
 try:
     import hglib
@@ -24,7 +25,6 @@ except ImportError:
     hglib = None
 
 
-RESULT_DIR = abspath(join(dirname(__file__), 'example_results'))
 MACHINE_FILE = abspath(join(dirname(__file__), 'asv-machine.json'))
 
 REFERENCE = """
@@ -140,12 +140,12 @@ REFERENCE_ONLY_CHANGED_MULTIENV = """
 """
 
 
-def test_compare(capsys, tmpdir):
+def test_compare(capsys, tmpdir, example_results):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
 
     conf = config.Config.from_json(
-        {'results_dir': RESULT_DIR,
+        {'results_dir': example_results,
          'repo': tools.generate_test_repo(tmpdir).path,
          'project': 'asv',
          'environment_type': "shouldn't matter what"})
@@ -183,7 +183,7 @@ def test_compare(capsys, tmpdir):
     "git",
     pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))
 ])
-def test_compare_name_lookup(dvcs_type, capsys, tmpdir):
+def test_compare_name_lookup(dvcs_type, capsys, tmpdir, example_results):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
 
@@ -193,14 +193,14 @@ def test_compare_name_lookup(dvcs_type, capsys, tmpdir):
 
     result_dir = os.path.join(tmpdir, 'results')
 
-    src = os.path.join(RESULT_DIR, 'cheetah')
+    src = os.path.join(example_results, 'cheetah')
     dst = os.path.join(result_dir, 'cheetah')
     os.makedirs(dst)
 
     for fn in ['feea15ca-py2.7-Cython-numpy1.8.json', 'machine.json']:
         shutil.copyfile(os.path.join(src, fn), os.path.join(dst, fn))
 
-    shutil.copyfile(os.path.join(RESULT_DIR, 'benchmarks.json'),
+    shutil.copyfile(os.path.join(example_results, 'benchmarks.json'),
                     os.path.join(result_dir, 'benchmarks.json'))
 
     # Copy to different commit

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -24,12 +24,12 @@ from asv.repo import get_repo
 
 
 from . import tools
+from .tools import example_results
 
-RESULT_DIR = abspath(join(dirname(__file__), 'example_results'))
 BENCHMARK_DIR = abspath(join(dirname(__file__), 'benchmark'))
 
 
-def test_publish(tmpdir):
+def test_publish(tmpdir, example_results):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
 
@@ -38,7 +38,7 @@ def test_publish(tmpdir):
     os.makedirs(join(result_dir, 'cheetah'))
 
     # Synthesize history with two branches that both have commits
-    result_files = [fn for fn in os.listdir(join(RESULT_DIR, 'cheetah'))
+    result_files = [fn for fn in os.listdir(join(example_results, 'cheetah'))
                     if fn.endswith('.json') and fn != 'machine.json']
     result_files.sort()
     master_values = list(range(len(result_files)*2//3))
@@ -54,7 +54,7 @@ def test_publish(tmpdir):
     commits = master_commits + only_branch
     for k, item in enumerate(zip(result_files, commits)):
         fn, commit = item
-        src = join(RESULT_DIR, 'cheetah', fn)
+        src = join(example_results, 'cheetah', fn)
         dst = join(result_dir, 'cheetah', commit[:8] + fn[8:])
         try:
             data = util.load_json(src)
@@ -65,9 +65,9 @@ def test_publish(tmpdir):
         data['commit_hash'] = commit
         util.write_json(dst, data)
 
-    shutil.copyfile(join(RESULT_DIR, 'benchmarks.json'),
+    shutil.copyfile(join(example_results, 'benchmarks.json'),
                     join(result_dir, 'benchmarks.json'))
-    shutil.copyfile(join(RESULT_DIR, 'cheetah', 'machine.json'),
+    shutil.copyfile(join(example_results, 'cheetah', 'machine.json'),
                     join(result_dir, 'cheetah', 'machine.json'))
 
     # Publish the synthesized data

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -195,7 +195,7 @@ def test_json_timestamp(tmpdir):
     r.save(tmpdir)
 
     r = util.load_json(join(tmpdir, 'mach', 'aaaa-env.json'))
-    keys = r['result_keys']
+    keys = r['result_columns']
     values = dict(zip(keys, r['results']['some_benchmark']))
     assert values['started_at'] == util.datetime_to_js_timestamp(stamp1)
     assert values['duration'] == duration

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -92,9 +92,9 @@ def test_results(tmpdir):
         r3.load_data(resultsdir)
 
         for rr in [r2, r3]:
-            assert rr._results == _truncate_floats(r._results)
+            assert rr._results == r._results
             assert rr._stats == _truncate_floats(r._stats)
-            assert rr._samples == _truncate_floats(r._samples)
+            assert rr._samples == r._samples
             assert rr._profiles == r._profiles
             assert rr.started_at == r._started_at
             assert rr.duration == _truncate_floats(r._duration)
@@ -106,8 +106,8 @@ def test_results(tmpdir):
             # Get with same parameters as stored
             params = r2.get_result_params(bench)
             assert params == values[bench]['params']
-            assert r2.get_result_value(bench, params) == _truncate_floats(values[bench]['result'])
-            assert r2.get_result_samples(bench, params) == _truncate_floats(values[bench]['samples'])
+            assert r2.get_result_value(bench, params) == values[bench]['result']
+            assert r2.get_result_samples(bench, params) == values[bench]['samples']
             stats = r2.get_result_stats(bench, params)
             if values[bench]['number'][0] is None:
                 assert stats == [None]

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -14,6 +14,20 @@ import six
 from asv import results, runner, util
 import pytest
 
+from .tools import example_results
+
+
+def _truncate_floats(item, digits=5):
+    if isinstance(item, float):
+        fmt = '{{:.{}e}}'.format(digits - 1)
+        return float(fmt.format(item))
+    elif isinstance(item, list):
+        return [_truncate_floats(x, digits) for x in item]
+    elif isinstance(item, dict):
+        return dict((k, _truncate_floats(v)) for k, v in item.items())
+    else:
+        return item
+
 
 def test_results(tmpdir):
     tmpdir = six.text_type(tmpdir)
@@ -78,12 +92,12 @@ def test_results(tmpdir):
         r3.load_data(resultsdir)
 
         for rr in [r2, r3]:
-            assert rr._results == r._results
-            assert rr._stats == r._stats
-            assert rr._samples == r._samples
+            assert rr._results == _truncate_floats(r._results)
+            assert rr._stats == _truncate_floats(r._stats)
+            assert rr._samples == _truncate_floats(r._samples)
             assert rr._profiles == r._profiles
             assert rr.started_at == r._started_at
-            assert rr.duration == r._duration
+            assert rr.duration == _truncate_floats(r._duration)
             assert rr.benchmark_version == r._benchmark_version
 
         # Check the get_* methods
@@ -92,8 +106,8 @@ def test_results(tmpdir):
             # Get with same parameters as stored
             params = r2.get_result_params(bench)
             assert params == values[bench]['params']
-            assert r2.get_result_value(bench, params) == values[bench]['result']
-            assert r2.get_result_samples(bench, params) == values[bench]['samples']
+            assert r2.get_result_value(bench, params) == _truncate_floats(values[bench]['result'])
+            assert r2.get_result_samples(bench, params) == _truncate_floats(values[bench]['samples'])
             stats = r2.get_result_stats(bench, params)
             if values[bench]['number'][0] is None:
                 assert stats == [None]
@@ -144,8 +158,8 @@ def test_get_result_hash_from_prefix(tmpdir):
     assert 'one of multiple commits' in str(excinfo.value)
 
 
-def test_backward_compat_load():
-    resultsdir = join(os.path.dirname(__file__), 'example_results')
+def test_backward_compat_load(example_results):
+    resultsdir = example_results
     filename = join('cheetah', '624da0aa-py2.7-Cython-numpy1.8.json')
 
     r = results.Results.load(join(resultsdir, filename))
@@ -181,14 +195,15 @@ def test_json_timestamp(tmpdir):
     r.save(tmpdir)
 
     r = util.load_json(join(tmpdir, 'mach', 'aaaa-env.json'))
-    assert r['started_at']['some_benchmark'] == util.datetime_to_js_timestamp(stamp1)
-    assert r['duration']['some_benchmark'] == duration
+    keys = r['result_keys']
+    values = dict(zip(keys, r['results']['some_benchmark']))
+    assert values['started_at'] == util.datetime_to_js_timestamp(stamp1)
+    assert values['duration'] == duration
 
 
-def test_iter_results(capsys, tmpdir):
-    src = os.path.join(os.path.dirname(__file__), 'example_results')
+def test_iter_results(capsys, tmpdir, example_results):
     dst = os.path.join(six.text_type(tmpdir), 'example_results')
-    shutil.copytree(src, dst)
+    shutil.copytree(example_results, dst)
 
     path = os.path.join(dst, 'cheetah')
 

--- a/test/test_rm.py
+++ b/test/test_rm.py
@@ -13,13 +13,14 @@ from asv import config
 from asv import results
 
 from . import tools
+from .tools import example_results
 
 
-def test_rm(tmpdir):
+def test_rm(tmpdir, example_results):
     tmpdir = six.text_type(tmpdir)
 
     shutil.copytree(
-        join(dirname(__file__), 'example_results'),
+        example_results,
         join(tmpdir, 'example_results'))
 
     conf = config.Config.from_json({

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -176,7 +176,7 @@ def test_run_build_failure(basic_conf):
     data_ok = util.load_json(fn_ok)
 
     for data in (data_broken, data_ok):
-        value = dict(zip(data['result_keys'], data['results'][bench_name]))
+        value = dict(zip(data['result_columns'], data['results'][bench_name]))
         assert value['started_at'] >= timestamp
         if data is data_broken:
             assert 'duration' not in value
@@ -185,8 +185,8 @@ def test_run_build_failure(basic_conf):
 
     assert len(data_broken['results']) == 1
     assert len(data_ok['results']) == 1
-    assert data_broken['result_keys'][0] == 'result'
-    assert data_ok['result_keys'][0] == 'result'
+    assert data_broken['result_columns'][0] == 'result'
+    assert data_ok['result_columns'][0] == 'result'
     assert data_broken['results'][bench_name][0] is None
     assert data_ok['results'][bench_name][0] == [42.0]
 
@@ -215,7 +215,7 @@ def test_run_with_repo_subdir(basic_conf_with_subdir):
                                  '*-*.json'))  # avoid machine.json
     data = util.load_json(fn_results)
 
-    value = dict(zip(data['result_keys'], data['results'][bench_name]))
+    value = dict(zip(data['result_columns'], data['results'][bench_name]))
     assert value['params'] == [['1', '2']]
     assert value['result'] == [6, 6]
 
@@ -233,7 +233,7 @@ def test_benchmark_param_selection(basic_conf):
         results = util.load_json(glob.glob(join(
             tmpdir, 'results_workflow', 'orangutan', '*-*.json'))[0])
         # replacing NaN by 'n/a' make assertions easier
-        keys = results['result_keys']
+        keys = results['result_columns']
         value = dict(zip(keys, results['results']['params_examples.track_param_selection']))
         return ['n/a' if util.is_nan(item) else item
                 for item in value['result']]
@@ -269,13 +269,13 @@ def test_run_append_samples(basic_conf):
                   if fn != 'machine.json']
 
     data = util.load_json(result_fn)
-    value = dict(zip(data['result_keys'], data['results']['time_examples.TimeSuite.time_example_benchmark_1']))
+    value = dict(zip(data['result_columns'], data['results']['time_examples.TimeSuite.time_example_benchmark_1']))
     assert value['stats_q_25'][0] is not None
     assert len(value['samples'][0]) == 1
 
     run_it()
     data = util.load_json(result_fn)
-    value = dict(zip(data['result_keys'], data['results']['time_examples.TimeSuite.time_example_benchmark_1']))
+    value = dict(zip(data['result_columns'], data['results']['time_examples.TimeSuite.time_example_benchmark_1']))
     assert len(value['samples'][0]) == 2
 
 
@@ -319,7 +319,7 @@ def test_env_matrix_value(basic_conf):
         result_fn2, = glob.glob(result_dir + '/*-SOME_TEST_VAR2.json')
 
         data = util.load_json(result_fn1)
-        assert data['result_keys'][0] == 'result'
+        assert data['result_columns'][0] == 'result'
         assert data['results']['time_secondary.track_environment_value'][0] == [1]
 
         data = util.load_json(result_fn2)

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -91,7 +91,7 @@ def test_run_benchmarks(benchmarks_fixture, tmpdir):
     assert times[
         'time_examples.TimeSuite.time_example_benchmark_1'].result != [None]
     stats = results.get_result_stats(name, b[name]['params'])
-    assert isinstance(stats[0]['std'], float)
+    assert isinstance(stats[0]['q_25'], float)
     # The exact number of samples may vary if the calibration is not fully accurate
     samples = results.get_result_samples(name, b[name]['params'])
     assert len(samples[0]) >= 4

--- a/test/test_show.py
+++ b/test/test_show.py
@@ -13,21 +13,21 @@ import textwrap
 from asv import config
 
 from . import tools
+from .tools import example_results
 
 import pytest
 
 
-RESULT_DIR = abspath(join(dirname(__file__), 'example_results'))
 BENCHMARK_DIR = abspath(join(dirname(__file__), 'example_results'))
 MACHINE_FILE = abspath(join(dirname(__file__), 'asv-machine.json'))
 
 @pytest.fixture
-def show_fixture(tmpdir):
+def show_fixture(tmpdir, example_results):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
 
     conf = config.Config.from_json(
-        {'results_dir': RESULT_DIR,
+        {'results_dir': example_results,
          'repo': tools.generate_test_repo(tmpdir).path,
          'project': 'asv',
          'environment_type': "shouldn't matter what"})

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -42,7 +42,7 @@ def test_compute_stats():
 
     assert statistics.compute_stats([], 1) == (None, None)
     assert statistics.compute_stats([15.0], 1) == (
-        15.0, {'ci_99': [-inf, inf], 'max': 15.0, 'mean': 15.0, 'min': 15.0,
+        15.0, {'ci_99_a': -inf, 'ci_99_b': inf, 'max': 15.0, 'mean': 15.0, 'min': 15.0,
                'number': 1, 'q_25': 15.0, 'q_75': 15.0, 'repeat': 1, 'std': 0.0})
 
     for nsamples, true_mean in product([10, 50, 250], [0, 0.3, 0.6]):
@@ -59,7 +59,7 @@ def test_compute_stats():
         assert np.allclose(stats['std'], np.std(samples, ddof=0))
         assert np.allclose(result, np.median(samples))
 
-        ci = stats['ci_99']
+        ci = stats['ci_99_a'], stats['ci_99_b']
         assert ci[0] <= true_mean <= ci[1]
         w = 12.0 * np.std(samples) / np.sqrt(len(samples))
         assert ci[1] - ci[0] < w

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -42,8 +42,8 @@ def test_compute_stats():
 
     assert statistics.compute_stats([], 1) == (None, None)
     assert statistics.compute_stats([15.0], 1) == (
-        15.0, {'ci_99_a': -inf, 'ci_99_b': inf, 'max': 15.0, 'mean': 15.0, 'min': 15.0,
-               'number': 1, 'q_25': 15.0, 'q_75': 15.0, 'repeat': 1, 'std': 0.0})
+        15.0, {'ci_99_a': -inf, 'ci_99_b': inf,
+               'number': 1, 'q_25': 15.0, 'q_75': 15.0, 'repeat': 1})
 
     for nsamples, true_mean in product([10, 50, 250], [0, 0.3, 0.6]):
         samples = np.random.randn(nsamples) + true_mean
@@ -51,12 +51,8 @@ def test_compute_stats():
 
         assert stats['repeat'] == len(samples)
         assert stats['number'] == 42
-        assert np.allclose(stats['mean'], np.mean(samples))
         assert np.allclose(stats['q_25'], np.percentile(samples, 25))
         assert np.allclose(stats['q_75'], np.percentile(samples, 75))
-        assert np.allclose(stats['min'], np.min(samples))
-        assert np.allclose(stats['max'], np.max(samples))
-        assert np.allclose(stats['std'], np.std(samples, ddof=0))
         assert np.allclose(result, np.median(samples))
 
         ci = stats['ci_99_a'], stats['ci_99_b']

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -34,21 +34,28 @@ def test_update_simple(monkeypatch, generate_result_dir):
     # Check renaming of long result files
     machine_dir = os.path.join(basedir, 'results', 'tarzan')
 
-    result_fn = [fn for fn in os.listdir(machine_dir)
-                 if fn != 'machine.json'][0]
+    result_fns = [fn for fn in sorted(os.listdir(machine_dir))
+                  if fn != 'machine.json']
     long_result_fn = 'abbacaca-' + 'a'*128 + '.json'
     hash_result_fn = ('abbacaca-env-'
                       + hashlib.md5(b'a'*128).hexdigest()
                       + '.json')
 
-    shutil.copyfile(os.path.join(machine_dir, result_fn),
+    shutil.copyfile(os.path.join(machine_dir, result_fns[0]),
                     os.path.join(machine_dir, long_result_fn))
+
+    old_env_name = util.load_json(os.path.join(machine_dir, result_fns[0]))['env_name']
 
     # Should succeed
     monkeypatch.chdir(basedir)
     tools.run_asv_with_conf(conf, "update", _machine_file=machine_file)
 
     # Check file rename
-    items = [fn.lower() for fn in os.listdir(machine_dir)]
-    assert long_result_fn not in items
-    assert hash_result_fn in items
+    items = [fn for fn in sorted(os.listdir(machine_dir))
+             if fn != 'machine.json']
+    assert long_result_fn.lower() not in [x.lower() for x in items]
+    assert hash_result_fn.lower() in [x.lower() for x in items]
+
+    # Check env name is preserved
+    new_env_name = util.load_json(os.path.join(machine_dir, items[0]))['env_name']
+    assert old_env_name == new_env_name

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -46,7 +46,7 @@ def test_update_simple(monkeypatch, generate_result_dir):
 
     # Should succeed
     monkeypatch.chdir(basedir)
-    tools.run_asv("update", _machine_file=machine_file)
+    tools.run_asv_with_conf(conf, "update", _machine_file=machine_file)
 
     # Check file rename
     items = [fn.lower() for fn in os.listdir(machine_dir)]

--- a/test/tools.py
+++ b/test/tools.py
@@ -472,21 +472,24 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
 
     benchmark_version = sha256(os.urandom(16)).hexdigest()
 
-    params = None
+    params = []
     param_names = None
     for commit, value in values.items():
         if isinstance(value, dict):
             params = value["params"]
+            value = value["result"]
+        else:
+            value = [value]
         result = Results({"machine": "tarzan"}, {}, commit,
                          repo.get_date_from_name(commit), "2.7", None, {})
         value = runner.BenchmarkResult(
-            result=[value],
-            samples=[None],
-            number=[None],
+            result=value,
+            samples=[None]*len(value),
+            number=[None]*len(value),
             errcode=0,
             stderr='',
             profile=None)
-        result.add_result({"name": "time_func", "version": benchmark_version, "params": []},
+        result.add_result({"name": "time_func", "version": benchmark_version, "params": params},
                           value, started_at=timestamp, duration=1.0)
         result.save(result_dir)
 

--- a/test/tools.py
+++ b/test/tools.py
@@ -505,6 +505,30 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
 
 
 @pytest.fixture(scope="session")
+def example_results(request):
+    with locked_cache_dir(request.config, "example-results") as cache_dir:
+        src = abspath(join(dirname(__file__), 'example_results'))
+        dst = abspath(join(cache_dir, 'results'))
+
+        if os.path.isdir(dst):
+            return dst
+
+        shutil.copytree(src, dst)
+
+        src_machine = join(dirname(__file__), 'asv-machine.json')
+        dst_machine = join(cache_dir, 'asv-machine.json')
+        shutil.copyfile(src_machine, dst_machine)
+
+        # Convert to current file format
+        conf = config.Config.from_json({'results_dir': dst,
+                                        'repo': 'none',
+                                        'project': 'asv'})
+        run_asv_with_conf(conf, 'update', _machine_file=dst_machine)
+
+        return dst
+
+
+@pytest.fixture(scope="session")
 def browser(request, pytestconfig):
     """
     Fixture for Selenium WebDriver browser interface


### PR DESCRIPTION
Avoid repeating key names, drop unused data, and store stats/duration
at reduced precision. Gives roughly 3x space saving. Probably no further
significant reductions can be made as long as using text format.

Closes: #609