### PR TITLE
ENH: Return pstats.Stats for --profile

### DIFF
--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -46,7 +46,7 @@ class Profile(Command):
             help="""The benchmark to profile.  Must be a
             fully-specified benchmark name. For parameterized benchmark, it
             must include the parameter combination to use, e.g.:
-            benchmark_name\(param0, param1, ...\)""")
+            benchmark_name\\(param0, param1, ...\\)""")
         parser.add_argument(
             'revision', nargs='?',
             help="""The revision of the project to profile.  May be a

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -214,5 +214,6 @@ class Profile(Command):
             color_print('')
             with temp_profile(profile_data) as profile_path:
                 stats = pstats.Stats(profile_path)
+                stats.strip_dirs()  # Addresses gh-71
                 stats.sort_stats('cumulative')
                 stats.print_stats()

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -46,7 +46,7 @@ class Profile(Command):
             help="""The benchmark to profile.  Must be a
             fully-specified benchmark name. For parameterized benchmark, it
             must include the parameter combination to use, e.g.:
-            benchmark_name(param0, param1, ...)""")
+            benchmark_name\(param0, param1, ...\)""")
         parser.add_argument(
             'revision', nargs='?',
             help="""The revision of the project to profile.  May be a

--- a/asv/results.py
+++ b/asv/results.py
@@ -561,6 +561,10 @@ class Results:
         profile_data = self._profiles[benchmark_name]
         profile_data = profile_data.encode('ascii')
         profile_bytes = zlib.decompress(base64.b64decode(profile_data))
+        return profile_bytes
+
+    def get_profile_stats(self, benchmark_name):
+        profile_bytes = self.get_profile(benchmark_name)
         return self._mk_pstats(profile_bytes)
 
     def has_profile(self, benchmark_name):

--- a/asv/results.py
+++ b/asv/results.py
@@ -554,8 +554,8 @@ class Results:
 
         Returns
         -------
-        profile_data : bytes
-            Raw profile data
+        profile_data : pstats.Stats
+            Profile data
 
         """
         profile_data = self._profiles[benchmark_name]

--- a/asv/results.py
+++ b/asv/results.py
@@ -7,6 +7,8 @@ import zlib
 import itertools
 import hashlib
 import datetime
+import tempfile
+import pstats
 
 from . import environment, statistics, util
 from .console import log
@@ -533,6 +535,14 @@ class Results:
             profile_data = profile_data.decode('ascii')
             self._profiles[benchmark_name] = profile_data
 
+    def _mk_pstats(self, bytedata):
+        fd, fpath = tempfile.mkstemp()
+        with os.fdopen(fd, 'wb') as hp:
+            hp.write(bytedata)
+        pstat = pstats.Stats(fpath)
+        os.remove(fpath)
+        return pstat
+
     def get_profile(self, benchmark_name):
         """
         Get the profile data for the given benchmark name.
@@ -550,7 +560,8 @@ class Results:
         """
         profile_data = self._profiles[benchmark_name]
         profile_data = profile_data.encode('ascii')
-        return zlib.decompress(base64.b64decode(profile_data))
+        profile_bytes = zlib.decompress(base64.b64decode(profile_data))
+        return self._mk_pstats(profile_bytes)
 
     def has_profile(self, benchmark_name):
         """

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -553,7 +553,25 @@ the ``--gui=runsnake`` to ``asv profile``, the profile is collected
 You can also get the raw profiling data by using the ``--output``
 argument to ``asv profile``.
 
+.. note::
+
+   Since the method name is passed as a regex, parenthesis need to be escaped, e.g.
+   ``asv profile 'benchmarks.MyBench.time_sort\(500\)' HEAD --gui snakeviz``
+
 See :ref:`cmd-asv-profile` for more options.
+
+To extract information from ``--profile`` runs of ``asv``::
+
+    $ python
+    import asv
+    results_asv = asv.results.iter_results(".asv")
+    res_objects = list(results_asv)
+    prof_data = res_objects[0].get_profile('benchmarks.MyBench.time_sort')
+    prof_data.sort_stats('cumulative').print_stats()
+
+Where different benchmarks may be used. A specific ``json`` may also be loaded
+directly with ``asv.results.Results.load(<json_path>)``, after which
+``get_profile`` can be used.
 
 .. _comparing:
 

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -567,6 +567,7 @@ To extract information from ``--profile`` runs of ``asv``::
     results_asv = asv.results.iter_results(".asv")
     res_objects = list(results_asv)
     prof_data = res_objects[0].get_profile_stats('benchmarks.MyBench.time_sort')
+    prof_data.strip_dirs() # Remove machine specific info
     prof_data.sort_stats('cumulative').print_stats()
 
 Where different benchmarks may be used. A specific ``json`` may also be loaded

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -566,12 +566,12 @@ To extract information from ``--profile`` runs of ``asv``::
     import asv
     results_asv = asv.results.iter_results(".asv")
     res_objects = list(results_asv)
-    prof_data = res_objects[0].get_profile('benchmarks.MyBench.time_sort')
+    prof_data = res_objects[0].get_profile_stats('benchmarks.MyBench.time_sort')
     prof_data.sort_stats('cumulative').print_stats()
 
 Where different benchmarks may be used. A specific ``json`` may also be loaded
 directly with ``asv.results.Results.load(<json_path>)``, after which
-``get_profile`` can be used.
+``get_profile_stats`` can be used.
 
 .. _comparing:
 


### PR DESCRIPTION
This, along with documentation changes chronicles how to use the results of `asv run --profile`. Closes #971, #808, #801, #71.

Addresses (7) of https://github.com/airspeed-velocity/asv/issues/1219#issuecomment-1270968475.