### PR TITLE
Add support for running tests with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = py27,py34,py35,py36,py37
+minversion = 2.3.1
+skipsdist = True
+
+[testenv]
+sitepackages = False
+usedevelop = True
+install_command = pip install {opts} {packages}
+deps =
+    pytest>=4.4.0
+    virtualenv
+    numpy
+    scipy
+    selenium
+    six
+    pytest-xdist
+    pytest-rerunfailures
+    pytest-faulthandler
+    pytest-timeout
+    feedparser
+    python-hglib
+    filelock
+commands =
+    python setup.py build_ext -i
+    pytest {posargs}


### PR DESCRIPTION
This commit adds a tox.ini file to support using [tox](https://tox.readthedocs.io/en/latest/) to run unit
tests locally. Tox makes it simple for users and contributors to run
tests locally with just the tox command. It will handle building a venv
installing asv in that venv and then running tests. It's especially useful
for testing multiple versions of python since it will build and maintain
separate testing venvs for running with multiple python interpreters.