### PR TITLE
CLN: Remove unused six imports

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -1,12 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 import shutil
 import multiprocessing
 import datetime
 from collections import defaultdict
-
-import six
 
 from . import Command
 from ..benchmarks import Benchmarks

--- a/asv/commands/rm.py
+++ b/asv/commands/rm.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-import six
-
 from fnmatch import fnmatchcase
 import sys
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 import sys
 import logging
@@ -9,8 +8,6 @@ import argparse
 import textwrap
 
 from collections import defaultdict
-
-import six
 
 from . import Command
 from ..benchmarks import Benchmarks

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -1,12 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import re
 import os
 import tempfile
 import contextlib
-import multiprocessing
-
-import six
 
 from .. import environment
 from ..console import log
@@ -21,6 +17,7 @@ WIN = (os.name == "nt")
 # Hence, serialize the calls to it.
 
 util.new_multiprocessing_lock("conda_lock")
+
 
 def _conda_lock():
     # function; for easier monkeypatching

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -1,10 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 import re
 import itertools
 import datetime
-import six
 
 from six.moves.urllib.parse import urlencode
 

--- a/asv/plugins/summarylist.py
+++ b/asv/plugins/summarylist.py
@@ -1,15 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 import itertools
-import six
 
 from ..console import log
 from ..publishing import OutputPublisher
 from ..graph import Graph
 
 from .. import util
-
 
 
 def benchmark_param_iter(benchmark):

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -1,11 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 from distutils.version import LooseVersion
 import sys
 import re
 import os
-
-import six
 
 from .. import environment
 from ..console import log

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 from os.path import abspath, dirname, join
 
-import six
 import pytest
 import shutil
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 import sys
-import six
 import pytest
 import json
 from collections import defaultdict

--- a/test/test_gh_pages.py
+++ b/test/test_gh_pages.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
-import six
 import pytest
 
 from . import tools

--- a/test/test_machine.py
+++ b/test/test_machine.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 from os.path import join
-
-import six
 
 from asv import machine
 

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -1,11 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import datetime
 import os
 from os.path import abspath, dirname, join, isfile, isdir
 import shutil
 
-import six
 import pytest
 import xml.etree.ElementTree as etree
 try:

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 from os.path import join
 
-import six
 import pytest
 import tempfile
 import shutil

--- a/test/test_rm.py
+++ b/test/test_rm.py
@@ -1,9 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 from os.path import dirname, join
 import shutil
-
-import six
 
 from asv import config
 from asv import results

--- a/test/test_show.py
+++ b/test/test_show.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 from os.path import abspath, dirname, join
 
-import six
 import textwrap
 
 from asv import config

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import io
 import locale
 import os
@@ -11,7 +10,6 @@ import threading
 import traceback
 import time
 import datetime
-import six
 import pytest
 
 from asv import console

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import os
 import re
 import shutil
@@ -8,7 +7,6 @@ import tempfile
 import contextlib
 from os.path import join, abspath, dirname
 
-import six
 from six.moves.urllib.parse import parse_qs, splitquery, splittag
 
 import pytest


### PR DESCRIPTION
xref # 1040

Clean up of `six` imports that are unused. This will make it easier to find pending code that does use `six`.