### PR TITLE
Remove --strict option, and fail by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ New Features
 
 API Changes
 ^^^^^^^^^^^
+- ``asv run`` and ``asv continuous`` don't implement the ``--strict`` option anymore,
+  and they will always return a non-zero (i.e. ``2``) exit status if any benchmark fail.
 
 Bug Fixes
 ^^^^^^^^^

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -47,10 +47,6 @@ class Continuous(Command):
         parser.add_argument(
             "--no-interleave-processes", action="store_false", dest="interleave_rounds",
             help=argparse.SUPPRESS)
-        parser.add_argument(
-            "--strict", action="store_true",
-            help="When set true the run command will exit with a non-zero "
-                 "return code if any benchmark is in a failed state")
         common_args.add_compare(parser, sort_default='ratio', only_changed_default=True)
         common_args.add_show_stderr(parser)
         common_args.add_bench(parser)
@@ -73,7 +69,7 @@ class Continuous(Command):
             env_spec=args.env_spec, record_samples=args.record_samples,
             append_samples=args.append_samples,
             quick=args.quick, interleave_rounds=args.interleave_rounds,
-            launch_method=args.launch_method, strict=args.strict, **kwargs
+            launch_method=args.launch_method, **kwargs
         )
 
     @classmethod
@@ -82,8 +78,7 @@ class Continuous(Command):
             show_stderr=False, bench=None,
             attribute=None, machine=None, env_spec=None,
             record_samples=False, append_samples=False,
-            quick=False, interleave_rounds=None, launch_method=None, _machine_file=None,
-            strict=False):
+            quick=False, interleave_rounds=None, launch_method=None, _machine_file=None):
         repo = get_repo(conf)
         repo.pull()
 
@@ -108,8 +103,7 @@ class Continuous(Command):
             show_stderr=show_stderr, machine=machine, env_spec=env_spec,
             record_samples=record_samples, append_samples=append_samples, quick=quick,
             interleave_rounds=interleave_rounds,
-            launch_method=launch_method, strict=strict,
-            _returns=run_objs, _machine_file=_machine_file)
+            launch_method=launch_method, _returns=run_objs, _machine_file=_machine_file)
         if result:
             return result
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -160,10 +160,6 @@ class Run(Command):
         parser.add_argument(
             "--no-pull", action="store_true",
             help="Do not pull the repository")
-        parser.add_argument(
-            "--strict", action="store_true",
-            help="When set true the run command will exit with a non-zero "
-                 "return code if any benchmark is in a failed state")
 
     @classmethod
     def run_from_conf_args(cls, conf, args, **kwargs):
@@ -179,7 +175,7 @@ class Run(Command):
             record_samples=args.record_samples, append_samples=args.append_samples,
             pull=not args.no_pull, interleave_rounds=args.interleave_rounds,
             launch_method=args.launch_method, durations=args.durations,
-            strict=args.strict, **kwargs
+            **kwargs
         )
 
     @classmethod
@@ -189,7 +185,7 @@ class Run(Command):
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
             skip_failed=False, skip_existing_commits=False, record_samples=False,
             append_samples=False, pull=True, interleave_rounds=False,
-            launch_method=None, durations=0, strict=False, _returns={}):
+            launch_method=None, durations=0, _returns={}):
         machine_params = Machine.load(
             machine_name=machine,
             _path=_machine_file, interactive=True)
@@ -506,16 +502,15 @@ class Run(Command):
                         if not skip_save:
                             result.save(conf.results_dir)
 
-                        if strict:
-                            failures = failures or any(
-                                code != 0 for code in result.errcode.values())
+                        failures = failures or any(
+                            code != 0 for code in result.errcode.values())
 
                         if durations > 0:
                             duration_set = Show._get_durations([(machine, result)], benchmark_set)
                             log.info(cls.format_durations(
                                 duration_set[(machine, env.name)], durations))
 
-        if failures and strict:
+        if failures:
             return 2
 
     @classmethod

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -13,7 +13,7 @@ def test_dev(capsys, basic_conf):
     # Test Dev runs (with full benchmark suite)
     ret = tools.run_asv_with_conf(conf, 'dev', '--quick', '-e',
                                   _machine_file=machine_file)
-    assert ret is None
+    assert ret == 2
     text, err = capsys.readouterr()
 
     # time_with_warnings failure case

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -47,7 +47,7 @@ def test_dev_with_repo_subdir(capsys, basic_conf_with_subdir):
 
 def test_dev_strict(basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
-    ret = tools.run_asv_with_conf(conf, 'dev', '--strict', '--quick',
+    ret = tools.run_asv_with_conf(conf, 'dev', '--quick',
                                   '--bench=TimeSecondary',
                                   _machine_file=machine_file)
     assert ret == 2

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -378,10 +378,10 @@ def test_format_durations():
     assert msg == expected
 
 
-def test_return_code_strict_mode(tmpdir, basic_conf_2):
+def test_return_code(tmpdir, basic_conf_2):
     tmpdir, local, conf, machine_file = basic_conf_2
 
     res = tools.run_asv_with_conf(conf, 'run', 'master^!', '--quick',
-                                  '--strict', '--bench', 'TimeSecondary',
+                                  '--bench', 'TimeSecondary',
                                   _machine_file=machine_file)
     assert res == 2

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -28,7 +28,7 @@ def test_run_publish(capfd, basic_conf_2):
                                   '-a', 'warmup_time=0',
                                   '--durations=5',
                                   _machine_file=machine_file)
-    assert ret is None
+    assert ret == 2
     text, err = capfd.readouterr()
 
     assert len(os.listdir(join(tmpdir, 'results_workflow', 'orangutan'))) == 5


### PR DESCRIPTION
Closes #1199

`--strict` will now be the default, and the option will be removed. To ignore the exist status, for example in CI systems, `asv run || true` or similar can be used.