### PR TITLE
Fix PEP-8 violations reported by flake8 on test/benchmark folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
         run: flake8 . || true # preventing CI failing while flake8 issues exist
       
       - name: flake8 validating correct file(s)
-        run: flake8 test/benchmark/params_examples.py
+        run: flake8 test/benchmark/cache_examples.py test/benchmark/code_extraction.py test/benchmark/params_examples.py test/benchmark/subdir/time_subdir.py test/benchmark/time_examples.py test/benchmark/time_secondary.py test/benchmark/timeraw_examples.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,6 @@ jobs:
 
       - name: flake8
         run: flake8 . || true # preventing CI failing while flake8 issues exist
+      
+      - name: flake8 validating correct file(s)
+        run: flake8 test/benchmark/params_examples.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 99
-ignore = ""
+ignore = W504

--- a/test/benchmark/cache_examples.py
+++ b/test/benchmark/cache_examples.py
@@ -42,6 +42,8 @@ def my_setup_cache():
 def track_my_cache_foo(d):
     assert not os.path.isfile("data.txt")
     return d['foo']
+
+
 track_my_cache_foo.setup_cache = my_setup_cache
 
 
@@ -78,8 +80,9 @@ class ClassLevelCacheTimeoutSuccess:
 def time_fail_second_run(data):
     if os.path.isfile("time_fail_second_run.tag"):
         raise RuntimeError()
-    with open("time_fail_second_run.tag", "w") as f:
+    with open("time_fail_second_run.tag", "w"):
         pass
+
 
 time_fail_second_run.setup_cache = my_setup_cache
 time_fail_second_run.number = 1

--- a/test/benchmark/code_extraction.py
+++ b/test/benchmark/code_extraction.py
@@ -4,21 +4,26 @@ def setup():
     # module-level
     pass
 
+
 def setup_cache():
     # module-level
     pass
+
 
 def track_test():
     # module-level 難
     return 0
 
+
 def track_pretty_source_test():
     return 0
+
 
 track_pretty_source_test.pretty_source = '''
     int track_pretty_source_test() {
         return 0;
     }'''
+
 
 class MyClass:
     def setup(self):
@@ -32,4 +37,3 @@ class MyClass:
     def track_test(self):
         # class-level 難
         return 0
-

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -3,8 +3,6 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import os # noqa F401 unused import
-
 
 class ClassOne(object):
     pass
@@ -22,7 +20,7 @@ track_param.params = [ClassOne, ClassTwo]
 
 
 def mem_param(n, m):
-    return [[0]*m]*n
+    return [[0] * m] * n
 
 
 mem_param.params = ([10, 20], [2, 3])

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -3,10 +3,12 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import os
+import os # noqa F401 unused import
+
 
 class ClassOne(object):
     pass
+
 
 class ClassTwo(object):
     pass
@@ -15,11 +17,13 @@ class ClassTwo(object):
 def track_param(n):
     return 42
 
+
 track_param.params = [ClassOne, ClassTwo]
 
 
 def mem_param(n, m):
     return [[0]*m]*n
+
 
 mem_param.params = ([10, 20], [2, 3])
 mem_param.param_names = ['number', 'depth']
@@ -81,6 +85,8 @@ def setup_skip(n):
 
 def time_skip(n):
     list(range(n))
+
+
 time_skip.params = [1000, 2000, 3000]
 time_skip.setup = setup_skip
 time_skip.sample_time = 0.01
@@ -91,13 +97,16 @@ def track_find_test(n):
 
     return asv_test_repo.dummy_value[n - 1]
 
+
 track_find_test.params = [1, 2]
 
 
 def time_find_test_timeout():
-    import asv_test_repo, time
+    import asv_test_repo
+    import time
     if asv_test_repo.dummy_value[1] < 0:
         time.sleep(100)
+
 
 time_find_test_timeout.timeout = 1.0
 time_find_test_timeout.repeat = 1
@@ -116,10 +125,12 @@ track_param_selection.params = [[1, 2], [3, 5]]
 def track_bytes():
     return 1000000
 
+
 track_bytes.unit = "bytes"
 
 
 def track_wrong_number_of_args(a, b):
     return 0
+
 
 track_wrong_number_of_args.params = [[1, 2]]

--- a/test/benchmark/subdir/time_subdir.py
+++ b/test/benchmark/subdir/time_subdir.py
@@ -1,5 +1,3 @@
-import time # noqa F401 unused import
-
 x = None
 
 

--- a/test/benchmark/subdir/time_subdir.py
+++ b/test/benchmark/subdir/time_subdir.py
@@ -1,4 +1,4 @@
-import time
+import time # noqa F401 unused import
 
 x = None
 

--- a/test/benchmark/time_examples.py
+++ b/test/benchmark/time_examples.py
@@ -39,12 +39,14 @@ def time_with_warnings():
     1 / 0
     warnings.warn('after')
 
+
 time_with_warnings.sample_time = 0.1
 
 
 def time_with_timeout():
     while True:
         pass
+
 
 time_with_timeout.timeout = 0.1
 
@@ -102,6 +104,7 @@ class TimeWithBadTimer(object):
 
 def time_auto_repeat():
     pass
+
 
 time_auto_repeat.number = 1
 time_auto_repeat.processes = 1

--- a/test/benchmark/time_secondary.py
+++ b/test/benchmark/time_secondary.py
@@ -18,7 +18,7 @@ from .shared import shared_function
 if sys.version_info[0] < 3:
     import commands
 try:
-    import commands.quickstart
+    import commands.quickstart # noqa F401 unused import
     assert False
 except ImportError:
     # OK

--- a/test/benchmark/timeraw_examples.py
+++ b/test/benchmark/timeraw_examples.py
@@ -4,8 +4,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import inspect  # Checked below.
-import sys
+import inspect  # Checked below. # noqa F401 unused import
+import sys # noqa F401 unused import
 
 
 class TimerawSuite(object):

--- a/test/benchmark/timeraw_examples.py
+++ b/test/benchmark/timeraw_examples.py
@@ -4,9 +4,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import inspect  # Checked below. # noqa F401 unused import
-import sys # noqa F401 unused import
-
 
 class TimerawSuite(object):
     def timeraw_fresh(self):


### PR DESCRIPTION
Check flake8 and fix pep8 issues related on :
* cache_examples.py
* code_extraction.py
* params_examples.py
* subdir/time_subdir.py
* time_examples.py
* time_secondary.py
* timeraw_examples.py