### PR TITLE
TST,BUG: Fix error with submodules

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -87,13 +87,13 @@ class Git(Repo):
     def checkout(self, path, commit_hash):
         def checkout_existing(display_error):
             # Deinit fails if no submodules, so ignore its failure
-            self._run_git(['submodule', 'deinit', '-f', '.'],
+            self._run_git(['-c','protocol.file.allow=always', 'submodule', 'deinit', '-f', '.'],
                           cwd=path, display_error=False, valid_return_codes=None)
             self._run_git(['checkout', '-f', commit_hash],
                           cwd=path, display_error=display_error)
             self._run_git(['clean', '-fdx'],
                           cwd=path, display_error=display_error)
-            self._run_git(['submodule', 'update', '--init', '--recursive'],
+            self._run_git(['-c','protocol.file.allow=always', 'submodule', 'update', '--init', '--recursive'],
                           cwd=path, display_error=display_error)
 
         if os.path.isdir(path):

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -263,14 +263,14 @@ def test_git_submodule(tmpdir):
     commit_hash_0 = dvcs.get_hash("master")
 
     # State 1 (one submodule)
-    dvcs.run_git(['submodule', 'add', sub_dvcs.path, 'sub1'])
+    dvcs.run_git(['-c','protocol.file.allow=always', 'submodule', 'add', sub_dvcs.path, 'sub1'])
     dvcs.commit('Add sub1')
     commit_hash_1 = dvcs.get_hash("master")
 
     # State 2 (one submodule with sub-submodule)
-    dvcs.run_git(['submodule', 'update', '--init'])
+    dvcs.run_git(['-c','protocol.file.allow=always', 'submodule', 'update', '--init'])
     sub1_dvcs = tools.Git(join(dvcs.path, 'sub1'))
-    sub_dvcs.run_git(['submodule', 'add', ssub_dvcs.path, 'ssub1'])
+    sub_dvcs.run_git(['-c','protocol.file.allow=always', 'submodule', 'add', ssub_dvcs.path, 'ssub1'])
     sub_dvcs.commit('Add sub1')
     sub1_dvcs.run_git(['pull'])
     dvcs.run_git(['add', 'sub1'])

--- a/test/tools.py
+++ b/test/tools.py
@@ -174,6 +174,7 @@ class Git:
         self.run_git(['init'])
         self.run_git(['config', 'user.email', 'robot@asv'])
         self.run_git(['config', 'user.name', 'Robotic Swallow'])
+        self.run_git(['config', 'protocol.file.allow', 'always'])
 
     def commit(self, message, date=None):
         if date is None:


### PR DESCRIPTION
`git` had some security fixes due to CVE-2022-39253, which breaks the existing implementation for pulling submodules. [This post](https://vielmetti.typepad.com/logbook/2022/10/git-security-fixes-lead-to-fatal-transport-file-not-allowed-error-in-ci-systems-cve-2022-39253.html) has a good explanation.