### PR TITLE
Sync sphinx docs benchmark examples with quickstart template file

### DIFF
--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -94,40 +94,10 @@ Once you've set up the project's configuration, you'll need to write
 some benchmarks.  The benchmarks live in Python files in the
 ``benchmarks`` directory.  The ``quickstart`` command has created a
 single example benchmark file already in
-``benchmarks/benchmarks.py``::
+``benchmarks/benchmarks.py``:
 
-    class TimeSuite:
-        """
-        An example benchmark that times the performance of various kinds
-        of iterating over dictionaries in Python.
-        """
-        def setup(self):
-            self.d = {}
-            for x in range(500):
-                self.d[x] = None
-
-        def time_keys(self):
-            for key in self.d.keys():
-                pass
-
-        def time_iterkeys(self):
-            for key in self.d.iterkeys():
-                pass
-
-        def time_range(self):
-            d = self.d
-            for key in range(500):
-                x = d[key]
-
-        def time_xrange(self):
-            d = self.d
-            for key in xrange(500):
-                x = d[key]
-
-
-    class MemSuite:
-        def mem_list(self):
-            return [0] * 256
+.. include:: ../../asv/template/benchmarks/benchmarks.py
+   :code: python
 
 You'll want to replace these benchmarks with your own.  See
 :ref:`writing-benchmarks` for more information.


### PR DESCRIPTION
#953 updated the quickstart template benchmarks to work with python 3.  However, the same 2.x examples were copy/pasted into the sphinx docs and are still there today: https://asv.readthedocs.io/en/stable/using.html

This PR uses RST `.. include::` to read in the actual template file and include it as formatted python code during the docs build, removing the need to manually keep the docs in sync with the actual template.