### PR TITLE
remove periods from command line help descriptions

### DIFF
--- a/asv/commands/check.py
+++ b/asv/commands/check.py
@@ -18,10 +18,10 @@ class Check(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "check", help="Import and check benchmark suite, but do not run benchmarks.",
+            "check", help="Import and check benchmark suite, but do not run benchmarks",
             description="""
                 This imports and checks basic validity of the benchmark suite, but
-                does not run the benchmark target code.""")
+                does not run the benchmark target code""")
 
         common_args.add_environment(parser, default_same=False)
         parser.set_defaults(func=cls.run_from_args)

--- a/asv/commands/show.py
+++ b/asv/commands/show.py
@@ -25,18 +25,18 @@ class Show(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "show", help="Print recorded data.",
+            "show", help="Print recorded data",
             description="""Print saved benchmark results.""")
 
         parser.add_argument(
             'commit', nargs='?', default=None,
-            help="""The commit to show data for.""")
+            help="""The commit to show data for""")
         parser.add_argument(
             '--details', action='store_true', default=False,
-            help="""Show all result details.""")
+            help="""Show all result details""")
         parser.add_argument(
             '--durations', action='store_true', default=False,
-            help="""Show only run durations.""")
+            help="""Show only run durations""")
         common_args.add_bench(parser)
         common_args.add_machine(parser)
         common_args.add_environment(parser)

--- a/asv/plugins/github.py
+++ b/asv/plugins/github.py
@@ -16,9 +16,9 @@ class GithubPages(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "gh-pages", help="Publish the results to Github pages.",
+            "gh-pages", help="Publish the results to Github pages",
             description="""
-            Publish the results to github pages.
+            Publish the results to github pages
 
             Updates the 'gh-pages' branch in the current repository,
             and pushes it to 'origin'.


### PR DESCRIPTION
I noticed that the use of periods (`.`)  in the command line help
descriptions is inconsistent. Most help description strings are not
terminated by a period, but some are. For example, observe the following
output:

```
subcommands:
  valid subcommands

  {help,quickstart,machine,setup,run,dev,continuous,find,rm,publish,preview,profile,update,show,compare,check,gh-pages}
    help                Display usage information
    quickstart          Create a new benchmarking suite
    machine             Define information about this machine
    setup               Setup virtual environments
    run                 Run a benchmark suite
    dev                 Do a test run of a benchmark suite during development
    continuous          Compare two commits directly
    find                Find commits that introduced large regressions
    rm                  Remove results from the database
    publish             Collate results into a website
    preview             Preview the results using a local web server
    profile             Run the profiler on a particular benchmark on a particular revision
    update              Update the results and config files to the current version
    show                Print recorded data.
    compare             Compare the benchmark results between two revisions (averaged over configurations)
    check               Import and check benchmark suite, but do not run benchmarks.
    gh-pages            Publish the results to Github pages.
```

The `show`, `check` and `gh-pages` descriptions are terminated with a
period, whereas the others are not.

This PR increases consistency by removing the periods in question from
the subcommand help text but also from the options help of each of the
subcommands in question.