### PR TITLE
Make 'asv dev' exactly equivalent to 'asv run' with --python=same default

### DIFF
--- a/asv/commands/dev.py
+++ b/asv/commands/dev.py
@@ -16,33 +16,17 @@ class Dev(Run):
             "dev", help="Do a test run of a benchmark suite during development",
             description="""
                 This runs a benchmark suite in a mode that is useful
-                during development.  It is equivalent to ``asv run
-                --quick --show-stderr --python=same``""")
+                during development.  It is equivalent to
+                ``asv run --python=same``""")
 
-        common_args.add_bench(parser)
-        common_args.add_machine(parser)
-        common_args.add_environment(parser, default_same=True)
-        parser.add_argument(
-            "--strict", action="store_true",
-            help="When set true the run command will exit with a non-zero "
-                 "return code if any benchmark is in a failed state")
+        cls._setup_arguments(parser, env_default_same=True)
+
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
 
     @classmethod
-    def run_from_conf_args(cls, conf, args, **kwargs):
-        return cls.run(conf, bench=args.bench, attribute=args.attribute,
-                       machine=args.machine, env_spec=args.env_spec,
-                       strict=args.strict, **kwargs)
-
-    @classmethod
-    def run(cls, conf, bench=None, attribute=None, env_spec=None, machine=None,
-            strict=False, _machine_file=None):
-        if not env_spec:
-            env_spec = ["existing:same"]
-        return super(cls, Dev).run(conf=conf, bench=bench, attribute=attribute,
-                                   show_stderr=True, quick=True,
-                                   env_spec=env_spec, machine=machine, dry_run=True,
-                                   strict=strict,
-                                   _machine_file=_machine_file)
+    def run(cls, conf, **kwargs):
+        if not kwargs.get("env_spec"):
+            kwargs["env_spec"] = ["existing:same"]
+        return super(cls, Dev).run(conf=conf, **kwargs)

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -77,6 +77,14 @@ class Run(Command):
                   asv run "--merges master"  run for only merge commits (git)
                 """))
 
+        cls._setup_arguments(parser)
+
+        parser.set_defaults(func=cls.run_from_args)
+
+        return parser
+
+    @classmethod
+    def _setup_arguments(cls, parser, env_default_same=False):
         parser.add_argument(
             'range', nargs='?', default=None,
             help="""Range of commits to benchmark.  For a git
@@ -119,7 +127,7 @@ class Run(Command):
             run only once.  This is useful to find basic errors in the
             benchmark functions faster.  The results are unlikely to
             be useful, and thus are not saved.""")
-        common_args.add_environment(parser)
+        common_args.add_environment(parser, default_same=env_default_same)
         parser.add_argument(
             "--set-commit-hash", default=None,
             help="""Set the commit hash to use when recording benchmark
@@ -162,10 +170,6 @@ class Run(Command):
             "--strict", action="store_true",
             help="When set true the run command will exit with a non-zero "
                  "return code if any benchmark is in a failed state")
-
-        parser.set_defaults(func=cls.run_from_args)
-
-        return parser
 
     @classmethod
     def run_from_conf_args(cls, conf, args, **kwargs):

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -70,7 +70,7 @@ def test_dev(capsys, basic_conf):
     tmpdir, local, conf = basic_conf
 
     # Test Dev runs (with full benchmark suite)
-    ret = tools.run_asv_with_conf(conf, 'dev',
+    ret = tools.run_asv_with_conf(conf, 'dev', '--quick', '-e',
                                   _machine_file=join(tmpdir, 'asv-machine.json'))
     assert ret is None
     text, err = capsys.readouterr()
@@ -91,7 +91,7 @@ def test_dev_with_repo_subdir(capsys, basic_conf_with_subdir):
     tmpdir, local, conf = basic_conf_with_subdir
 
     # Test Dev runs
-    tools.run_asv_with_conf(conf, 'dev',
+    tools.run_asv_with_conf(conf, 'dev', '--quick',
                             '--bench=time_secondary.track_value',
                             _machine_file=join(tmpdir, 'asv-machine.json'))
     text, err = capsys.readouterr()
@@ -106,7 +106,7 @@ def test_dev_with_repo_subdir(capsys, basic_conf_with_subdir):
 
 def test_dev_strict(basic_conf):
     tmpdir, local, conf = basic_conf
-    ret = tools.run_asv_with_conf(conf, 'dev', '--strict',
+    ret = tools.run_asv_with_conf(conf, 'dev', '--strict', '--quick',
                                   '--bench=TimeSecondary',
                                   _machine_file=join(tmpdir, 'asv-machine.json'))
     assert ret == 2


### PR DESCRIPTION
Change `asv dev` behavior to be same as `asv run` with `--python=same` default,
dropping `--show-stderr` and `--quick` options.

Closes: gh-872