### PR TITLE
Update travis config for python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
           SKIP="$SKIP|asv/benchmark.py.*undefined name .(run|params)."
           PYFLAKES_NODOCTEST=1 pyflakes asv test | grep -E -v "$SKIP" > test.out; cat test.out; test \! -s test.out
 
-    - python: 3.8-dev
+    - python: 3.8
       dist: xenial
       env:
         - COVERAGE="--cov=asv --cov=test"


### PR DESCRIPTION
This commit updates the travis config to use python 3.8 instead of
python 3.8-dev. Now that 3.8 has been released there's no reason to
track the dev branch to test asv on python 3.8.