### PR TITLE
More reasonable data filling behavior in summary graphs

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -398,3 +398,9 @@ def test_check_output_exit_code(capsys):
         util.check_output([sys.executable, '-c', 'import sys; sys.exit(1)'])
     out, err = capsys.readouterr()
     assert '(exit status 1)' in out
+
+
+def test_geom_mean_na():
+    for x in [[1, 2, -3], [1, 2, 3], [3, 1, 3, None, None]]:
+        expected = abs(x[0]*x[1]*x[2])**(1/3)
+        assert abs(util.geom_mean_na(x) - expected) < 1e-10


### PR DESCRIPTION
When constructing the averaged data series for the summary graphs,
limit the missing data filling to a fraction of the number of available points,
and don't fill beyond the bounds of available points.

Closes #894