### PR TITLE
ENH: Optionally add some kind of pickle replacement

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -65,8 +65,7 @@ from collections import Counter
 from time import process_time
 
 try:
-    import dill as pickle
-    pickle.settings['recurse'] = True
+    import cloudpickle as pickle
 except ImportError:
     import pickle
 

--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -47,7 +47,6 @@ import inspect
 import itertools
 import json
 import os
-import pickle
 import re
 import subprocess
 import textwrap
@@ -64,6 +63,12 @@ from hashlib import sha256
 from importlib import import_module
 from collections import Counter
 from time import process_time
+
+try:
+    import dill as pickle
+    pickle.settings['recurse'] = True
+except ImportError:
+    import pickle
 
 wall_timer = timeit.default_timer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ Documentation = "https://asv.readthedocs.io/en/stable/"
 asv = "asv.__main__:main"
 
 [project.optional-dependencies]
+perf = [
+    "dill",
+]
 test = [
     "pytest",
     "pytest-xdist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ asv = "asv.__main__:main"
 
 [project.optional-dependencies]
 perf = [
-    "dill",
+    "cloudpickle",
 ]
 test = [
     "pytest",

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -8,8 +8,7 @@ import traceback
 import datetime
 
 try:
-    import dill as pickle
-    pickle.settings['recurse'] = True
+    import cloudpickle as pickle
 except ImportError:
     import pickle
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -2,11 +2,16 @@
 import os
 import sys
 import shutil
-import pickle
 import multiprocessing
 import threading
 import traceback
 import datetime
+
+try:
+    import dill as pickle
+    pickle.settings['recurse'] = True
+except ImportError:
+    import pickle
 
 import pytest
 


### PR DESCRIPTION
Closes https://github.com/airspeed-velocity/asv/issues/347. I noticed this came up once before in a PR, #351, and the motivation wasn't discussed (its in the issue, essentially functions can be stored with `dill` over `pickle`).

In terms of `cloudpickle` (used by `dask`, discussed on the older PR), it seems like it has a slightly different use-case and this [StackOverflow post by the author](https://stackoverflow.com/a/32925601/1895378) seems to suggest the differences are minor if any, and `cloudpickle` [strongly discourages](https://pypi.org/project/cloudpickle/) usage for long term storage.

`dill` [doesn't support](https://dill.readthedocs.io/en/latest/index.html) the types `frame`, `generator`, `traceback`.

This is actually a problem, since we pickle `benchmark` objects which might as well have generators. Will switch to `cloudpickle`.