### PR TITLE
Remove unused sys.exit

### DIFF
--- a/asv/__main__.py
+++ b/asv/__main__.py
@@ -4,9 +4,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import sys
-
 from .main import main
 
 if __name__ == '__main__':
-    sys.exit(main())
+    main()


### PR DESCRIPTION
This `sys.exit` call is never executed, and adds no value, since `main` already calls `sys.exit` and won't return.