### PR TITLE
Sort the environment variables when building the environment name

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -285,7 +285,7 @@ def get_env_name(tool_name, python, requirements, tagged_env_vars, build=False):
 
     env_vars = _untag_env_vars(tagged_env_vars, build=build)
 
-    for env_var, value in six.iteritems(env_vars):
+    for env_var, value in sorted(six.iteritems(env_vars)):
         name.append(''.join([env_var, value]))
 
     return util.sanitize_filename('-'.join(name))


### PR DESCRIPTION
The environment variables were added after sorting the list. This makes tests unreliable.