### PR TITLE
Save intermediate results from 'asv find', with flag to disable

### DIFF
--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -147,6 +147,9 @@ class Find(Command):
                 env.env_vars
             )
 
+            if not skip_save:
+                result.load_data(conf.results_dir)
+
             res = run_benchmarks(benchmarks, env, results=result,
                                  show_stderr=show_stderr,
                                  launch_method=launch_method)

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -6,6 +6,7 @@ from . import Command, common_args
 from ..benchmarks import Benchmarks
 from ..console import log
 from ..machine import Machine
+from ..results import Results
 from ..repo import get_repo
 from ..runner import run_benchmarks
 from .. import util
@@ -44,6 +45,9 @@ class Find(Command):
             "--invert", "-i", action="store_true",
             help="""Search for a decrease in the benchmark value,
             rather than an increase.""")
+        parser.add_argument(
+            "--skip-save", action="store_true",
+            help="""Do not save intermediate results from the search""")
         common_args.add_parallel(parser)
         common_args.add_show_stderr(parser)
         common_args.add_machine(parser)
@@ -61,12 +65,14 @@ class Find(Command):
             invert=args.invert, show_stderr=args.show_stderr,
             parallel=args.parallel,
             machine=args.machine, env_spec=args.env_spec,
-            launch_method=args.launch_method, **kwargs
+            launch_method=args.launch_method, skip_save=args.skip_save,
+            **kwargs
         )
 
     @classmethod
     def run(cls, conf, range_spec, bench, invert=False, show_stderr=False, parallel=1,
-            machine=None, env_spec=None, _machine_file=None, launch_method=None):
+            machine=None, env_spec=None, _machine_file=None, launch_method=None,
+            skip_save=False):
         params = {}
         machine_params = Machine.load(
             machine_name=machine,
@@ -128,10 +134,25 @@ class Find(Command):
                 f"For {conf.project} commit {commit_name}:")
 
             env.install_project(conf, repo, commit_hash)
+            params['python'] = env.python
+            params.update(env.requirements)
 
-            res = run_benchmarks(benchmarks, env,
+            result = Results(
+                params,
+                env.requirements,
+                commit_hash,
+                repo.get_date(commit_hash),
+                env.python,
+                env.name,
+                env.env_vars
+            )
+
+            res = run_benchmarks(benchmarks, env, results=result,
                                  show_stderr=show_stderr,
                                  launch_method=launch_method)
+
+            if not skip_save:
+                res.save(conf.results_dir)
 
             result = res.get_result_value(benchmark_name,
                                           benchmarks[benchmark_name]['params'])

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -36,6 +36,20 @@ def test_find(capfd, tmpdir):
                             "params_examples.track_find_test",
                             _machine_file=machine_file)
 
+    def get_result_files():
+        results_dir = os.path.join(conf.results_dir, 'orangutan')
+        if not os.path.isdir(results_dir):
+            return ['machine.json']
+        return sorted(os.listdir(results_dir))
+
+    # Test find at least runs, not saving results
+    prev_result_files = get_result_files()
+    tools.run_asv_with_conf(conf, 'find', "--skip-save",
+                            f"{git_default_branch()}~5..{git_default_branch()}",
+                            "params_examples.track_find_test",
+                            _machine_file=machine_file)
+    assert get_result_files() == prev_result_files
+
     # Check it found the first commit after the initially tested one
     output, err = capfd.readouterr()
 
@@ -43,6 +57,14 @@ def test_find(capfd, tmpdir):
         [which('git'), 'rev-parse', f'{git_default_branch()}^'], cwd=conf.repo)
 
     assert f"Greatest regression found: {regression_hash[:8]}" in output
+
+    # Test find at least runs, saving results --- should give same outcome
+    tools.run_asv_with_conf(conf, 'find',
+                            f"{git_default_branch()}~5..{git_default_branch()}",
+                            "params_examples.track_find_test",
+                            _machine_file=machine_file)
+    output2, err2 = capfd.readouterr()
+    assert get_result_files() == prev_result_files
 
 
 @pytest.mark.flaky(reruns=1, reruns_delay=5)  # depends on a timeout

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -4,14 +4,14 @@ import glob
 import os
 import sys
 import json
-from os.path import join, isfile
+import shutil
+from os.path import join, isfile, abspath, relpath, dirname
 
 import pytest
 
-from asv import util
+from asv import config, util
 
 from . import tools
-
 
 dummy_values = (
     (6, 1),
@@ -20,7 +20,7 @@ dummy_values = (
 )
 
 def generate_basic_conf(tmpdir, repo_subdir='', values=dummy_values, dummy_packages=True):
-    tmpdir = six.text_type(tmpdir)
+    tmpdir = str(tmpdir)
     local = abspath(dirname(__file__))
     os.chdir(tmpdir)
 

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -47,7 +47,6 @@ def generate_basic_conf(tmpdir, repo_subdir='', values=dummy_values, dummy_packa
 
     conf_dict = {
         'env_dir': 'env',
-        'environment_type': 'virtualenv',
         'benchmark_dir': 'benchmark',
         'results_dir': 'results_workflow',
         'html_dir': 'html',

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -13,8 +13,67 @@ from asv import util
 from . import tools
 
 
-def test_run_publish(capfd, basic_conf_2):
-    tmpdir, local, conf, machine_file = basic_conf_2
+dummy_values = (
+    (6, 1),
+    (6, 6),
+    (6, 6),
+)
+
+def generate_basic_conf(tmpdir, repo_subdir='', values=dummy_values, dummy_packages=True):
+    tmpdir = six.text_type(tmpdir)
+    local = abspath(dirname(__file__))
+    os.chdir(tmpdir)
+
+    # Use relative paths on purpose since this is what will be in
+    # actual config files
+
+    shutil.copytree(os.path.join(local, 'benchmark'), 'benchmark')
+
+    machine_file = join(tmpdir, 'asv-machine.json')
+
+    shutil.copyfile(join(local, 'asv-machine.json'),
+                    machine_file)
+
+    repo_path = tools.generate_test_repo(tmpdir, values,
+                                         subdir=repo_subdir).path
+
+    if dummy_packages:
+        matrix = {
+            "asv_dummy_test_package_1": [""],
+            "asv_dummy_test_package_2": tools.DUMMY2_VERSIONS,
+        }
+    else:
+        matrix = {}
+
+    conf_dict = {
+        'env_dir': 'env',
+        'environment_type': 'virtualenv',
+        'benchmark_dir': 'benchmark',
+        'results_dir': 'results_workflow',
+        'html_dir': 'html',
+        'repo': relpath(repo_path),
+        'dvcs': 'git',
+        'project': 'asv',
+        'matrix': matrix,
+    }
+    if repo_subdir:
+        conf_dict['repo_subdir'] = repo_subdir
+
+    conf = config.Config.from_json(conf_dict)
+
+    if hasattr(sys, 'pypy_version_info'):
+        conf.pythons = ["pypy{0[0]}.{0[1]}".format(sys.version_info)]
+
+    return tmpdir, local, conf, machine_file
+
+
+@pytest.fixture
+def basic_conf(tmpdir, dummy_packages):
+    return generate_basic_conf(tmpdir)
+
+
+def test_run_publish(capfd, basic_conf):
+    tmpdir, local, conf, machine_file = basic_conf
     tmpdir = util.long_path(tmpdir)
 
     conf.matrix = {


### PR DESCRIPTION
Currently, the intermediate binary search steps of `asv find` are never saved, requiring a separate `asv run` to persist the appropriate commit in regression results. This greatly reduces the number of full `asv run`s while also increasing regression precision.

This PR saves intermediate results under the assumption they are comparable to `asv run` and provides a new flag `--skip-save` to opt-out of this behavior.