### PR TITLE
CI: reduce number of Travis-CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,25 +30,17 @@ matrix:
     - python: 3.8-dev
       dist: xenial
 
-    - python: 3.7
-      dist: xenial
-
-    - python: 2.7
-
     - python: 3.6
-
-    - python: 3.5
-
-    - python: 2.7
       env:
         - USE_CONDA=true
         - COVERAGE="--cov=asv --cov=test"
 
-    - python: 3.6
-      env: USE_CONDA=true
-
     - python: pypy3
       dist: xenial
+
+    - python: 2.7
+
+    - python: 3.5
 
 cache:
   directories:


### PR DESCRIPTION
Drop conda Py2 and virtualenv Py3.6, Py3.7.  Travis + Appveyor cover
together the supported python versions.