### PR TITLE
 BUG: detect accumulated change in detect_regressions

### DIFF
--- a/asv/step_detect.py
+++ b/asv/step_detect.py
@@ -467,9 +467,11 @@ def detect_regressions(steps, threshold=0, min_size=2):
         Latest value
     best_value
         Best value
-    regression_pos : list of (before, after, value_before, value_after)
+    regression_pos : list of (before, after, value_before, best_value_after)
         List of positions between which the value increased. The first item
         corresponds to the last position at which the best value was obtained.
+        The last item indicates the best value found after the regression
+        (which is not always the value immediately following the regression).
 
     """
     if not steps:

--- a/asv/step_detect.py
+++ b/asv/step_detect.py
@@ -480,31 +480,36 @@ def detect_regressions(steps, threshold=0, min_size=2):
 
     last_v = steps[-1][2]
     best_v = last_v
-    best_err = steps[-1][4]
+    thresholded_best_v = last_v
+    thresholded_best_err = steps[-1][4]
     prev_l = None
     short_prev = None
 
     # Find upward steps that resulted to worsened value afterward
     for l, r, cur_v, cur_min, cur_err in reversed(steps):
-        threshold_step = max(cur_err, best_err, threshold * cur_v)
+        threshold_step = max(cur_err, thresholded_best_err, threshold * cur_v)
 
-        if best_v > cur_v + threshold_step:
+        if thresholded_best_v > cur_v + threshold_step:
             if r - l < min_size:
                 # Accept short intervals conditionally
-                short_prev = (best_v, best_err)
+                short_prev = (thresholded_best_v, thresholded_best_err)
+
             regression_pos.append((r - 1, prev_l, cur_v, best_v))
+
+            thresholded_best_v = cur_v
+            thresholded_best_err = cur_err
         elif short_prev is not None:
             # Ignore the previous short interval, if the level
             # is now back to where it was
             if short_prev[0] <= cur_v + threshold_step:
                 regression_pos.pop()
-                best_v, best_err = short_prev
+                thresholded_best_v, thresholded_best_err = short_prev
             short_prev = None
 
         prev_l = l
+
         if cur_v < best_v:
             best_v = cur_v
-            best_err = cur_err
 
     regression_pos.reverse()
 

--- a/test/test_step_detect.py
+++ b/test/test_step_detect.py
@@ -312,6 +312,15 @@ def test_regression_threshold():
     assert best == None
     assert pos == None
 
+    # Gradual change should result to a regression detected somewhere,
+    # even if the individual steps are smaller than the threshold
+    steps = [(0, 1,   1.0, 1.0, 0.0),
+             (1, 2,   1.04, 1.04, 0.0),
+             (2, 3,   1.08, 1.08, 0.0),]
+
+    latest, best, pos = detect_regressions(steps, threshold=0.05)
+    assert pos == [(0, 1, 1.0, 1.04)]
+
 
 def test_zero_weight():
     t = list(range(50))


### PR DESCRIPTION
Instead of comparing the individual step changes to a threshold, compare
the total accumulated change, in order to pick up gradual regressions.

Fixes #932