### PR TITLE
Take Atom feed id date from commit date instead of benchmark run

### DIFF
--- a/asv/feed.py
+++ b/asv/feed.py
@@ -38,14 +38,18 @@ class FeedEntry(object):
         as a separate entry, so if an entry is updated, it appears as
         a new entry only if the id_context changes.
         Default: [title, link, content]
+    id_date : datetime
+        Date to include in the id.
+        Default: same as *updated*
 
     """
-    def __init__(self, title, updated, link=None, content=None, id_context=None):
+    def __init__(self, title, updated, link=None, content=None, id_context=None, id_date=None):
         self.title = title
         self.link = link
         self.updated = updated
         self.content = content
         self.id_context = id_context
+        self.id_date = id_date
 
     def get_atom(self, id_prefix, language):
         item = etree.Element(ATOM_NS + 'entry')
@@ -56,8 +60,13 @@ class FeedEntry(object):
         else:
             id_context += list(self.id_context)
 
+        if self.id_date is None:
+            id_date = self.updated
+        else:
+            id_date = self.id_date
+
         el = etree.Element(ATOM_NS + 'id')
-        el.text = _get_id(id_prefix, self.updated, id_context)
+        el.text = _get_id(id_prefix, id_date, id_context)
         item.append(el)
 
         el = etree.Element(ATOM_NS + 'title')

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -207,8 +207,10 @@ class Regressions(OutputPublisher):
                 # as the same one, as long as the benchmark name and
                 # commits match.
                 id_context = [name, revision_to_hash.get(rev1, ""), revision_to_hash.get(rev2, "")]
+                id_rev = rev1 if rev1 is not None else rev2
+                id_date = util.js_timestamp_to_datetime(revision_timestamps[id_rev])
 
-                entries.append(feed.FeedEntry(title, updated, link, summary, id_context))
+                entries.append(feed.FeedEntry(title, updated, link, summary, id_context, id_date))
 
         entries.sort(key=lambda x: x.updated, reverse=True)
 

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -207,8 +207,7 @@ class Regressions(OutputPublisher):
                 # as the same one, as long as the benchmark name and
                 # commits match.
                 id_context = [name, revision_to_hash.get(rev1, ""), revision_to_hash.get(rev2, "")]
-                id_rev = rev1 if rev1 is not None else rev2
-                id_date = util.js_timestamp_to_datetime(revision_timestamps[id_rev])
+                id_date = util.js_timestamp_to_datetime(revision_timestamps[rev2])
 
                 entries.append(feed.FeedEntry(title, updated, link, summary, id_context, id_date))
 

--- a/test/test_feed.py
+++ b/test/test_feed.py
@@ -36,7 +36,8 @@ def prettify_xml(text):
 def dummy_feed_xml():
     entry_1 = feed.FeedEntry(title='Some title', updated=datetime.datetime(1993, 1, 1))
     entry_2 = feed.FeedEntry(title='Another title', updated=datetime.datetime(1990, 1, 1),
-                             link='http://foo', content='More text', id_context=['something'])
+                             link='http://foo', content='More text', id_context=['something'],
+                             id_date=datetime.datetime(2000, 1, 1))
 
     stream = io.BytesIO()
     feed.write_atom(stream, [entry_1, entry_2], author='Me', title='Feed title',
@@ -75,7 +76,7 @@ Some title</title>
 </entry>
 <entry>
 <id>
-tag:baz.com,1990-01-01:/abd78e0420c232c75f3e7582946dac13e18a54b0b5542fbc3159458f8b16fd4f</id>
+tag:baz.com,2000-01-01:/abd78e0420c232c75f3e7582946dac13e18a54b0b5542fbc3159458f8b16fd4f</id>
 <title xml:lang="en">
 Another title</title>
 <updated>

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -420,7 +420,8 @@ def test_regression_atom_feed_update(dvcs_type, tmpdir):
     commit_values = {}
     for commit, value in zip(commits, values[:-5]):
         commit_values[commit] = value
-    conf = tools.generate_result_dir(tmpdir, dvcs, commit_values)
+    conf = tools.generate_result_dir(tmpdir, dvcs, commit_values,
+                                     updated=datetime.datetime(1970, 1, 1))
 
     tools.run_asv_with_conf(conf, "publish")
 
@@ -432,7 +433,8 @@ def test_regression_atom_feed_update(dvcs_type, tmpdir):
 
     shutil.rmtree(conf.results_dir)
     shutil.rmtree(conf.html_dir)
-    conf = tools.generate_result_dir(tmpdir, dvcs, commit_values)
+    conf = tools.generate_result_dir(tmpdir, dvcs, commit_values,
+                                     updated=datetime.datetime(1990, 1, 1))
 
     tools.run_asv_with_conf(conf, "publish")
 

--- a/test/tools.py
+++ b/test/tools.py
@@ -447,7 +447,7 @@ def generate_repo_from_ops(tmpdir, dvcs_type, operations):
     return dvcs
 
 
-def generate_result_dir(tmpdir, dvcs, values, branches=None):
+def generate_result_dir(tmpdir, dvcs, values, branches=None, updated=None):
     result_dir = join(tmpdir, "results")
     os.makedirs(result_dir)
     html_dir = join(tmpdir, "html")
@@ -471,7 +471,8 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
         'version': 1,
     })
 
-    timestamp = datetime.datetime.utcnow()
+    if updated is None:
+        updated = datetime.datetime(1970, 1, 1)
 
     benchmark_version = sha256(os.urandom(16)).hexdigest()
 
@@ -493,7 +494,7 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
             stderr='',
             profile=None)
         result.add_result({"name": "time_func", "version": benchmark_version, "params": params},
-                          value, started_at=timestamp, duration=1.0)
+                          value, started_at=updated, duration=1.0)
         result.save(result_dir)
 
     if params:


### PR DESCRIPTION
The Atom feed ids should be 1-to-1 with the commits where the
regressions occurred, so the commit date should be used instead of
benchmark run time in the tag: uris.

See gh-938