### PR TITLE
ENH: Speeding up collecting low-timing samples

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -1176,6 +1176,7 @@ def main_run_server(args):
             # (Poll in a loop is simplest --- also used by subprocess.py)
             start_time = wall_timer()
             is_timeout = False
+            time2sleep = 1e-15
             while True:
                 res, status = os.waitpid(pid, os.WNOHANG)
                 if res != 0:
@@ -1188,8 +1189,8 @@ def main_run_server(args):
                     else:
                         os.kill(pid, signal.SIGTERM)
                     is_timeout = True
-
-                time.sleep(0.05)
+                time2sleep *= 1e+1
+                time.sleep(min(time2sleep, 0.001))
 
             # Report result
             with io.open(stdout_file, 'r', errors='replace') as f:


### PR DESCRIPTION
  Putting the parent process of the main server to sleep for 50ms
  after each fork has a tremendous impact on the speed of
  collecting low-timing samples.

  Execute the following asv command before this patch cost:
```Bash    
asv run -n -e --python=same --bench BinaryComplex \
    -a warmup_time=0.001 -a number=100 --cpu-affinity=6,7 --durations
```
```Bash
                          benchmark                          total duration
  --------------------------------------------------------- ----------------
   bench_ufunc_strides.BinaryComplex.time_ufunc_scalar_in0       22.2s
   bench_ufunc_strides.BinaryComplex.time_ufunc_scalar_in1       22.2s
         bench_ufunc_strides.BinaryComplex.time_ufunc            22.2s
                            total                                1.11m
  ========================================================= ================
```
  And after:
```Bash
                          benchmark                          total duration
  --------------------------------------------------------- ----------------
         bench_ufunc_strides.BinaryComplex.time_ufunc            4.48s
   bench_ufunc_strides.BinaryComplex.time_ufunc_scalar_in0       4.11s
   bench_ufunc_strides.BinaryComplex.time_ufunc_scalar_in1       4.09s
                            total                                12.7s
  ========================================================= ================

```