### PR TITLE
Add id attribute to benchmark group containers to make them linkable.

### DIFF
--- a/asv/www/summarygrid.js
+++ b/asv/www/summarygrid.js
@@ -111,7 +111,7 @@ $(document).ready(function() {
         }
 
         $.each(get_benchmarks_by_groups(), function(group, benchmarks) {
-            var group_container = $('<div class="benchmark-group"/>')
+            var group_container = $('<div id="' + group + '" class="benchmark-group"/>')
             group_container.append($('<h1>' + group + '</h1>'));
             summary_display.append(group_container);
             $.each(benchmarks, function(i, bm_name) {

--- a/asv/www/summarygrid.js
+++ b/asv/www/summarygrid.js
@@ -111,7 +111,8 @@ $(document).ready(function() {
         }
 
         $.each(get_benchmarks_by_groups(), function(group, benchmarks) {
-            var group_container = $('<div id="' + group + '" class="benchmark-group"/>')
+            var group_container = $('<div class="benchmark-group"/>')
+            group_container.attr('id', 'group-' + group)
             group_container.append($('<h1>' + group + '</h1>'));
             summary_display.append(group_container);
             $.each(benchmarks, function(i, bm_name) {


### PR DESCRIPTION
This pull request add an id attribute to benchmark group containers.
This make the benchmark group sections linkable with anchors `#<group>`.
I personally find that useful when link to specific sections are needed from a documentation.

Thanks for considering it.