### PR TITLE
Changes required to set minimum Python version to 3.7

### DIFF
--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -148,7 +148,7 @@ will to default to the version of Python that the ``asv`` command
 If provided, it should be a list of strings.  It may be one of the
 following:
 
-- a Python version string, e.g. ``"2.7"``, in which case:
+- a Python version string, e.g. ``"3.7"``, in which case:
 
   - if ``conda`` is found, ``conda`` will be used to create an
     environment for that version of Python via a temporary

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -313,7 +313,7 @@ Each exclude rule can contain the following keys:
 
 For example::
 
-    "pythons": ["2.6", "2.7"],
+    "pythons": ["3.8", "3.9"],
     "matrix": {
         "req": {
             "numpy": ["1.7", "1.8"],
@@ -323,22 +323,22 @@ For example::
         "env": {"FOO": ["1", "2"]},
     },
     "exclude": [
-        {"python": "2.6", "req": {"numpy": "1.7"}},
+        {"python": "3.8", "req": {"numpy": "1.7"}},
         {"sys_platform": "(?!win32).*", "req": {"colorama": ""}},
         {"sys_platform": "win32", "req": {"colorama": null}},
         {"env": {"FOO": "1"}},
     ]
 
 This will generate all combinations of Python version and items in the
-matrix, except those with Python 2.6 and Numpy 1.7. In other words,
+matrix, except those with Python 3.8 and Numpy 3.9. In other words,
 the combinations::
 
-    python==2.6 numpy==1.8 Cython==latest (colorama==latest) FOO=2
-    python==2.6 numpy==1.8 (colorama==latest) FOO=2
-    python==2.7 numpy==1.7 Cython==latest (colorama==latest) FOO=2
-    python==2.7 numpy==1.7 (colorama==latest) FOO=2
-    python==2.7 numpy==1.8 Cython==latest (colorama==latest) FOO=2
-    python==2.7 numpy==1.8 (colorama==latest) FOO=2
+    python==3.8 numpy==1.8 Cython==latest (colorama==latest) FOO=2
+    python==3.8 numpy==1.8 (colorama==latest) FOO=2
+    python==3.9 numpy==1.7 Cython==latest (colorama==latest) FOO=2
+    python==3.9 numpy==1.7 (colorama==latest) FOO=2
+    python==3.9 numpy==1.8 Cython==latest (colorama==latest) FOO=2
+    python==3.9 numpy==1.8 (colorama==latest) FOO=2
 
 The ``colorama`` package will be installed only if the current
 platform is Windows.
@@ -367,12 +367,12 @@ The exclude rules are not applied to includes.
 For example::
 
     "include": [
-        {"python": "2.7", "req": {"numpy": "1.8.2"}, "env": {"FOO": "true"}},
+        {"python": "3.9", "req": {"numpy": "1.8.2"}, "env": {"FOO": "true"}},
         {"platform": "win32", "environment_type": "conda",
          "req": {"python": "2.7", "libpython": ""}}
     ]
 
-This corresponds to two additional environments. One runs on Python 2.7
+This corresponds to two additional environments. One runs on Python 3.9
 and including the specified version of Numpy. The second is active only
 for Conda on Windows, and installs the latest version of ``libpython``.
 

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -2,7 +2,7 @@ Installing airspeed velocity
 ============================
 
 **airspeed velocity** is known to work on Linux, Mac OS-X, and Windows.
-It is known to work with Python 3.7.
+It is known to work with Python 3.7 and higher.
 It works also with PyPy.
 
 **airspeed velocity** is a standard Python package, and the latest

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -2,7 +2,7 @@ Installing airspeed velocity
 ============================
 
 **airspeed velocity** is known to work on Linux, Mac OS-X, and Windows.
-It is known to work with Python 2.7, 3.4, 3.5, and 3.6.
+It is known to work with Python 3.7.
 It works also with PyPy.
 
 **airspeed velocity** is a standard Python package, and the latest

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -218,7 +218,7 @@ for you, but it expects to find the Python versions specified
 in the ``asv.conf.json`` file available on the ``PATH``.  For example,
 if the ``asv.conf.json`` file has::
 
-  "pythons": ["3.7"]
+  "pythons": ["3.7", "3.10"]
 
 then it will use the executables named ``python2.7`` and
 ``python3.6`` on the path.  There are many ways to get multiple

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -214,11 +214,11 @@ installed to support other environment tools.  The
 tool used to create environments.
 
 When using ``virtualenv``, ``asv`` does not build Python interpreters
-for you, but it expects to find each of the Python versions specified
+for you, but it expects to find the Python versions specified
 in the ``asv.conf.json`` file available on the ``PATH``.  For example,
 if the ``asv.conf.json`` file has::
 
-  "pythons": ["2.7", "3.6"]
+  "pythons": ["3.7"]
 
 then it will use the executables named ``python2.7`` and
 ``python3.6`` on the path.  There are many ways to get multiple

--- a/setup.py
+++ b/setup.py
@@ -261,7 +261,7 @@ def run_setup(build_binary=False):
             str('console_scripts'): ['asv = asv.main:main']
         },
 
-        python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+        python_requires='>=3.7',
 
         zip_safe=False,
 
@@ -280,7 +280,6 @@ def run_setup(build_binary=False):
             'Environment :: Web Environment',
             'Intended Audience :: Developers',
             'License :: OSI Approved :: BSD License',
-            'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 3',
             'Topic :: Software Development :: Testing',
         ]


### PR DESCRIPTION
xref #1022 

Update the required Python version on `setup.py` and some parts of the documentation.

@datapythonista do you think we need to update the examples on the exclude and include part? https://asv.readthedocs.io/en/stable/asv.conf.json.html