### PR TITLE
Don't use distutils

### DIFF
--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -2,7 +2,7 @@
 import sys
 import re
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from .. import environment, util
 from ..console import log
@@ -108,11 +108,11 @@ class Virtualenv(environment.Environment):
         except ImportError:
             return False
         else:
-            if LooseVersion(virtualenv.__version__) == LooseVersion('1.11.0'):
+            if Version(virtualenv.__version__) == Version('1.11.0'):
                 log.warning(
                     "asv is not compatible with virtualenv 1.11 due to a bug in "
                     "setuptools.")
-            if LooseVersion(virtualenv.__version__) < LooseVersion('1.10'):
+            if Version(virtualenv.__version__) < Version('1.10'):
                 log.warning(
                     "If using virtualenv, it much be at least version 1.10")
 

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -60,7 +60,7 @@ A benchmark suite directory has the following layout.  The
       save on disk space.
 
       The project is built in this directory with the standard
-      ``distutils`` ``python setup.py build`` command.  This means
+      ``python setup.py build`` command.  This means
       repeated builds happen in the same place and `ccache
       <https://ccache.samba.org>`__ is able to cache and reuse many of
       the build products.

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-from distutils.errors import CompileError
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
+from setuptools.errors import CompileError
 
 
 class optional_build_ext(build_ext):


### PR DESCRIPTION
`disutiils` is going to be removed in Python 3.12 and these are the standard replacements (I believe).