### PR TITLE
example to run single commit

### DIFF
--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -292,6 +292,10 @@ Or, to benchmark all of the commits since a particular tag (``v0.1``)::
 
     asv run v0.1..master
 
+To benchmark a single commit, or tag, use `^!` (git)::
+
+    asv run v0.1^!
+
 Corresponding examples for Mercurial using the revsets specification are also
 possible.
 


### PR DESCRIPTION
I couldn't find how to benchmark a specific tag or commit. 

This Issue gave the answer, https://github.com/airspeed-velocity/asv/issues/544#issuecomment-330463218, but the information is only shown in the `git run` command-line help and not on the website. 

I added one example in the "Using" section. 