### PR TITLE
ENH: Report stderr for failures

### DIFF
--- a/asv/results.py
+++ b/asv/results.py
@@ -920,6 +920,10 @@ def format_benchmark_result(results, benchmark):
         display = _format_benchmark_result(display_result, benchmark)
         display = "\n".join(display).strip()
         details = display
+
+        # Display error if stderr is present
+        if failure_count > 0 and bool(results.stderr):
+            details += f"\n{results.stderr[name]}"
     else:
         if failure_count == 0:
             # Failure already shown above


### PR DESCRIPTION
Closes #1222 and #566. With this PR, something like:

```
# benchmarks/benchmarks.py
class Simple:
    params = ([False, True])
    param_names = ["ok"]

    def time_failure(self, ok):
        if ok:
            x = 34.2**4.2
        else:
            import something
            raise NotImplementedError
```

Will give:

```
[75.00%] ··· benchmarks.Simple.time_failure                                                    1/2 failed
[75.00%] ··· ======= ============
                ok               
             ------- ------------
              False     failed   
               True   97.5±0.3ns 
             ======= ============
             For parameters: False
             Traceback (most recent call last):
               File "/home/rgoswami/Git/Github/Python/asv/asv/benchmark.py", line 1218, in main_run_server
                 main_run(run_args)
               File "/home/rgoswami/Git/Github/Python/asv/asv/benchmark.py", line 1094, in main_run
                 result = benchmark.do_run()
                          ^^^^^^^^^^^^^^^^^^
               File "/home/rgoswami/Git/Github/Python/asv/asv/benchmark.py", line 470, in do_run
                 return self.run(*self._current_params)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               File "/home/rgoswami/Git/Github/Python/asv/asv/benchmark.py", line 567, in run
                 samples, number = self.benchmark_timing(timer, min_repeat, max_repeat,
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               File "/home/rgoswami/Git/Github/Python/asv/asv/benchmark.py", line 603, in benchmark_timing
                 timing = timer.timeit(number)
                          ^^^^^^^^^^^^^^^^^^^^
               File "/home/rgoswami/mambaforge/envs/expasv/lib/python3.11/timeit.py", line 178, in timeit
                 timing = self.inner(it, self.timer)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
               File "<timeit-src>", line 6, in inner
               File "/home/rgoswami/Git/Github/Python/asv/asv/benchmark.py", line 525, in func
                 self.func(*param)
               File "/home/rgoswami/Git/Github/Python/blah/benchmarks/benchmarks.py", line 53, in time_failure
                 import something
             ModuleNotFoundError: No module named 'something'
```

While without it, only the fact that it failed is reported, and users have to figure out why themselves, that is, the output was:

```
[75.00%] ··· benchmarks.Simple.time_failure                                                    1/2 failed
[75.00%] ··· ======= ==========
                ok             
             ------- ----------
              False    failed  
               True   94.3±4ns 
             ======= ==========
```