### PR TITLE
fix typo

### DIFF
--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -137,7 +137,7 @@ applies to in two ways:
   included in the timing of the benchmark.
 
 A separate cache is used for each environment and each commit of the
-project begin tested and is thrown out between benchmark runs.
+project being tested and is thrown out between benchmark runs.
 
 For example, caching data in a pickle::
 


### PR DESCRIPTION
This one is hard to spot, as the wrong word is used, rather then being
and incorrect spelling.