### PR TITLE
BUG: Allow branches that conflict with file names

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - conda update conda -y
   - conda install -q --yes python=%PYTHON_VERSION% conda pip pytest pytest-xdist pytest-timeout filelock selenium conda-build bzip2 pympler rpy2
   - python -m pip install -U pip
-  - python -m pip install pytest-rerunfailures json5 pympler tabulate colorama
+  - python -m pip install pytest-rerunfailures json5 pympler tabulate colorama virtualenv
 
   # Check that we have the expected version of Python
   - python --version

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -119,7 +119,7 @@ class Git(Repo):
     def get_hashes_from_range(self, range_spec):
         args = ['rev-list', '--first-parent']
         if range_spec != "":
-            args += shlex.split(range_spec)
+            args += shlex.split(range_spec) + ["--"]
         output = self._run_git(args, valid_return_codes=(0, 1), dots=False)
         return output.strip().split()
 

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -435,7 +435,8 @@ def test_regression_atom_feed_update(dvcs_type, tmpdir):
         b_content = b.find('{http://www.w3.org/2005/Atom}content')
         assert a_content.text != b_content.text
 
-def test_gh1209(tmpdir):
+def test_branch_name_is_also_filename(tmpdir):
+    # gh-1209
     tmpdir = str(tmpdir)
     dvcs = tools.generate_test_repo(tmpdir, list(range(10)),
                                     dvcs_type="git",

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -451,9 +451,9 @@ def test_gh1209(tmpdir):
         json5.dump(conf, fhandle, indent=4)
         fhandle.truncate()
     subprocess.run(["asv", "machine", "--yes"],
-                   cwd=dvcs.path, check=True)
+                   cwd=dvcs.path, check=False)
     subprocess.run(["asv", "run"],
-                   cwd=dvcs.path, check=True)
+                   cwd=dvcs.path, check=False)
     retdat = subprocess.run(["asv", "publish"], cwd=dvcs.path,
                             capture_output=True, text=True)
     assert "git rev-list --first-parent benchmarks" not in retdat.stderr

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -2,9 +2,11 @@
 import datetime
 import os
 import shutil
+import subprocess
 import xml.etree.ElementTree as etree
 from os.path import abspath, dirname, join, isfile, isdir
 
+import json5
 import pytest
 
 try:
@@ -432,3 +434,27 @@ def test_regression_atom_feed_update(dvcs_type, tmpdir):
         a_content = a.find('{http://www.w3.org/2005/Atom}content')
         b_content = b.find('{http://www.w3.org/2005/Atom}content')
         assert a_content.text != b_content.text
+
+def test_gh1209(tmpdir):
+    tmpdir = str(tmpdir)
+    dvcs = tools.generate_test_repo(tmpdir, list(range(10)),
+                                    dvcs_type="git",
+                                    extra_branches=[(f"{util.git_default_branch()}~4",
+                                                     "benchmarks", [11, 12, 13])])
+    subprocess.run(["asv", "quickstart", "--top-level"],
+                   cwd=dvcs.path, check=True)
+    with open(f"{dvcs.path}/asv.conf.json", 'r+') as fhandle:
+        conf = json5.load(fhandle)
+        conf["branches"] = ["benchmarks"]
+        conf["dvcs"] = "git"
+        fhandle.seek(0)
+        json5.dump(conf, fhandle, indent=4)
+        fhandle.truncate()
+    subprocess.run(["asv", "machine", "--yes"],
+                   cwd=dvcs.path, check=True)
+    subprocess.run(["asv", "run"],
+                   cwd=dvcs.path, check=True)
+    retdat = subprocess.run(["asv", "publish"], cwd=dvcs.path,
+                            capture_output=True, text=True)
+    assert "git rev-list --first-parent benchmarks" not in retdat.stderr
+    assert retdat.returncode == 0


### PR DESCRIPTION
Before, if I had a file named "benchmarks" and a branch specified in asv.conf.json also named "benchmarks", then when I ran `asv publish` I would get

```
$ asv publish
[ 11.11%] · Loading machine info
[ 22.22%] · Getting params, commits, tags and branches
[ 22.22%] ·· Error running /usr/local/bin/git rev-list --first-parent benchmarks (exit status 128)
             STDOUT -------->
             
             STDERR -------->
             fatal: ambiguous argument 'benchmarks': both revision and filename
             Use '--' to separate paths from revisions, like this:
             'git <command> [<revision>...] -- [<file>...]'

Traceback (most recent call last):
  File "/Users/nickcrews/Documents/projects/dedupe/.venv/bin/asv", line 8, in <module>
    sys.exit(main())
....
```

Tested locally, it works fine now.