### PR TITLE
Print if setup was skipped with the corresponding message if provided

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -548,8 +548,9 @@ class Benchmark(object):
         try:
             for setup in self._setups:
                 setup(*self._current_params)
-        except NotImplementedError:
+        except NotImplementedError as e:
             # allow skipping test
+            print("asv: skipped: {!r} ".format(e))
             return True
         return False
 


### PR DESCRIPTION
I find it very useful to see if a benchmark was skipped at all during execution and to get the reason as they can be quite intricate sometimes.

I was not sure how to print the message, as this is a peculiar file. I chose `stderr` since it is unbuffered and feels semantically right, but I have no strong opinions on the matter.