### PR TITLE
ENH: Add cleaner matches in conda/mamba

### DIFF
--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -102,34 +102,14 @@ class Conda(environment.Environment):
     @classmethod
     def _matches(cls, python):
         if not re.match(r'^[0-9].*$', python):
-            # The python name should be a version number
-            return False
-
-        try:
-            conda = _find_conda()
-        except IOError:
             return False
         else:
-            # This directory never gets created, since we're just
-            # doing a dry run below.  All it needs to be is something
-            # that doesn't already exist.
-            path = os.path.join(tempfile.gettempdir(), 'check')
-
-            # Check that the version number is valid
+            conda = _find_conda()
             try:
                 with _conda_lock():
-                    util.check_call([
-                        conda,
-                        'create',
-                        '--yes',
-                        '-p',
-                        path,
-                        'python={0}'.format(python),
-                        '--dry-run'], display_error=False, dots=False)
+                    return util.search_channels(conda, "python", python)
             except util.ProcessError:
                 return False
-            else:
-                return True
 
     def _setup(self):
         log.info("Creating conda environment for {0}".format(self.name))

--- a/asv/util.py
+++ b/asv/util.py
@@ -1389,3 +1389,20 @@ def git_default_branch():
     except ProcessError:
         default_branch = 'master'
     return default_branch
+
+
+def search_channels(cli_path, pkg, version):
+    try:
+        result = subprocess.run([cli_path, "search",
+                                 f"{pkg}=={version}"],
+                                capture_output=True,
+                                text=True,
+                                check=False)
+    except subprocess.CalledProcessError as e:
+        print(f"Error searching for {pkg} {version}, got:\n {e}",
+              file=sys.stderr)
+        return False
+    if f"No match found for: {pkg}=={version}." in result.stdout:
+        return False
+    # Worked!
+    return True


### PR DESCRIPTION
Testing by creating an environment is much slower than simply searching. This PR updates the `match` mechanism and the utility function might be useful elsewhere as well.