### PR TITLE
Give GraalPy some time to warm up by default

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -538,6 +538,8 @@ class TimeBenchmark(Benchmark):
         if warmup_time < 0:
             if '__pypy__' in sys.modules:
                 warmup_time = 1.0
+            elif '__graalpython__' in sys.modules:
+                warmup_time = 5.0
             else:
                 # Transient effects exist also on CPython, e.g. from
                 # OS scheduling


### PR DESCRIPTION
[GraalPy](https://github.com/oracle/graalpython/) has two main modes, execution as native binary or hosted on the JVM. Both need warmup, but the latter needs more and since determining which is which is a bit specific, I figured it shouldn't hurt to use the conservative warmup time for both.