### PR TITLE
ENH: Add a markdown renderer for asv compare

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - conda update conda -y
   - conda install -q --yes python=%PYTHON_VERSION% conda pip pytest pytest-xdist pytest-timeout filelock selenium conda-build bzip2 pympler
   - python -m pip install -U pip
-  - python -m pip install pytest-rerunfailures json5 pympler
+  - python -m pip install pytest-rerunfailures json5 pympler tabulate
 
   # Check that we have the expected version of Python
   - python --version

--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -59,7 +59,7 @@ def add_compare(parser, only_changed_default=False, sort_default='name'):
     parser.add_argument('--no-only-changed', dest='only_changed', action='store_false')
 
     parser.add_argument(
-        '--sort', action='store', type=str, choices=('name', 'ratio'),
+        '--sort', action='store', type=str, choices=('name', 'ratio', 'default'),
         default=sort_default, help="""Sort order""")
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,5 +18,6 @@ python-hglib
 flake8
 isort>= 5.11.5
 json5
+tabulate
 pympler; platform_python_implementation != "PyPy"
 pyyaml

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -48,106 +48,105 @@ All benchmarks:
 | +        | 1.00s                | 3.00s               | 3.00    | time_with_version_match                       |
 | +        | 1.00s                | 3.00s               | 3.00    | time_with_version_mismatch_bench              |
 | x        | 1.00s                | 3.00s               | 3.00    | time_with_version_mismatch_other              |
-"""
+"""  # noqa: E501 line too long
 
 REFERENCE_SPLIT = """
 Benchmarks that have improved:
 
-       before           after         ratio
-     [22b920c6]       [fcf8c079]
--          69.1μs           18.3μs     0.27  time_units.time_unit_to
+| Change   | Before [22b920c6]    | After [fcf8c079]    |   Ratio | Benchmark (Parameter)   |
+|----------|----------------------|---------------------|---------|-------------------------|
+| -        | 69.1μs               | 18.3μs              |    0.27 | time_units.time_unit_to |
 
 Benchmarks that have stayed the same:
 
-       before           after         ratio
-     [22b920c6]       [fcf8c079]
-           failed           failed      n/a  time_AAA_failure
-              n/a              n/a      n/a  time_AAA_skip
-          1.00±1s          3.00±1s    ~3.00  time_ci_big
-            1.00s            1.00s     1.00  time_other.time_parameterized(1)
-            2.00s            4.00s     2.00  time_other.time_parameterized(2)
-           83.6μs           55.4μs     0.66  time_quantity.time_quantity_init_scalar
-            282μs            147μs     0.52  time_quantity.time_quantity_scalar_conversion
-               42               42     1.00  time_secondary.track_value
-            5.73m            5.73m     1.00  time_units.mem_unit
-           1.64ms           1.53ms     0.93  time_units.time_unit_compose
-           11.9μs           13.1μs     1.10  time_units.time_very_simple_unit_parse
+| Change   | Before [22b920c6]    | After [fcf8c079]    | Ratio   | Benchmark (Parameter)                         |
+|----------|----------------------|---------------------|---------|-----------------------------------------------|
+|          | failed               | failed              | n/a     | time_AAA_failure                              |
+|          | n/a                  | n/a                 | n/a     | time_AAA_skip                                 |
+|          | 1.00±1s              | 3.00±1s             | ~3.00   | time_ci_big                                   |
+|          | 1.00s                | 1.00s               | 1.00    | time_other.time_parameterized(1)              |
+|          | 2.00s                | 4.00s               | 2.00    | time_other.time_parameterized(2)              |
+|          | 83.6μs               | 55.4μs              | 0.66    | time_quantity.time_quantity_init_scalar       |
+|          | 282μs                | 147μs               | 0.52    | time_quantity.time_quantity_scalar_conversion |
+|          | 42                   | 42                  | 1.00    | time_secondary.track_value                    |
+|          | 5.73m                | 5.73m               | 1.00    | time_units.mem_unit                           |
+|          | 1.64ms               | 1.53ms              | 0.93    | time_units.time_unit_compose                  |
+|          | 11.9μs               | 13.1μs              | 1.10    | time_units.time_very_simple_unit_parse        |
 
 Benchmarks that have got worse:
 
-       before           after         ratio
-     [22b920c6]       [fcf8c079]
-!             n/a           failed      n/a  params_examples.ParamSuite.track_value
-+         1.00±0s          3.00±0s     3.00  time_ci_small
-!           454μs           failed      n/a  time_coordinates.time_latitude
-!           3.00s           failed      n/a  time_other.time_parameterized(3)
-+          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion
-+           934μs            108ms   115.90  time_quantity.time_quantity_init_array
-+          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
-+           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
-+           372μs           11.5ms    30.81  time_units.time_unit_parse
-+           1.00s            3.00s     3.00  time_with_version_match
-+           1.00s            3.00s     3.00  time_with_version_mismatch_bench
+| Change   | Before [22b920c6]    | After [fcf8c079]    | Ratio   | Benchmark (Parameter)                        |
+|----------|----------------------|---------------------|---------|----------------------------------------------|
+| !        | n/a                  | failed              | n/a     | params_examples.ParamSuite.track_value       |
+| +        | 1.00±0s              | 3.00±0s             | 3.00    | time_ci_small                                |
+| !        | 454μs                | failed              | n/a     | time_coordinates.time_latitude               |
+| !        | 3.00s                | failed              | n/a     | time_other.time_parameterized(3)             |
+| +        | 1.75ms               | 153ms               | 87.28   | time_quantity.time_quantity_array_conversion |
+| +        | 934μs                | 108ms               | 115.90  | time_quantity.time_quantity_init_array       |
+| +        | 1.31ms               | 7.75ms              | 5.91    | time_quantity.time_quantity_ufunc_sin        |
+| +        | 125μs                | 3.81ms              | 30.42   | time_units.time_simple_unit_parse            |
+| +        | 372μs                | 11.5ms              | 30.81   | time_units.time_unit_parse                   |
+| +        | 1.00s                | 3.00s               | 3.00    | time_with_version_match                      |
+| +        | 1.00s                | 3.00s               | 3.00    | time_with_version_mismatch_bench             |
 
 Benchmarks that are not comparable:
 
-       before           after         ratio
-     [22b920c6]       [fcf8c079]
-x           1.00s            3.00s     3.00  time_with_version_mismatch_other
-"""
+| Change   | Before [22b920c6]    | After [fcf8c079]    |   Ratio | Benchmark (Parameter)            |
+|----------|----------------------|---------------------|---------|----------------------------------|
+| x        | 1.00s                | 3.00s               |       3 | time_with_version_mismatch_other |
+"""  # noqa: E501 line too long
 
 REFERENCE_ONLY_CHANGED = """
-       before           after         ratio
-     [22b920c6]       [fcf8c079]
-     <name1>          <name2>
-!             n/a           failed      n/a  params_examples.ParamSuite.track_value
-!           454μs           failed      n/a  time_coordinates.time_latitude
-!           3.00s           failed      n/a  time_other.time_parameterized(3)
-+           934μs            108ms   115.90  time_quantity.time_quantity_init_array
-+          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion
-+           372μs           11.5ms    30.81  time_units.time_unit_parse
-+           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
-+          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
-+         1.00±0s          3.00±0s     3.00  time_ci_small
-+           1.00s            3.00s     3.00  time_with_version_match
-+           1.00s            3.00s     3.00  time_with_version_mismatch_bench
--          69.1μs           18.3μs     0.27  time_units.time_unit_to
-"""
+| Change   | Before [22b920c6] <name1>   | After [fcf8c079] <name2>   | Ratio   | Benchmark (Parameter)                        |
+|----------|-----------------------------|----------------------------|---------|----------------------------------------------|
+| !        | n/a                         | failed                     | n/a     | params_examples.ParamSuite.track_value       |
+| !        | 454μs                       | failed                     | n/a     | time_coordinates.time_latitude               |
+| !        | 3.00s                       | failed                     | n/a     | time_other.time_parameterized(3)             |
+| +        | 1.75ms                      | 153ms                      | 87.28   | time_quantity.time_quantity_array_conversion |
+| +        | 1.31ms                      | 7.75ms                     | 5.91    | time_quantity.time_quantity_ufunc_sin        |
+| +        | 372μs                       | 11.5ms                     | 30.81   | time_units.time_unit_parse                   |
+| +        | 125μs                       | 3.81ms                     | 30.42   | time_units.time_simple_unit_parse            |
+| +        | 1.00±0s                     | 3.00±0s                    | 3.00    | time_ci_small                                |
+| +        | 1.00s                       | 3.00s                      | 3.00    | time_with_version_match                      |
+| +        | 1.00s                       | 3.00s                      | 3.00    | time_with_version_mismatch_bench             |
+| +        | 934μs                       | 108ms                      | 115.90  | time_quantity.time_quantity_init_array       |
+| -        | 69.1μs                      | 18.3μs                     | 0.27    | time_units.time_unit_to                      |
+"""  # noqa: E501 line too long
 
 REFERENCE_ONLY_CHANGED_MULTIENV = """
-       before           after         ratio
-     [22b920c6]       [fcf8c079]
-!             n/a           failed      n/a  params_examples.ParamSuite.track_value [cheetah/py2.7-numpy1.8]
-!           454μs           failed      n/a  time_coordinates.time_latitude [cheetah/py2.7-numpy1.8]
-!           3.00s           failed      n/a  time_other.time_parameterized(3) [cheetah/py2.7-numpy1.8]
-+           934μs            108ms   115.90  time_quantity.time_quantity_init_array [cheetah/py2.7-numpy1.8]
-+          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion [cheetah/py2.7-numpy1.8]
-+           372μs           11.5ms    30.81  time_units.time_unit_parse [cheetah/py2.7-numpy1.8]
-+           125μs           3.81ms    30.42  time_units.time_simple_unit_parse [cheetah/py2.7-numpy1.8]
-+          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin [cheetah/py2.7-numpy1.8]
-+         1.00±0s          3.00±0s     3.00  time_ci_small [cheetah/py2.7-numpy1.8]
-+           1.00s            3.00s     3.00  time_with_version_match [cheetah/py2.7-numpy1.8]
-+           1.00s            3.00s     3.00  time_with_version_mismatch_bench [cheetah/py2.7-numpy1.8]
--          69.1μs           18.3μs     0.27  time_units.time_unit_to [cheetah/py2.7-numpy1.8]
+| Change   | Before [22b920c6]    | After [fcf8c079]    | Ratio   | Benchmark (Parameter)                                                 |
+|----------|----------------------|---------------------|---------|-----------------------------------------------------------------------|
+| !        | n/a                  | failed              | n/a     | params_examples.ParamSuite.track_value [cheetah/py2.7-numpy1.8]       |
+| !        | 454μs                | failed              | n/a     | time_coordinates.time_latitude [cheetah/py2.7-numpy1.8]               |
+| !        | 3.00s                | failed              | n/a     | time_other.time_parameterized(3) [cheetah/py2.7-numpy1.8]             |
+| +        | 1.75ms               | 153ms               | 87.28   | time_quantity.time_quantity_array_conversion [cheetah/py2.7-numpy1.8] |
+| +        | 1.31ms               | 7.75ms              | 5.91    | time_quantity.time_quantity_ufunc_sin [cheetah/py2.7-numpy1.8]        |
+| +        | 372μs                | 11.5ms              | 30.81   | time_units.time_unit_parse [cheetah/py2.7-numpy1.8]                   |
+| +        | 125μs                | 3.81ms              | 30.42   | time_units.time_simple_unit_parse [cheetah/py2.7-numpy1.8]            |
+| +        | 1.00±0s              | 3.00±0s             | 3.00    | time_ci_small [cheetah/py2.7-numpy1.8]                                |
+| +        | 1.00s                | 3.00s               | 3.00    | time_with_version_match [cheetah/py2.7-numpy1.8]                      |
+| +        | 1.00s                | 3.00s               | 3.00    | time_with_version_mismatch_bench [cheetah/py2.7-numpy1.8]             |
+| +        | 934μs                | 108ms               | 115.90  | time_quantity.time_quantity_init_array [cheetah/py2.7-numpy1.8]       |
+| -        | 69.1μs               | 18.3μs              | 0.27    | time_units.time_unit_to [cheetah/py2.7-numpy1.8]                      |
 """  # noqa: E501 line too long
 
 REFERENCE_ONLY_CHANGED_NOSTATS = """
-       before           after         ratio
-     [22b920c6]       [fcf8c079]
-!             n/a           failed      n/a  params_examples.ParamSuite.track_value
-!           454μs           failed      n/a  time_coordinates.time_latitude
-!           3.00s           failed      n/a  time_other.time_parameterized(3)
-+           934μs            108ms   115.90  time_quantity.time_quantity_init_array
-+          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion
-+           372μs           11.5ms    30.81  time_units.time_unit_parse
-+           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
-+          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
-+         1.00±1s          3.00±1s     3.00  time_ci_big
-+         1.00±0s          3.00±0s     3.00  time_ci_small
-+           1.00s            3.00s     3.00  time_with_version_match
-+           1.00s            3.00s     3.00  time_with_version_mismatch_bench
--          69.1μs           18.3μs     0.27  time_units.time_unit_to
-"""
+| Change   | Before [22b920c6]    | After [fcf8c079]    | Ratio   | Benchmark (Parameter)                        |
+|----------|----------------------|---------------------|---------|----------------------------------------------|
+| !        | n/a                  | failed              | n/a     | params_examples.ParamSuite.track_value       |
+| !        | 454μs                | failed              | n/a     | time_coordinates.time_latitude               |
+| !        | 3.00s                | failed              | n/a     | time_other.time_parameterized(3)             |
+| +        | 1.75ms               | 153ms               | 87.28   | time_quantity.time_quantity_array_conversion |
+| +        | 1.31ms               | 7.75ms              | 5.91    | time_quantity.time_quantity_ufunc_sin        |
+| +        | 372μs                | 11.5ms              | 30.81   | time_units.time_unit_parse                   |
+| +        | 125μs                | 3.81ms              | 30.42   | time_units.time_simple_unit_parse            |
+| +        | 1.00±1s              | 3.00±1s             | 3.00    | time_ci_big                                  |
+| +        | 1.00±0s              | 3.00±0s             | 3.00    | time_ci_small                                |
+| +        | 1.00s                | 3.00s               | 3.00    | time_with_version_match                      |
+| +        | 1.00s                | 3.00s               | 3.00    | time_with_version_mismatch_bench             |
+| +        | 934μs                | 108ms               | 115.90  | time_quantity.time_quantity_init_array       |
+| -        | 69.1μs               | 18.3μs              | 0.27    | time_units.time_unit_to                      |
+"""  # noqa: E501 line too long
 
 
 def test_compare(capsys, tmpdir, example_results):

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -22,32 +22,32 @@ MACHINE_FILE = abspath(join(dirname(__file__), 'asv-machine.json'))
 REFERENCE = """
 All benchmarks:
 
-       before           after         ratio
-     [22b920c6]       [fcf8c079]
-!             n/a           failed      n/a  params_examples.ParamSuite.track_value
-           failed           failed      n/a  time_AAA_failure
-              n/a              n/a      n/a  time_AAA_skip
-          1.00±1s          3.00±1s    ~3.00  time_ci_big
-+         1.00±0s          3.00±0s     3.00  time_ci_small
-!           454μs           failed      n/a  time_coordinates.time_latitude
-            1.00s            1.00s     1.00  time_other.time_parameterized(1)
-            2.00s            4.00s     2.00  time_other.time_parameterized(2)
-!           3.00s           failed      n/a  time_other.time_parameterized(3)
-+          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion
-+           934μs            108ms   115.90  time_quantity.time_quantity_init_array
-           83.6μs           55.4μs     0.66  time_quantity.time_quantity_init_scalar
-            282μs            147μs     0.52  time_quantity.time_quantity_scalar_conversion
-+          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
-               42               42     1.00  time_secondary.track_value
-            5.73m            5.73m     1.00  time_units.mem_unit
-+           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
-           1.64ms           1.53ms     0.93  time_units.time_unit_compose
-+           372μs           11.5ms    30.81  time_units.time_unit_parse
--          69.1μs           18.3μs     0.27  time_units.time_unit_to
-           11.9μs           13.1μs     1.10  time_units.time_very_simple_unit_parse
-+           1.00s            3.00s     3.00  time_with_version_match
-+           1.00s            3.00s     3.00  time_with_version_mismatch_bench
-x           1.00s            3.00s     3.00  time_with_version_mismatch_other
+| Change   | Before [22b920c6]    | After [fcf8c079]    | Ratio   | Benchmark (Parameter)                         |
+|----------|----------------------|---------------------|---------|-----------------------------------------------|
+| !        | n/a                  | failed              | n/a     | params_examples.ParamSuite.track_value        |
+|          | failed               | failed              | n/a     | time_AAA_failure                              |
+|          | n/a                  | n/a                 | n/a     | time_AAA_skip                                 |
+|          | 1.00±1s              | 3.00±1s             | ~3.00   | time_ci_big                                   |
+| +        | 1.00±0s              | 3.00±0s             | 3.00    | time_ci_small                                 |
+| !        | 454μs                | failed              | n/a     | time_coordinates.time_latitude                |
+|          | 1.00s                | 1.00s               | 1.00    | time_other.time_parameterized(1)              |
+|          | 2.00s                | 4.00s               | 2.00    | time_other.time_parameterized(2)              |
+| !        | 3.00s                | failed              | n/a     | time_other.time_parameterized(3)              |
+| +        | 1.75ms               | 153ms               | 87.28   | time_quantity.time_quantity_array_conversion  |
+| +        | 934μs                | 108ms               | 115.90  | time_quantity.time_quantity_init_array        |
+|          | 83.6μs               | 55.4μs              | 0.66    | time_quantity.time_quantity_init_scalar       |
+|          | 282μs                | 147μs               | 0.52    | time_quantity.time_quantity_scalar_conversion |
+| +        | 1.31ms               | 7.75ms              | 5.91    | time_quantity.time_quantity_ufunc_sin         |
+|          | 42                   | 42                  | 1.00    | time_secondary.track_value                    |
+|          | 5.73m                | 5.73m               | 1.00    | time_units.mem_unit                           |
+| +        | 125μs                | 3.81ms              | 30.42   | time_units.time_simple_unit_parse             |
+|          | 1.64ms               | 1.53ms              | 0.93    | time_units.time_unit_compose                  |
+| +        | 372μs                | 11.5ms              | 30.81   | time_units.time_unit_parse                    |
+| -        | 69.1μs               | 18.3μs              | 0.27    | time_units.time_unit_to                       |
+|          | 11.9μs               | 13.1μs              | 1.10    | time_units.time_very_simple_unit_parse        |
+| +        | 1.00s                | 3.00s               | 3.00    | time_with_version_match                       |
+| +        | 1.00s                | 3.00s               | 3.00    | time_with_version_mismatch_bench              |
+| x        | 1.00s                | 3.00s               | 3.00    | time_with_version_mismatch_other              |
 """
 
 REFERENCE_SPLIT = """

--- a/test/test_continuous.py
+++ b/test/test_continuous.py
@@ -30,8 +30,9 @@ def test_continuous(capfd, basic_conf_2):
     text, err = capfd.readouterr()
     assert "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY" in text
     assert "PERFORMANCE INCREASED" in text or "PERFORMANCE DECREASED" in text
-    assert ("+               1                6     6.00  params_examples.track_find_test(2)"
-            in text)
+    expected_string = "| +        |                            1 |                           6 |       6 | params_examples.track_find_test(2) [orangutan/virtualenv-py3.11-asv_dummy_test_package_1-asv_dummy_test_package_20.3.9] |"
+    assert expected_string in text
+
     assert "params_examples.ClassOne" in text
 
     # Check rounds were interleaved (timing benchmark was run twice)

--- a/test/test_continuous.py
+++ b/test/test_continuous.py
@@ -30,7 +30,8 @@ def test_continuous(capfd, basic_conf_2):
     text, err = capfd.readouterr()
     assert "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY" in text
     assert "PERFORMANCE INCREASED" in text or "PERFORMANCE DECREASED" in text
-    expected_string = "| +        |                            1 |                           6 |       6 | params_examples.track_find_test(2) [orangutan/virtualenv-py3.11-asv_dummy_test_package_1-asv_dummy_test_package_20.3.9] |"
+    # Check output, but not the whole row
+    expected_string = "params_examples.track_find_test(2) [orangutan/virtualenv-py"  # noqa: E501 line too long
     assert expected_string in text
 
     assert "params_examples.ClassOne" in text

--- a/test/test_continuous.py
+++ b/test/test_continuous.py
@@ -31,8 +31,8 @@ def test_continuous(capfd, basic_conf_2):
     assert "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY" in text
     assert "PERFORMANCE INCREASED" in text or "PERFORMANCE DECREASED" in text
     # Check output, but not the whole row
-    expected_string = "params_examples.track_find_test(2) [orangutan/virtualenv-py"  # noqa: E501 line too long
-    assert expected_string in text
+    pattern = r"params_examples\.track_find_test\(2\) \[orangutan\/\w+-py"
+    assert re.search(pattern, text) is not None
 
     assert "params_examples.ClassOne" in text
 


### PR DESCRIPTION
Closes #1210. I think this would be a reasonable change throughout, for all the outputs. None of the current outputs are machine readable.