### PR TITLE
RemovePY2 six from asv/commands/quickstart.py and test/test_console.py files

### DIFF
--- a/asv/commands/quickstart.py
+++ b/asv/commands/quickstart.py
@@ -2,9 +2,6 @@
 
 import os
 import shutil
-
-from six.moves import input as raw_input
-
 from . import Command
 from ..console import log, color_print
 
@@ -51,7 +48,7 @@ class Quickstart(Command):
             color_print("(2) benchmark suite in a separate repository")
             color_print("")
             while True:
-                answer = raw_input("Layout to use? [1/2] ")
+                answer = input("Layout to use? [1/2] ")
                 if answer.lower()[:1] == "1":
                     top_level = True
                     break

--- a/test/test_console.py
+++ b/test/test_console.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import six
 import io
 import os
 import sys
@@ -21,53 +20,40 @@ def test_write_with_fallback(tmpdir, capfd):
             locale.getpreferredencoding = lambda: preferred_encoding
 
             # Check writing to io.StringIO
-            if six.PY3:
-                stream = io.StringIO()
-                _write_with_fallback(value, stream)
-                assert stream.getvalue() == value
-            else:
-                stream = io.StringIO()
-                with pytest.raises(TypeError):
-                    _write_with_fallback(value, stream)
+            stream = io.StringIO()
+            _write_with_fallback(value, stream)
+            assert stream.getvalue() == value
 
             # Check writing to a text stream
-            if six.PY3:
-                buf = io.BytesIO()
-                stream = io.TextIOWrapper(buf, encoding=stream_encoding)
-                _write_with_fallback(value, stream)
-                stream.flush()
-                got = buf.getvalue()
-                assert got == expected
+            buf = io.BytesIO()
+            stream = io.TextIOWrapper(buf, encoding=stream_encoding)
+            _write_with_fallback(value, stream)
+            stream.flush()
+            got = buf.getvalue()
+            assert got == expected
 
             # Writing to io.BytesIO
-            if six.PY3:
-                stream = io.BytesIO()
-                with pytest.raises(TypeError):
-                    _write_with_fallback(value, stream)
-            else:
-                stream = io.BytesIO()
+            stream = io.BytesIO()
+            with pytest.raises(TypeError):
                 _write_with_fallback(value, stream)
-                assert stream.getvalue() == expected
 
             # Check writing to a file
             fn = os.path.join(tmpdir, 'tmp.txt')
-            if six.PY3:
-                with io.open(fn, 'w', encoding=stream_encoding) as stream:
-                    _write_with_fallback(value, stream)
-                with open(fn, 'rb') as stream:
-                    got = stream.read()
-                    assert got == expected
+            with io.open(fn, 'w', encoding=stream_encoding) as stream:
+                _write_with_fallback(value, stream)
+            with open(fn, 'rb') as stream:
+                got = stream.read()
+                assert got == expected
 
             # Check writing to Py2 files
-            if not six.PY3:
-                if stream_encoding == preferred_encoding:
-                    # No stream encoding: write in locale encoding
-                    for mode in ['w', 'wb']:
-                        with open(fn, mode) as stream:
-                            _write_with_fallback(value, stream)
-                        with open(fn, 'rb') as stream:
-                            got = stream.read()
-                            assert got == expected
+            if stream_encoding == preferred_encoding:
+                # No stream encoding: write in locale encoding
+                for mode in ['w', 'wb']:
+                    with open(fn, mode) as stream:
+                        _write_with_fallback(value, stream)
+                    with open(fn, 'rb') as stream:
+                        got = stream.read()
+                        assert got == expected
         finally:
             locale.getpreferredencoding = old_getpreferredencoding
 
@@ -84,10 +70,7 @@ def test_write_with_fallback(tmpdir, capfd):
 
     for pref_enc, stream_enc, s in itertools.product(encodings, encodings, strings):
         expected = None
-        if six.PY3:
-            encodings = [stream_enc, pref_enc]
-        else:
-            encodings = [pref_enc]
+        encodings = [stream_enc, pref_enc]
         for enc in encodings:
             try:
                 expected = s.encode(enc)


### PR DESCRIPTION
xref #1040

This will remove six functionality in the following files;

-     asv/commands/quickstart.py
-     test/test_console.py