### PR TITLE
Packaging requirements-dev.txt, needed by setup.py in conda-forge

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,7 @@ recursive-include asv *.html *.js *.css *.ico *.png
 include asv.conf.json
 recursive-include benchmarks *.py
 
-include pip_requirements.txt
+include requirements-dev.txt
 include pyproject.toml
 include pytest.ini
 


### PR DESCRIPTION
conda-forge feedstock builds are failing, because `requirements-dev.txt` is used in `setup.py` but it's not shipped in the source dist.

See https://github.com/airspeed-velocity/asv/issues/967#issuecomment-1030661996