### PR TITLE
util: try to provide cpu name for windows

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -995,6 +995,13 @@ def get_cpu_info():
     elif sys.platform.startswith('darwin'):
         sysctl = which('sysctl')
         return check_output([sysctl, '-n', 'machdep.cpu.brand_string']).strip()
+    elif sys.platform.startswith('win'):
+        try:
+            from win32com.client import GetObject
+            cimv = GetObject("winmgmts:root\cimv2")
+            return cimv.ExecQuery("Select Name from Win32_Processor")[0].name
+        except:
+            pass
     return ''
 
 


### PR DESCRIPTION
Trying to get CPU name from Win32_Processor class.
This class was introduced in Win10, hence supress.
Docs for the class:
https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-processor