### PR TITLE
Resolve --set-commit-hash hash from the repository

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -223,6 +223,9 @@ class Run(Command):
         if pull:
             repo.pull()
 
+        if set_commit_hash is not None:
+            set_commit_hash = repo.get_hash_from_name(set_commit_hash)
+
         # Track failures across the run command
         failures = False
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -49,7 +49,8 @@ def test_set_commit_hash(capsys, existing_env_conf):
     r = repo.get_repo(conf)
     commit_hash = r.get_hash_from_name(r.get_branch_name())
 
-    tools.run_asv_with_conf(conf, 'run', '--set-commit-hash=' + commit_hash, _machine_file=join(tmpdir, 'asv-machine.json'))
+    tools.run_asv_with_conf(conf, 'run', '--set-commit-hash=' + r.get_branch_name(),
+                            _machine_file=join(tmpdir, 'asv-machine.json'))
 
     env_name = list(environment.get_environments(conf, None))[0].name
     result_filename = commit_hash[:conf.hash_length] + '-' + env_name + '.json'


### PR DESCRIPTION
This allows the user to provide e.g. HEAD to `--set-commit-hash`.