### PR TITLE
find: acknowledge invert in difference calculations

### DIFF
--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -176,6 +176,9 @@ class Find(Command):
                     denom = abs(va) + abs(vb) + abs(vc)
                     if denom == 0:
                         denom = 1.0
+                    if invert:
+                        denom*=-1.0
+
                     results_ab.append((va - vb) / denom)
                     results_bc.append((vb - vc) / denom)
             return max(results_ab), max(results_bc)
@@ -220,9 +223,6 @@ class Find(Command):
 
             diff_b, diff_a = difference_3way(hi_result, mid_result, lo_result)
 
-            if invert:
-                diff_a *= -1.0
-                diff_b *= -1.0
 
             if diff_a >= diff_b:
                 return do_search(lo, mid)

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -232,6 +232,12 @@ class Find(Command):
         result = do_search(0, len(commit_hashes) - 1)
 
         commit_name = repo.get_decorated_hash(commit_hashes[result], 8)
-        log.info("Greatest regression found: {0}".format(commit_name))
+
+        if invert:
+            direction = "improvement"
+        else:
+            direction = "regression"
+
+        log.info("Greatest {0} found: {1}".format(direction, commit_name))
 
         return 0

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -71,7 +71,7 @@ def test_find_timeout(capfd, tmpdir):
     assert "asv: benchmark timed out (timeout 1.0s)" in output
 
 
-def test_find3(capfd, tmpdir):
+def test_find_inverted(capfd, tmpdir):
     values = [
         (5, 6),
         (6, 6),
@@ -90,5 +90,5 @@ def test_find3(capfd, tmpdir):
     regression_hash = check_output(
         [which('git'), 'rev-parse', f'master^'], cwd=conf.repo)
 
-    formatted = "Greatest regression found: {0}".format(regression_hash[:8])
+    formatted = "Greatest improvement found: {0}".format(regression_hash[:8])
     assert formatted in output

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -69,3 +69,26 @@ def test_find_timeout(capfd, tmpdir):
 
     assert "Greatest regression found: {0}".format(regression_hash[:8]) in output
     assert "asv: benchmark timed out (timeout 1.0s)" in output
+
+
+def test_find3(capfd, tmpdir):
+    values = [
+        (5, 6),
+        (6, 6),
+        (6, 6),
+        (6, 1),
+        (6, 1),
+    ]
+
+
+    tmpdir, local, conf, machine_file = generate_basic_conf(tmpdir, values=values, dummy_packages=False)
+    tools.run_asv_with_conf(*[conf, 'find',"-i", f"master~4..master", "params_examples.track_find_test"],
+                            _machine_file=machine_file)
+
+    output, err = capfd.readouterr()
+
+    regression_hash = check_output(
+        [which('git'), 'rev-parse', f'master^'], cwd=conf.repo)
+
+    formatted = "Greatest regression found: {0}".format(regression_hash[:8])
+    assert formatted in output


### PR DESCRIPTION
When calculating `difference_3_way` we choose max of diff between `a-b` and `b-c` which is not true if we are using `invert` flag. In this case the change sign will be `-` so when going for `max` `find` will prefer any degradation over actual improvement. So, in order to fix that we can use `- denom` in `difference` calculations. 