### PR TITLE
CLN: clean pytest config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,9 +58,6 @@ console_scripts =
 
 [tool:pytest]
 addopts=-p no:logging
-markers=
-    timeout
-    flaky
 
 [flake8]
 max-line-length = 99


### PR DESCRIPTION
Those markers come with their plugins.