### PR TITLE
Exclude .pyc-only modules from benchmark suite on python2

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -954,6 +954,11 @@ def disc_modules(module_name, ignore_import_errors=False):
             traceback.print_exc()
             return
 
+    # Exclude sourceless .pyc/.pyo left around (py3 __pycache__
+    # behaves sensibly, so workaround only for py2)
+    if sys.version_info[0] == 2 and not inspect.getsourcefile(module):
+        return
+
     yield module
 
     if getattr(module, '__path__', None):


### PR DESCRIPTION
The .pyc files are left around e.g. by git checkout, and python2 treats
them as importable modules. Python3 default behavior is to not consider
cached compiled modules as importable, so follow the behavior on Py2.

Closes gh-860