### PR TITLE
CLN: fix maxrss unit on macos

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -128,21 +128,11 @@ if sys.platform.startswith('win'):
         if not ok:
             raise RuntimeError("SetProcessAffinityMask failed")
 else:
-    try:
-        import resource
+    import resource
 
-        # POSIX
-        if sys.platform == 'darwin':
-            def get_maxrss():
-                # OSX getrusage returns maxrss in bytes
-                # https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getrusage.2.html
-                return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-        else:
-            def get_maxrss():
-                # Linux, *BSD return maxrss in kilobytes
-                return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
-    except ImportError:
-        pass
+    def get_maxrss():
+        # convert from kilobytes to bytes
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
 
     def set_cpu_affinity(affinity_list):
         """Set CPU affinity to CPUs listed (numbered 0...n-1)"""


### PR DESCRIPTION
The macOS doc says the unit is kb. See https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getrusage.2.html

There is an answer that compares RSS and VSZ https://stackoverflow.com/questions/7880784/what-is-rss-and-vsz-in-linux-memory-management/21049737#21049737

We might need to investigate how do we calculate memory. 

Also, we could use psutil to replace a lot of code in this file. But in the comment, it says this module cannot have dependencies other than the standard library. We should look into this as well.