### PR TITLE
Fix loading of pages for benchmarks with escaped entities

### DIFF
--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -1362,7 +1362,7 @@ $(document).ready(function() {
 
 
     $.asv.register_page('graphdisplay', function(params) {
-        var benchmark = params['benchmark'];
+        var benchmark = decodeURIComponent(params['benchmark']);
         var highlight_revisions = null;
         var state_selection = null;
 


### PR DESCRIPTION
this fixes a problem similar to the one in #954.

The names of benchmarks may contain characters that are encoded so they
need to be decoded when looking up the benchmark in the database.