### PR TITLE
Virtualenv no longer supports --no-site-packages; remove it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,9 @@ install:
         $TRAVIS_PIP install virtualenv numpy scipy;
       fi
     fi
+    if $TRAVIS_PYTHON -c 'import sys; sys.exit(0 if "__pypy__" in sys.modules else 1)'; then
+      $TRAVIS_PIP install "pytest>=4.4.0,<5.0" "pytest-rerunfailures>=8.0" "pytest-faulthandler<2.0"
+    fi
     $TRAVIS_PIP install selenium six "pytest>=4.4.0" "pytest-xdist" pytest-rerunfailures pytest-faulthandler pytest-timeout feedparser python-hglib filelock;
     if [[ "$COVERAGE" != '' ]]; then $TRAVIS_PIP install pytest-cov codecov; fi;
   - $TRAVIS_PYTHON setup.py build_ext -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ install:
       fi
     fi
     if $TRAVIS_PYTHON -c 'import sys; sys.exit(0 if "__pypy__" in sys.modules else 1)'; then
-      $TRAVIS_PIP install "pytest>=4.4.0,<5.0" "pytest-rerunfailures>=8.0" "pytest-faulthandler<2.0"
+      $TRAVIS_PIP install "pytest>=4.4.0,<5.0" "pytest-rerunfailures>=8.0,<9.0" "pytest-faulthandler<2.0"
     fi
     $TRAVIS_PIP install selenium six "pytest>=4.4.0" "pytest-xdist" pytest-rerunfailures pytest-faulthandler pytest-timeout feedparser python-hglib filelock;
     if [[ "$COVERAGE" != '' ]]; then $TRAVIS_PIP install pytest-cov codecov; fi;

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -140,7 +140,6 @@ class Virtualenv(environment.Environment):
         util.check_call([
             sys.executable,
             "-mvirtualenv",
-            '--no-site-packages',
             "-p",
             self._executable,
             self._path], env=env)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-pytest>=4.4.0; platform_python_implementation != "pypy"
-pytest>-4.4.0,<5.0; platform_python_implementation == "pypy"
+pytest>=4.4.0; platform_python_implementation != "PyPy"
+pytest>-4.4.0,<5.0; platform_python_implementation == "PyPy"
 virtualenv>=1.7
 filelock
 six
@@ -12,8 +12,8 @@ scipy
 selenium
 pytest-xdist
 pytest-rerunfailures>=8.0
-pytest-faulthandler; platform_python_implementation != "pypy"
-pytest-faulthandler<2.0; platform_python_implementation == "pypy"
+pytest-faulthandler; platform_python_implementation != "PyPy"
+pytest-faulthandler<2.0; platform_python_implementation == "PyPy"
 pytest-timeout
 feedparser
 python-hglib

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest>=4.4.0; platform_python_implementation != "PyPy"
-pytest>-4.4.0,<5.0; platform_python_implementation == "PyPy"
+pytest>=4.4.0,<5.0; platform_python_implementation == "PyPy"
 virtualenv>=1.7
 filelock
 six

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest>=4.4.0
-virtualenv
+virtualenv>=1.7
 filelock
 six
 pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,8 @@ numpy
 scipy
 selenium
 pytest-xdist
-pytest-rerunfailures>=8.0
+pytest-rerunfailures>=8.0; platform_python_implementation != "PyPy"
+pytest-rerunfailures>=8.0,<9.0; platform_python_implementation == "PyPy"
 pytest-faulthandler; platform_python_implementation != "PyPy"
 pytest-faulthandler<2.0; platform_python_implementation == "PyPy"
 pytest-timeout

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
-pytest>=4.4.0
+pytest>=4.4.0; platform_python_implementation != "pypy"
+pytest>-4.4.0,<5.0; platform_python_implementation == "pypy"
 virtualenv>=1.7
 filelock
 six
@@ -10,8 +11,9 @@ numpy
 scipy
 selenium
 pytest-xdist
-pytest-rerunfailures
-pytest-faulthandler
+pytest-rerunfailures>=8.0
+pytest-faulthandler; platform_python_implementation != "pypy"
+pytest-faulthandler<2.0; platform_python_implementation == "pypy"
 pytest-timeout
 feedparser
 python-hglib


### PR DESCRIPTION
I got crashes when trying to use asv with latest virtualenv.

I think `virtualenv >= 20.0.0b1` removed `--no-site-packages`, with no readily apparent replacement.
However, `virtualenv >= 1.7` apparently [has this as the default](https://virtualenv.pypa.io/en/legacy/changes.html#v1-7-2011-11-30), so that may be less needed now than it once was.

It may be worth adding a setuptools `virtualenv` extra to make sure the virtualenv version is recent enough.

Closes #906 
Alternate: #905