### PR TITLE
MAINT: switch from deprecated lockfile to filelock

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - "%CONDA_PATH%\\Scripts\\activate.bat"
 
   # Install the build and runtime dependencies of the project.
-  - conda install -q --yes python=%PYTHON_VERSION% conda six pip pytest pytest-xdist pytest-timeout lockfile selenium conda-build bzip2
+  - conda install -q --yes python=%PYTHON_VERSION% conda six pip pytest pytest-xdist pytest-timeout filelock selenium conda-build bzip2
   - python -mpip install pytest-rerunfailures pytest-faulthandler
 
   # Check that we have the expected version of Python

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ install:
         $TRAVIS_PIP install virtualenv numpy scipy;
       fi
     fi
-    $TRAVIS_PIP install selenium six "pytest>=4.4.0" "pytest-xdist" pytest-rerunfailures pytest-faulthandler pytest-timeout feedparser python-hglib lockfile;
+    $TRAVIS_PIP install selenium six "pytest>=4.4.0" "pytest-xdist" pytest-rerunfailures pytest-faulthandler pytest-timeout feedparser python-hglib filelock;
     if [[ "$COVERAGE" != '' ]]; then $TRAVIS_PIP install pytest-cov codecov; fi;
   - $TRAVIS_PYTHON setup.py build_ext -i
 

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ def run_setup(build_binary=False):
         zip_safe=False,
 
         # py.test testing
-        tests_require=['pytest', 'lockfile'],
+        tests_require=['pytest', 'filelock'],
         cmdclass=cmdclass,
 
         author="Michael Droettboom",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,12 +32,12 @@ def pytest_sessionstart(session):
 def _monkeypatch_conda_lock(config):
     import asv.plugins.conda
     import asv.util
-    import lockfile
+    import filelock
 
     @contextlib.contextmanager
     def _conda_lock():
         conda_lock = asv.util.get_multiprocessing_lock("conda_lock")
-        with conda_lock, lockfile.LockFile(str(path)):
+        with conda_lock, filelock.FileLock(str(path)):
             yield
 
     path = config.cache.makedir('conda-lock') / 'lock'

--- a/test/tools.py
+++ b/test/tools.py
@@ -97,7 +97,7 @@ except ImportError:
 WAIT_TIME = 20.0
 
 
-from lockfile import LockFile
+from filelock import FileLock
 
 
 def get_default_environment_type(conf, python):
@@ -111,7 +111,7 @@ def locked_cache_dir(config, cache_key, timeout=900, tag=None):
     lockfile = join(six.text_type(base_dir), 'lock')
     cache_dir = join(six.text_type(base_dir), 'cache')
 
-    lock = LockFile(lockfile)
+    lock = FileLock(lockfile)
     lock.acquire(timeout=timeout)
     try:
         # Clear cache dir contents if it was generated with different


### PR DESCRIPTION
The `lockfile` package is deprecated: https://pypi.org/project/lockfile/
```
Note: This package is deprecated
```
Additionally, the upstream repo has gone out of its way to hide the source code: https://opendev.org/openstack/pylockfile/

The `filelock` package implements an equivalent API, is actively maintained, and already included in the base dependencies by anaconda.