### PR TITLE
BUG: Use `colorama` on windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - conda update conda -y
   - conda install -q --yes python=%PYTHON_VERSION% conda pip pytest pytest-xdist pytest-timeout filelock selenium conda-build bzip2 pympler
   - python -m pip install -U pip
-  - python -m pip install pytest-rerunfailures json5 pympler tabulate
+  - python -m pip install pytest-rerunfailures json5 pympler tabulate colorama
 
   # Check that we have the expected version of Python
   - python --version

--- a/asv/console.py
+++ b/asv/console.py
@@ -200,6 +200,13 @@ class Log:
         self._logger = logging.getLogger()
         self._needs_newline = False
         self._last_dot = time.time()
+        if sys.platform in {'win32', 'cli'}:
+            try:
+                import colorama
+                colorama.init()
+                self._colorama = True
+            except Exception as exc:
+                print(f"On Windows, colorama is suggested, but got {exc}")
 
     def _stream_formatter(self, record):
         '''

--- a/asv/machine.py
+++ b/asv/machine.py
@@ -152,7 +152,7 @@ class Machine:
 
     @staticmethod
     def generate_machine_file(use_defaults=False):
-        if not sys.stdout.isatty() and not use_defaults:
+        if not sys.stdout.isatty() and not use_defaults and not log._colorama:
             raise util.UserError(
                 "Run asv at the console the first time to generate "
                 "one, or run `asv machine --yes`.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,10 @@ dynamic = [
     "version",
 ]
 dependencies = [
-  "colorama; os_name == 'nt'",
+    "json5",
+    "tabulate",
+    "colorama; os_name == 'nt'",
+    "pympler; platform_python_implementation != \"PyPy\"",
 ]
 
 [project.urls]
@@ -49,8 +52,6 @@ test = [
     "selenium",
     "pytest-rerunfailures",
     "python-hglib",
-    "json5",
-    "pympler; platform_python_implementation != \"PyPy\"",
 ]
 doc = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ classifiers = [
 dynamic = [
     "version",
 ]
+dependencies = [
+  "colorama; os_name == 'nt'",
+]
 
 [project.urls]
 "Source Code" = "https://github.com/airspeed-velocity/asv"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ setuptools
 wheel
 sphinx
 sphinx_bootstrap_theme
+colorama; os_name == 'nt'
 # Optional requirements follow:
 numpy
 scipy; platform_python_implementation != "PyPy"


### PR DESCRIPTION
The documentation mentions using `colorama` on Windows. This closes #546 , and essentially tracks what `ipython` does in https://github.com/ipython/ipython/commit/0a16e9d0e624a99578587eaa288ab1b6a3836a98. It seems reasonable to put it in the `Log` class constructor, since that's a singleton in the code.