### PR TITLE
BUG: fix mutable list value init

### DIFF
--- a/asv/results.py
+++ b/asv/results.py
@@ -723,7 +723,7 @@ class Results(object):
                     elif key.startswith('stats_'):
                         if value is not None:
                             if name not in obj._stats:
-                                obj._stats[name] = [{}]*len(value)
+                                obj._stats[name] = [{} for _ in value]
 
                             stats_key = key[6:]
                             for j, v in enumerate(value):

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -60,6 +60,9 @@ def test_results(tmpdir):
                                   'version': "1", 'profile': b'\x00\xff'},
             'suite2.benchmark1': {'result': [x3], 'number': [None],
                                   'samples': [None], 'params': [['c']],
+                                  'version': None, 'profile': b'\x00\xff'},
+            'suite3.benchmark1': {'result': [x1, x2], 'number': [1, 1],
+                                  'samples': [[x1,x1], [x2,x2,x3]], 'params': [['c', 'd']],
                                   'version': None, 'profile': b'\x00\xff'}
         }
 


### PR DESCRIPTION
This managed to slip by... Added a test for the parametrized benchmark loading with nontrivial stats values.