### PR TITLE
CI: disable parallel run from appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,7 +36,7 @@ build_script:
   - python setup.py build_ext -i
 
 test_script:
-  - python -m pytest -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp -n 2 -v -v --environment-type=conda --webdriver=ChromeHeadless --timeout=1800 --durations=100 test
+  - python -m pytest -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp -v --environment-type=conda --webdriver=ChromeHeadless --timeout=1800 --durations=100 test
 
 after_build:
   # Clear up pip cache


### PR DESCRIPTION
The test runs seem to hang quite often on appveyor. Since calls to conda in any case won't run in parallel, try to avoid issues / make things easier to debug by disabling pytest-xdist.