### PR TITLE
Fix content overflow in graph tooltips

### DIFF
--- a/asv/www/asv.css
+++ b/asv/www/asv.css
@@ -78,7 +78,7 @@ nav li.active span.navbar-brand:hover {
     min-width: 100px;
     max-width: 800px;
     text-align: left;
-    white-space: pre;
+    white-space: pre-wrap;
     font-family: monospace;
 }
 


### PR DESCRIPTION
I'm not 100% sure if the `white-space` property was set to `pre` for a specific reason, but this fixes the very annoying content overflow that happens with a lot of/long variants.

PS: I'm finding time again for ASV, I should be able to get back to my pending PR. 