### PR TITLE
Add --strict flag to exit non-zero on benchmark failures

### DIFF
--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -48,6 +48,10 @@ class Continuous(Command):
             can take longer.""")
         parser.add_argument(
             "--no-interleave-processes", action="store_false", dest="interleave_processes")
+        parser.add_argument(
+            "--strict", action="store_true",
+            help="When set true the run command will exit with a non-zero "
+                 "return code if any benchmark is in a failed state")
         common_args.add_compare(parser, sort_default='ratio', only_changed_default=True)
         common_args.add_show_stderr(parser)
         common_args.add_bench(parser)
@@ -69,7 +73,7 @@ class Continuous(Command):
             env_spec=args.env_spec, record_samples=args.record_samples,
             append_samples=args.append_samples,
             quick=args.quick, interleave_processes=args.interleave_processes,
-            launch_method=args.launch_method, **kwargs
+            launch_method=args.launch_method, strict=args.strict, **kwargs
         )
 
     @classmethod
@@ -77,7 +81,8 @@ class Continuous(Command):
             factor=None, split=False, only_changed=True, sort='ratio',
             show_stderr=False, bench=None,
             attribute=None, machine=None, env_spec=None, record_samples=False, append_samples=False,
-            quick=False, interleave_processes=None, launch_method=None, _machine_file=None):
+            quick=False, interleave_processes=None, launch_method=None, _machine_file=None,
+            strict=False):
         repo = get_repo(conf)
         repo.pull()
 
@@ -102,7 +107,7 @@ class Continuous(Command):
             show_stderr=show_stderr, machine=machine, env_spec=env_spec,
             record_samples=record_samples, append_samples=append_samples, quick=quick,
             interleave_processes=interleave_processes,
-            launch_method=launch_method,
+            launch_method=launch_method, strict=strict,
             _returns=run_objs, _machine_file=_machine_file)
         if result:
             return result

--- a/asv/commands/dev.py
+++ b/asv/commands/dev.py
@@ -22,6 +22,10 @@ class Dev(Run):
         common_args.add_bench(parser)
         common_args.add_machine(parser)
         common_args.add_environment(parser, default_same=True)
+        parser.add_argument(
+            "--strict", action="store_true",
+            help="When set true the run command will exit with a non-zero "
+                 "return code if any benchmark is in a failed state")
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
@@ -30,13 +34,15 @@ class Dev(Run):
     def run_from_conf_args(cls, conf, args, **kwargs):
         return cls.run(conf, bench=args.bench, attribute=args.attribute,
                        machine=args.machine, env_spec=args.env_spec,
-                       **kwargs)
+                       strict=args.strict, **kwargs)
 
     @classmethod
-    def run(cls, conf, bench=None, attribute=None, env_spec=None, machine=None, _machine_file=None):
+    def run(cls, conf, bench=None, attribute=None, env_spec=None, machine=None,
+            strict=False, _machine_file=None):
         if not env_spec:
             env_spec = ["existing:same"]
         return super(cls, Dev).run(conf=conf, bench=bench, attribute=attribute,
                                    show_stderr=True, quick=True,
                                    env_spec=env_spec, machine=machine, dry_run=True,
+                                   strict=strict,
                                    _machine_file=_machine_file)

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -224,7 +224,7 @@ class Run(Command):
             repo.pull()
 
         # Track failures across the run command
-        failures = []
+        failures = False
 
         # Comparison period for date_period filtering
         old_commit_hashes = None
@@ -506,6 +506,7 @@ class Run(Command):
 
                         if not skip_save:
                             result.save(conf.results_dir)
+
                         if strict:
                             failures = failures or any(
                                 code != 0 for code in result.errcode.values())

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -507,17 +507,15 @@ class Run(Command):
                         if not skip_save:
                             result.save(conf.results_dir)
                         if strict:
-                            failed = [
-                                failed_bench for failed_bench in
-                                result.errcode if
-                                result.errcode[failed_bench] != 0]
-                            failures += failed
+                            failures = failures or any(
+                                code != 0 for code in result.errcode.values())
 
                         if durations > 0:
                             duration_set = Show._get_durations([(machine, result)], benchmark_set)
                             log.info(cls.format_durations(duration_set[(machine, env.name)], durations))
+
         if failures and strict:
-            return len(failures)
+            return 2
 
     @classmethod
     def format_durations(cls, durations, num_durations):

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -158,6 +158,10 @@ class Run(Command):
         parser.add_argument(
             "--no-pull", action="store_true",
             help="Do not pull the repository")
+        parser.add_argument(
+            "--strict", action="store_true",
+            help="When set true the run command will exit with a non-zero "
+                 "return code if any benchmark is in a failed state")
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -177,7 +181,7 @@ class Run(Command):
             record_samples=args.record_samples, append_samples=args.append_samples,
             pull=not args.no_pull, interleave_processes=args.interleave_processes,
             launch_method=args.launch_method, durations=args.durations,
-            **kwargs
+            strict=args.strict, **kwargs
         )
 
     @classmethod
@@ -187,7 +191,7 @@ class Run(Command):
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
             skip_failed=False, skip_existing_commits=False, record_samples=False,
             append_samples=False, pull=True, interleave_processes=False,
-            launch_method=None, durations=0, _returns={}):
+            launch_method=None, durations=0, strict=False, _returns={}):
         machine_params = Machine.load(
             machine_name=machine,
             _path=_machine_file, interactive=True)
@@ -218,6 +222,9 @@ class Run(Command):
         repo = get_repo(conf)
         if pull:
             repo.pull()
+
+        # Track failures across the run command
+        failures = []
 
         # Comparison period for date_period filtering
         old_commit_hashes = None
@@ -499,10 +506,18 @@ class Run(Command):
 
                         if not skip_save:
                             result.save(conf.results_dir)
+                        if strict:
+                            failed = [
+                                failed_bench for failed_bench in
+                                result.errcode if
+                                result.errcode[failed_bench] != 0]
+                            failures += failed
 
                         if durations > 0:
                             duration_set = Show._get_durations([(machine, result)], benchmark_set)
                             log.info(cls.format_durations(duration_set[(machine, env.name)], durations))
+        if failures and strict:
+            return len(failures)
 
     @classmethod
     def format_durations(cls, durations, num_durations):

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -70,8 +70,9 @@ def test_dev(capsys, basic_conf):
     tmpdir, local, conf = basic_conf
 
     # Test Dev runs (with full benchmark suite)
-    tools.run_asv_with_conf(conf, 'dev',
-                            _machine_file=join(tmpdir, 'asv-machine.json'))
+    ret = tools.run_asv_with_conf(conf, 'dev',
+                                  _machine_file=join(tmpdir, 'asv-machine.json'))
+    assert ret is None
     text, err = capsys.readouterr()
 
     # time_with_warnings failure case
@@ -101,6 +102,14 @@ def test_dev_with_repo_subdir(capsys, basic_conf_with_subdir):
     # Check that it did not clone or install
     assert "Cloning" not in text
     assert "Installing" not in text
+
+
+def test_dev_strict(basic_conf):
+    tmpdir, local, conf = basic_conf
+    ret = tools.run_asv_with_conf(conf, 'dev', '--strict',
+                                  '--bench=TimeSecondary',
+                                  _machine_file=join(tmpdir, 'asv-machine.json'))
+    assert ret == 2
 
 
 def test_run_python_same(capsys, basic_conf):

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -402,9 +402,7 @@ def test_format_durations():
 def test_return_code_strict_mode(tmpdir, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
 
-
-
-    res = tools.run_asv_with_conf(conf, 'run', 'master',
+    res = tools.run_asv_with_conf(conf, 'run', 'master^!', '--quick',
                                   '--strict', '--bench', 'TimeSecondary',
                                   _machine_file=machine_file)
     assert res == 2

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -397,3 +397,14 @@ def test_format_durations():
        total         6.00s      
     =========== ================""")
     assert msg == expected
+
+
+def test_return_code_strict_mode(tmpdir, basic_conf):
+    tmpdir, local, conf, machine_file = basic_conf
+
+
+
+    res = tools.run_asv_with_conf(conf, 'run', 'master',
+                                  '--strict', '--bench', 'TimeSecondary',
+                                  _machine_file=machine_file)
+    assert res == 2

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -93,11 +93,12 @@ def test_run_publish(capfd, basic_conf):
     }
 
     # Tests a typical complete run/publish workflow
-    tools.run_asv_with_conf(conf, 'run', "master", '--steps=2',
-                            '--quick', '--show-stderr', '--profile',
-                            '-a', 'warmup_time=0',
-                            '--durations=5',
-                            _machine_file=machine_file)
+    ret = tools.run_asv_with_conf(conf, 'run', "master", '--steps=2',
+                                  '--quick', '--show-stderr', '--profile',
+                                  '-a', 'warmup_time=0',
+                                  '--durations=5',
+                                  _machine_file=machine_file)
+    assert ret is None
     text, err = capfd.readouterr()
 
     assert len(os.listdir(join(tmpdir, 'results_workflow', 'orangutan'))) == 5


### PR DESCRIPTION
This commit adds a new flag, --strict, to the run (and by extension dev)
and continous commands. When set any benchmark failures encountered
will be treated as an error and the command will exit non-zero when the
run is finished. This is especially useful when running benchmarks in
a CI system or similar automated environment and wish to know if a
change was made to break a benchmark.

Fixes #449