### PR TITLE
Rename 'processes' attribute to 'rounds' for clarity

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -604,7 +604,8 @@ class TimeBenchmark(Benchmark):
         self.type = "time"
         self.unit = "seconds"
         self._attr_sources = attr_sources
-        self.processes = int(_get_first_attr(self._attr_sources, 'processes', 2))
+        old = int(_get_first_attr(self._attr_sources, 'processes', 2))  # backward compat.
+        self.rounds = int(_get_first_attr(self._attr_sources, 'rounds', old))
         self._load_vars()
 
     def _load_vars(self):
@@ -653,7 +654,7 @@ class TimeBenchmark(Benchmark):
                 min_repeat = 1
                 max_repeat = 10
                 max_time = 20.0
-                if self.processes > 1:
+                if self.rounds > 1:
                     max_repeat //= 2
                     max_time /= 2.0
             else:

--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -100,7 +100,11 @@ class DictionaryArgAction(argparse.Action):
             raise argparse.ArgumentError(self,
                                          "{!r} cannot be set".format(key))
 
+        dest_key = key
         conv = self.converters.get(key, None)
+        if isinstance(conv, tuple):
+            dest_key, conv = conv
+
         if conv is not None:
             try:
                 value = conv(value)
@@ -112,7 +116,7 @@ class DictionaryArgAction(argparse.Action):
         result = getattr(namespace, self.dest, None)
         if result is None:
             result = {}
-        result[key] = value
+        result[dest_key] = value
         setattr(namespace, self.dest, result)
 
 
@@ -161,7 +165,8 @@ def add_bench(parser):
         'warmup_time': float,
         'repeat': parse_repeat,
         'number': int,
-        'processes': int,
+        'rounds': int,
+        'processes': ('rounds', int),  # backward compatibility
         'sample_time': float,
         'cpu_affinity': parse_affinity
     }

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import os
 import six
+import argparse
 
 from . import Command
 from .run import Run
@@ -42,12 +43,19 @@ class Continuous(Command):
             benchmark functions faster.  The results are unlikely to
             be useful, and thus are not saved.""")
         parser.add_argument(
-            "--interleave-processes", action="store_true", default=None,
-            help="""Interleave benchmarks with multiple processes across
+            "--interleave-rounds", action="store_true", default=None,
+            help="""Interleave benchmarks with multiple rounds across
             commits. This can avoid measurement biases from commit ordering,
             can take longer.""")
         parser.add_argument(
-            "--no-interleave-processes", action="store_false", dest="interleave_processes")
+            "--no-interleave-rounds", action="store_false", dest="interleave_rounds")
+        # Backward compatibility for '--(no-)interleave-rounds'
+        parser.add_argument(
+            "--interleave-processes", action="store_true", default=False, dest="interleave_rounds",
+            help=argparse.SUPPRESS)
+        parser.add_argument(
+            "--no-interleave-processes", action="store_false", dest="interleave_rounds",
+            help=argparse.SUPPRESS)
         parser.add_argument(
             "--strict", action="store_true",
             help="When set true the run command will exit with a non-zero "
@@ -73,7 +81,7 @@ class Continuous(Command):
             machine=args.machine,
             env_spec=args.env_spec, record_samples=args.record_samples,
             append_samples=args.append_samples,
-            quick=args.quick, interleave_processes=args.interleave_processes,
+            quick=args.quick, interleave_rounds=args.interleave_rounds,
             launch_method=args.launch_method, strict=args.strict, **kwargs
         )
 
@@ -82,7 +90,7 @@ class Continuous(Command):
             factor=None, split=False, only_changed=True, sort='ratio', use_stats=True,
             show_stderr=False, bench=None,
             attribute=None, machine=None, env_spec=None, record_samples=False, append_samples=False,
-            quick=False, interleave_processes=None, launch_method=None, _machine_file=None,
+            quick=False, interleave_rounds=None, launch_method=None, _machine_file=None,
             strict=False):
         repo = get_repo(conf)
         repo.pull()
@@ -107,7 +115,7 @@ class Continuous(Command):
             conf, range_spec=commit_hashes, bench=bench, attribute=attribute,
             show_stderr=show_stderr, machine=machine, env_spec=env_spec,
             record_samples=record_samples, append_samples=append_samples, quick=quick,
-            interleave_processes=interleave_processes,
+            interleave_rounds=interleave_rounds,
             launch_method=launch_method, strict=strict,
             _returns=run_objs, _machine_file=_machine_file)
         if result:

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -142,7 +142,7 @@ def run_benchmarks(benchmarks, env, results=None,
         Whether to retain any previously measured result samples
         and use them in statistics computations.
     run_rounds : sequence of int, optional
-        Run rounds for benchmarks with multiple processes.
+        Run rounds for benchmarks with multiple rounds.
         If None, run all rounds.
     launch_method : {'auto', 'spawn', 'forkserver'}, optional
         Benchmark launching method to use.
@@ -163,7 +163,7 @@ def run_benchmarks(benchmarks, env, results=None,
         extra_params['number'] = 1
         extra_params['repeat'] = 1
         extra_params['warmup_time'] = 0
-        extra_params['processes'] = 1
+        extra_params['rounds'] = 1
 
     if results is None:
         results = Results.unnamed()
@@ -172,14 +172,14 @@ def run_benchmarks(benchmarks, env, results=None,
     setup_cache_timeout = {}
     benchmark_order = {}
     cache_users = {}
-    max_processes = 0
+    max_rounds = 0
 
-    def get_processes(benchmark):
-        """Get number of processes to use for a job"""
-        if 'processes' in extra_params:
-            return int(extra_params['processes'])
+    def get_rounds(benchmark):
+        """Get number of rounds to use for a job"""
+        if 'rounds' in extra_params:
+            return int(extra_params['rounds'])
         else:
-            return int(benchmark.get('processes', 1))
+            return int(benchmark.get('rounds', 1))
 
     for name, benchmark in sorted(six.iteritems(benchmarks)):
         key = benchmark.get('setup_cache_key')
@@ -187,11 +187,11 @@ def run_benchmarks(benchmarks, env, results=None,
                                                      benchmark['timeout']),
                                        setup_cache_timeout.get(key, 0))
         benchmark_order.setdefault(key, []).append((name, benchmark))
-        max_processes = max(max_processes, get_processes(benchmark))
+        max_rounds = max(max_rounds, get_rounds(benchmark))
         cache_users.setdefault(key, set()).add(name)
 
     if run_rounds is None:
-        run_rounds = list(range(1, max_processes + 1))
+        run_rounds = list(range(1, max_rounds + 1))
 
     # Interleave benchmark runs, in setup_cache order
     existing_results = results.get_result_keys(benchmarks)
@@ -202,9 +202,9 @@ def run_benchmarks(benchmarks, env, results=None,
                 for name, benchmark in benchmark_set:
                     log.step()
 
-                    processes = get_processes(benchmark)
+                    rounds = get_rounds(benchmark)
 
-                    if run_round > processes:
+                    if run_round > rounds:
                         if (not append_samples and
                                 run_round == run_rounds[-1] and
                                 name in existing_results):

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -5,6 +5,23 @@ Benchmark types and attributes
 
    .. contents::
 
+Benchmark types
+---------------
+
+The following benchmark types are recognized:
+
+- ``def time_*()``: measure time taken by the function. See :ref:`timing-benchmarks`.
+- ``def timeraw_*()``: measure time taken by the function, after interpreter start. See :ref:`raw-timing-benchmarks`.
+- ``def mem_*()``: measure memory size of the object returned.  See :ref:`memory-benchmarks`.
+- ``def peakmem_*()``: measure peak memory size of the process when calling the function.
+  See :ref:`peak-memory`.
+- ``def track_*()``: use the returned numerical value as the benchmark result
+  See :ref:`tracking`.
+
+
+Benchmark attributes
+--------------------
+
 Benchmark attributes can either be applied directly to the benchmark function::
 
     def time_something():
@@ -20,26 +37,9 @@ or appear as class attributes::
         def time_something(self):
             pass
 
-Benchmark types
----------------
-
-The following benchmark types are recognized:
-
-- ``def time_*()``: measure time taken by the function. See :ref:`timing-benchmarks`.
-- ``def mem_*()``: measure memory size of the object returned.  See :ref:`memory-benchmarks`.
-- ``def peakmem_*()``: measure peak memory size of the process when calling the function.
-  See :ref:`peak-memory`.
-- ``def track_*()``: use the returned numerical value as the benchmark result
-  See :ref:`tracking`.
-
-
-Benchmark attributes
---------------------
-
-General
-```````
-
-The following attributes are applicable to all benchmark types:
+Different benchmark types have their own sets of applicable
+attributes.  Moreover, the following attributes are applicable to all
+benchmark types:
 
 - ``timeout``: The amount of time, in seconds, to give the benchmark
   to run before forcibly killing it.  Defaults to 60 seconds.
@@ -114,15 +114,15 @@ Timing benchmarks
   benchmark. If not specified, ``warmup_time`` defaults to 0.1 seconds
   (on PyPy, the default is 1.0 sec).
 
-- ``processes``: How many processes to launch for running the benchmarks
-  (default: 2). The processes run benchmarks in an interleaved order,
+- ``rounds``: How many rounds to run the benchmark in (default: 2).
+  The rounds run different timing benchmarks in an interleaved order,
   allowing to sample over longer periods of background performance
   variations (e.g. CPU power levels).
 
-- ``repeat``: The number measurement samples to collect per process.
+- ``repeat``: The number measurement samples to collect per round.
   Each sample consists of running the benchmark ``number`` times.
-  The median time from all samples is used as the final measurement
-  result.
+  The median time from all samples collected in all roudns is used
+  as the final measurement result.
 
   ``repeat`` can be a tuple ``(min_repeat, max_repeat, max_time)``.
   In this case, the measurement first collects at least ``min_repeat``
@@ -130,7 +130,7 @@ Timing benchmarks
   or the collection time exceeds ``max_time``.
 
   When not provided (``repeat`` set to 0), the default value is
-  ``(1, 10, 20.0)`` if ``processes==1`` and ``(1, 5, 10.0)`` otherwise.
+  ``(1, 10, 20.0)`` if ``rounds==1`` and ``(1, 5, 10.0)`` otherwise.
 
 - ``number``: Manually choose the number of iterations in each sample.
   If ``number`` is specified, ``sample_time`` is ignored.

--- a/docs/source/tuning.rst
+++ b/docs/source/tuning.rst
@@ -15,8 +15,8 @@ Airspeed Velocity has mechanisms to deal with these variations.  For
 dealing with short-time variations, you can use the ``sample_time``,
 ``number`` and ``repeat`` attributes of timing benchmarks to control
 how results are sampled and averaged.  For long-time variations, you
-can use the ``processes`` attribute and ``--interleave-processes``,
-``--append-samples``, and ``-a processes=4`` command line options to
+can use the ``rounds`` attribute and ``--interleave-rounds``,
+``--append-samples``, and ``-a rounds=4`` command line options to
 run timing benchmarks at more widely spaced times, in order to average
 over long-time performance variations.
 

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -266,12 +266,19 @@ Timing
 
 Timing benchmarks have the prefix ``time``.
 
-The timing itself is based on the Python standard library's `timeit`
-module, with some extensions for automatic heuristics shamelessly
-stolen from IPython's `%timeit
-<http://ipython.org/ipython-doc/dev/api/generated/IPython.core.magics.execution.html?highlight=timeit#IPython.core.magics.execution.ExecutionMagics.timeit>`__
-magic function.  This means that in most cases the benchmark function
-itself will be run many times to achieve accurate timing.
+How ASV runs benchmarks is as follows (pseudocode for main idea)::
+
+     for round in range(`rounds`):
+        for benchmark in benchmarks:
+            with new process:
+                <calibrate `number` if not manually set>
+                for j in range(`repeat`):
+                    <setup `benchmark`>
+                    sample = timing_function(<run benchmark `number` times>) / `number`
+                    <teardown `benchmark`>
+
+where the actual `rounds`, `repeat`, and `number` are :doc:`attributes
+of the benchmark <benchmarks>`.
 
 The default timing function is `timeit.default_timer`, which uses the
 highest resolution clock available on a given platform to measure the
@@ -311,7 +318,7 @@ How ``setup`` and ``teardown`` behave for timing benchmarks
 is similar to the Python ``timeit`` module, and the behavior is controlled
 by the ``number`` and ``repeat`` attributes.
 
-For the list of attributes, see :doc:`benchmarks`.
+For the list of benchmark attributes, see :doc:`benchmarks`.
 
 .. _memory-benchmarks:
 

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -373,6 +373,8 @@ memory usage you want to track::
 For details, see :doc:`benchmarks`.
 
 
+.. _raw-timing-benchmarks:
+
 Raw timing benchmarks
 `````````````````````
 

--- a/test/test_continuous.py
+++ b/test/test_continuous.py
@@ -36,7 +36,7 @@ def test_continuous(capfd, basic_conf):
     assert "+               1                6     6.00  params_examples.track_find_test(2)" in text
     assert "params_examples.ClassOne" in text
 
-    # Check processes were interleaved (timing benchmark was run twice)
+    # Check rounds were interleaved (timing benchmark was run twice)
     assert re.search(r"For.*commit [a-f0-9]+ (<[a-z0-9~^]+> )?\(round 1/2\)", text, re.M), text
 
     result_found = False

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -260,7 +260,7 @@ def test_run_append_samples(basic_conf):
     def run_it():
         tools.run_asv_with_conf(conf, 'run', "master^!",
                                 '--bench', 'time_examples.TimeSuite.time_example_benchmark_1',
-                                '--append-samples', '-a', 'repeat=(1, 1, 10.0)', '-a', 'processes=1',
+                                '--append-samples', '-a', 'repeat=(1, 1, 10.0)', '-a', 'rounds=1',
                                 '-a', 'number=1', '-a', 'warmup_time=0',
                                 _machine_file=machine_file)
 
@@ -289,7 +289,7 @@ def test_cpu_affinity(basic_conf):
 
     tools.run_asv_with_conf(conf, 'run', "master^!",
                             '--bench', 'time_examples.TimeSuite.time_example_benchmark_1',
-                            '--cpu-affinity=0', '-a', 'repeat=(1, 1, 10.0)', '-a', 'processes=1',
+                            '--cpu-affinity=0', '-a', 'repeat=(1, 1, 10.0)', '-a', 'rounds=1',
                             '-a', 'number=1', '-a', 'warmup_time=0',
                             _machine_file=machine_file)
 


### PR DESCRIPTION
It was already called 'rounds' in the UI, and moreover 'processes'
raises confusion about whether benchmarks are run in parallel.