### PR TITLE
BLD: Switch to testing PyPy 3.9 instead of 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.10", "pypy-3.7", "pypy-3.8"]
+        python-version: ["3.7", "3.10", "pypy-3.8", "pypy-3.9"]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Addresses https://github.com/airspeed-velocity/asv/pull/1253#issuecomment-1518976791. Closes #1264.