### PR TITLE
make benchmark template work with Python 3

### DIFF
--- a/asv/template/benchmarks/benchmarks.py
+++ b/asv/template/benchmarks/benchmarks.py
@@ -16,18 +16,13 @@ class TimeSuite:
         for key in self.d.keys():
             pass
 
-    def time_iterkeys(self):
-        for key in self.d.iterkeys():
+    def time_values(self):
+        for value in self.d.values():
             pass
 
     def time_range(self):
         d = self.d
         for key in range(500):
-            x = d[key]
-
-    def time_xrange(self):
-        d = self.d
-        for key in xrange(500):
             x = d[key]
 
 


### PR DESCRIPTION
afaik, xrange and iterkeys do not exist anymore in Python 3.