### PR TITLE
TST: Disable W3C mode in Chrome webdriver.

### DIFF
--- a/test/tools.py
+++ b/test/tools.py
@@ -514,6 +514,7 @@ def browser(request, pytestconfig):
     def ChromeHeadless():
         options = selenium.webdriver.ChromeOptions()
         options.add_argument('headless')
+        options.add_experimental_option('w3c', False)
         return selenium.webdriver.Chrome(options=options)
 
     ns = {}


### PR DESCRIPTION
When Chrome driver [was updated to 75](https://apps.fedoraproject.org/koschei/build/6587238), tests started failing ([full log](https://kojipkgs.fedoraproject.org/work/tasks/912/36190912/build.log)) with:

> E       selenium.common.exceptions.WebDriverException: Message: unknown command: Cannot call non W3C standard command while in W3C mode

This disables W3C mode, so that tests will continue to work. There's not much in the error message, so I haven't quite figured out what doesn't work here, but this enables tests to pass again.