### PR TITLE
remove deprecated `--no-site-packages` flag in virtualenv

### DIFF
--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -140,7 +140,6 @@ class Virtualenv(environment.Environment):
         util.check_call([
             sys.executable,
             "-mvirtualenv",
-            '--no-site-packages',
             "-p",
             self._executable,
             self._path], env=env)


### PR DESCRIPTION
Hello,

`--no-site-packages` was deprecated some time ago, and removed in `20.x`. I noticed this because it [broke CI][0] for my project.

I can do a better job of checking `virtualenv` versions and keeping the flag for older versions, but just removing it should be fine for most `virtualenv` usages?

[0]: https://github.com/dib-lab/sourmash/runs/439242791#step:5:36