### PR TITLE
 Rewrite check_output on Windows to not be prone to deadlocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,12 +94,12 @@ install:
         $TRAVIS_PIP install virtualenv numpy scipy;
       fi
     fi
-    $TRAVIS_PIP install selenium six "pytest>=4.4.0" "pytest-xdist" pytest-rerunfailures feedparser python-hglib lockfile;
+    $TRAVIS_PIP install selenium six "pytest>=4.4.0" "pytest-xdist" pytest-rerunfailures pytest-faulthandler pytest-timeout feedparser python-hglib lockfile;
     if [[ "$COVERAGE" != '' ]]; then $TRAVIS_PIP install pytest-cov codecov; fi;
   - $TRAVIS_PYTHON setup.py build_ext -i
 
 script:
-  - $TRAVIS_PYTHON -m pytest -l $COVERAGE -n 3 -v -v --webdriver=FirefoxHeadless test
+  - $TRAVIS_PYTHON -m pytest -l $COVERAGE -n 3 -v -v --webdriver=FirefoxHeadless --timeout=1800 --timeout-method=thread --durations=100 test
 
 after_script:
   - if [[ "$COVERAGE" != '' ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,8 +32,8 @@ install:
     - "%PYTHON%\\Scripts\\activate.bat"
 
     # Install the build and runtime dependencies of the project.
-    - "conda install -q --yes python=%PYTHON_VERSION% conda six pip pytest pytest-xdist lockfile selenium conda-build bzip2"
-    - "python -mpip install pytest-rerunfailures"
+    - "conda install -q --yes python=%PYTHON_VERSION% conda six pip pytest pytest-xdist pytest-timeout lockfile selenium conda-build bzip2"
+    - "python -mpip install pytest-rerunfailures pytest-faulthandler"
 
     # Tell conda to not use hardlinks: on Windows it's not possible
     # to delete hard links to files in use, which causes problem when
@@ -54,7 +54,7 @@ install:
 build: false
 
 test_script:
-    - "python -m pytest -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp -v -v --webdriver=FirefoxHeadless test"
+    - "python -m pytest -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp -n 2 -v -v --webdriver=FirefoxHeadless --timeout=1800 --durations=100 test"
 
 after_build:
     # Clear up pip cache

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -158,6 +158,13 @@ def test_popen():
     popen.communicate()
 
 
+def test_large_output():
+    # More data than a pipe buffer can hold
+    data = util.check_output([sys.executable, "-c",
+                              "import sys; [sys.stdout.write('x'*1000) for j in range(5000)]"])
+    assert data == 'x'*5000000
+
+
 # This *does* seem to work, only seems untestable somehow...
 # def test_dots(capsys):
 #     code = r"""

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -88,6 +88,7 @@ def basic_conf(tmpdir, dummy_packages):
 
 def test_run_publish(capfd, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
+    tmpdir = util.long_path(tmpdir)
 
     conf.matrix = {
         "req": dict(conf.matrix),


### PR DESCRIPTION
Unclear whether there is a real issue with this code (or if it's just conda hanging),
so this is partially debugging the issue on the CI.