### PR TITLE
Add --no-stats option to compare/continuous for using only `factor`

### DIFF
--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -45,6 +45,11 @@ def add_compare(parser, only_changed_default=False, sort_default='name'):
         be displayed in the results list.""")
 
     parser.add_argument(
+        '--no-stats', action="store_false", dest="use_stats", default=True,
+        help="""Do not use result statistics in comparisons, only `factor`
+        and the median result.""")
+
+    parser.add_argument(
         '--split', '-s', action='store_true',
         help="""Split the output into a table of benchmarks that have
         improved, stayed the same, and gotten worse.""")

--- a/asv/commands/compare.py
+++ b/asv/commands/compare.py
@@ -123,11 +123,12 @@ class Compare(Command):
                        factor=args.factor, split=args.split,
                        only_changed=args.only_changed, sort=args.sort,
                        machine=args.machine,
-                       env_spec=args.env_spec)
+                       env_spec=args.env_spec,
+                       use_stats=args.use_stats)
 
     @classmethod
     def run(cls, conf, hash_1, hash_2, factor=None, split=False, only_changed=False,
-            sort='name', machine=None, env_spec=None):
+            sort='name', machine=None, env_spec=None, use_stats=True):
 
         repo = get_repo(conf)
         try:
@@ -168,7 +169,7 @@ class Compare(Command):
         commit_names = {hash_1: repo.get_name_from_hash(hash_1),
                         hash_2: repo.get_name_from_hash(hash_2)}
 
-        cls.print_table(conf, hash_1, hash_2, factor=factor, split=split,
+        cls.print_table(conf, hash_1, hash_2, factor=factor, split=split, use_stats=use_stats,
                         only_changed=only_changed, sort=sort,
                         machine=machine, env_names=env_names, commit_names=commit_names)
 

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -68,6 +68,7 @@ class Continuous(Command):
             conf=conf, branch=args.branch, base=args.base,
             factor=args.factor, split=args.split,
             only_changed=args.only_changed, sort=args.sort,
+            use_stats=args.use_stats,
             show_stderr=args.show_stderr, bench=args.bench, attribute=args.attribute,
             machine=args.machine,
             env_spec=args.env_spec, record_samples=args.record_samples,
@@ -78,7 +79,7 @@ class Continuous(Command):
 
     @classmethod
     def run(cls, conf, branch=None, base=None,
-            factor=None, split=False, only_changed=True, sort='ratio',
+            factor=None, split=False, only_changed=True, sort='ratio', use_stats=True,
             show_stderr=False, bench=None,
             attribute=None, machine=None, env_spec=None, record_samples=False, append_samples=False,
             quick=False, interleave_processes=None, launch_method=None, _machine_file=None,
@@ -142,6 +143,7 @@ class Continuous(Command):
                                      resultset_1=results_iter(parent),
                                      resultset_2=results_iter(head),
                                      factor=factor, split=split,
+                                     use_stats=use_stats,
                                      only_changed=only_changed, sort=sort,
                                      commit_names=commit_names)
         worsened, improved = status

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -139,6 +139,24 @@ REFERENCE_ONLY_CHANGED_MULTIENV = """
 -          69.1μs           18.3μs     0.27  time_units.time_unit_to [cheetah/py2.7-numpy1.8]
 """
 
+REFERENCE_ONLY_CHANGED_NOSTATS = """
+       before           after         ratio
+     [22b920c6]       [fcf8c079]
+!             n/a           failed      n/a  params_examples.ParamSuite.track_value
+!           454μs           failed      n/a  time_coordinates.time_latitude
+!           3.00s           failed      n/a  time_other.time_parameterized(3)
++           934μs            108ms   115.90  time_quantity.time_quantity_init_array
++          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion
++           372μs           11.5ms    30.81  time_units.time_unit_parse
++           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
++          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
++         1.00±1s          3.00±1s     3.00  time_ci_big
++         1.00±0s          3.00±0s     3.00  time_ci_small
++           1.00s            3.00s     3.00  time_with_version_match
++           1.00s            3.00s     3.00  time_with_version_mismatch_bench
+-          69.1μs           18.3μs     0.27  time_units.time_unit_to
+"""
+
 
 def test_compare(capsys, tmpdir, example_results):
     tmpdir = six.text_type(tmpdir)
@@ -177,6 +195,14 @@ def test_compare(capsys, tmpdir, example_results):
                                  split=False, only_changed=True, sort='ratio')
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE_ONLY_CHANGED_MULTIENV.strip()
+
+    # Check results with no stats
+    tools.run_asv_with_conf(conf, 'compare', '22b920c6', 'fcf8c079', '--machine=cheetah',
+                            '--factor=2', '--sort=ratio', '--environment=py2.7-numpy1.8',
+                            '--no-stats', '--only-changed')
+    text, err = capsys.readouterr()
+    assert text.strip() == REFERENCE_ONLY_CHANGED_NOSTATS.strip()
+    assert "time_ci_big" in text.strip()
 
 
 @pytest.mark.parametrize("dvcs_type", [


### PR DESCRIPTION
Enable ignoring spread of measurement results in comparison, and making
the decision whether a result was changed only based on the single
aggregate numerical value.