### PR TITLE
Fix JavaScript navigation for method names with escaped entities

### DIFF
--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -318,7 +318,7 @@ $(document).ready(function() {
 
         var match = str.match(/^([^?]*?)\?/);
         if (match) {
-            info['location'] = match[1].replace(/\/+/, '/').split('/');
+            info['location'] = decodeURIComponent(match[1]).replace(/\/+/, '/').split('/');
             var rest = str.slice(match[1].length+1);
             var parts = rest.split('&');
             for (var i = 0; i < parts.length; ++i) {
@@ -340,7 +340,7 @@ $(document).ready(function() {
             }
         }
         else {
-            info['location'] = str.replace(/\/+/, '/').split('/');
+            info['location'] = decodeURIComponent(str).replace(/\/+/, '/').split('/');
         }
         return info;
     }


### PR DESCRIPTION
In Python 3, a method such as `def time_β(): pass` is valid. However,
asv's HTML output struggles with characters in benchmark names that get
URL encoded. The following shows up in the browser console for such
a method:

```
Uncaught TypeError: index.benchmarks[current_benchmark] is undefined
```

The problem here seems to be that `current_benchmark` is not correctly
decoded and contains the URL encoding of `β`.