### PR TITLE
add support for mamba

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - "%CONDA_PATH%\\Scripts\\activate.bat"
 
   # Install the build and runtime dependencies of the project.
-  - conda install -q --yes python=%PYTHON_VERSION% conda six pip pytest pytest-xdist pytest-timeout filelock selenium conda-build bzip2 mamba
+  - conda install -q --yes -c conda-forge python=%PYTHON_VERSION% conda six pip pytest pytest-xdist pytest-timeout filelock selenium conda-build bzip2 mamba
   - python -mpip install pytest-rerunfailures pytest-faulthandler
 
   # Check that we have the expected version of Python

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - "%CONDA_PATH%\\Scripts\\activate.bat"
 
   # Install the build and runtime dependencies of the project.
-  - conda install -q --yes python=%PYTHON_VERSION% conda six pip pytest pytest-xdist pytest-timeout filelock selenium conda-build bzip2
+  - conda install -q --yes python=%PYTHON_VERSION% conda six pip pytest pytest-xdist pytest-timeout filelock selenium conda-build bzip2 mamba
   - python -mpip install pytest-rerunfailures pytest-faulthandler
 
   # Check that we have the expected version of Python

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
       popd;
       . $HOME/miniconda3/etc/profile.d/conda.sh  # enable conda bash function
       conda activate
-      conda install --yes conda-build bzip2
+      conda install --yes conda-build bzip2 mamba
       conda info
     else
       ENVIRONMENT_TYPE=virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
       popd;
       . $HOME/miniconda3/etc/profile.d/conda.sh  # enable conda bash function
       conda activate
-      conda install --yes conda-build bzip2 mamba
+      conda install --yes -c conda-forge conda-build bzip2 mamba
       conda info
     else
       ENVIRONMENT_TYPE=virtualenv

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -1,0 +1,39 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+from .. import util
+from .conda import Conda
+
+
+
+class Mamba(Conda):
+    """
+    Manage an environment using mamba.
+
+    Dependencies are installed using ``mamba``.  The benchmarked
+    project is installed using ``pip`` (since ``mamba`` doesn't have a
+    method to install from an arbitrary ``setup.py``).
+    """
+    tool_name = "mamba"
+    _matches_cache = {}
+
+    @staticmethod
+    def _find_executable():
+        """
+        Find the mamba executable robustly across mamba versions.
+
+        Returns
+        -------
+        mamba : str
+            Path to the mamba executable.
+
+        Raises
+        ------
+        IOError
+            If the executable cannot be found in the PATH.
+        """
+        return util.which('mamba')
+
+_find_mamba = Mamba._find_executable

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -384,7 +384,7 @@ defaults to ``"benchmarks"``.
 
 ``environment_type``
 --------------------
-Specifies the tool to use to create environments.  May be "conda",
+Specifies the tool to use to create environments.  May be "conda", "mamba",
 "virtualenv" or another value depending on the plugins in use.  If
 missing or the empty string, the tool will be automatically determined
 by looking for tools on the ``PATH`` environment variable.

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -433,7 +433,7 @@ def test_environment_select(environment_type):
         # Check default python specifiers
         environments = list(environment.get_environments(conf, [environment_type, "virtualenv"]))
         items = sorted((env.tool_name, env.python) for env in environments)
-        assert items == [(environment_type, '1.9'), (environment_type PYTHON_VER1), ('virtualenv', PYTHON_VER1)]
+        assert items == [(environment_type, '1.9'), (environment_type, PYTHON_VER1), ('virtualenv', PYTHON_VER1)]
 
         # Check specific python specifiers
         environments = list(environment.get_environments(conf, ["conda:3.5", "virtualenv:"+PYTHON_VER1]))

--- a/test/tools.py
+++ b/test/tools.py
@@ -86,8 +86,8 @@ except (RuntimeError, IOError) as exc:
 
 try:
     # Conda can install required Python versions on demand
-    _check_mamba()
-    HAS_MAMBA = True
+    _find_mamba()
+    HAS_MAMBA = True and HAS_CONDA
 except (RuntimeError, IOError) as exc:
     HAS_MAMBA = False
 

--- a/test/tools.py
+++ b/test/tools.py
@@ -41,6 +41,7 @@ from asv.commands.preview import create_httpd
 from asv.repo import get_repo
 from asv.results import Results
 from asv.plugins.conda import _find_conda
+from asv.plugins.mamba import _find_mamba
 
 
 # Two Python versions for testing
@@ -82,6 +83,13 @@ try:
     HAS_CONDA = True
 except (RuntimeError, IOError) as exc:
     HAS_CONDA = False
+
+try:
+    # Conda can install required Python versions on demand
+    _check_mamba()
+    HAS_MAMBA = True
+except (RuntimeError, IOError) as exc:
+    HAS_MAMBA = False
 
 
 try:


### PR DESCRIPTION
Trying to add support for `mamba` envs. Closes #962.

Should `mamba` be part of the tool autodiscovery mechanism specified in [`pythons`](https://asv.readthedocs.io/en/stable/asv.conf.json.html#pythons)? It's not clear to me how one can prioritize the env type [here](https://github.com/airspeed-velocity/asv/blob/master/asv/environment.py#L404).