### PR TITLE
MAINT: Add a CI timeout for GHA

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,7 +36,7 @@ build_script:
   - dir asv
 
 test_script:
-  - python -m pytest -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp -v --environment-type=conda --webdriver=ChromeHeadless --timeout=1800 --durations=100 test
+  - python -m pytest -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp -v --environment-type=conda --webdriver=ChromeHeadless --timeout=300 --durations=100 test
 
 after_build:
   # Clear up pip cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: pip install .
 
       - name: Run tests
-        run: python -m pytest -v --timeout=1800 --durations=20 test
+        run: python -m pytest -v --timeout=300 --durations=100 test
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.7", "3.10", "pypy-3.7", "pypy-3.8"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Adds the suggestions by @mattip from #1117. Closes #1117. We already have `pytest-timeout` for per-test timeouts, though it was a little too generous before..