### PR TITLE
virtualenv: remove --no-site-packages option

### DIFF
--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -140,7 +140,6 @@ class Virtualenv(environment.Environment):
         util.check_call([
             sys.executable,
             "-mvirtualenv",
-            '--no-site-packages',
             "-p",
             self._executable,
             self._path], env=env)


### PR DESCRIPTION
Seems like since virtualenv 20 there is no `--no-site-packages` option.