### PR TITLE
MAINT: Standardize styles with black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ repos:
         exclude: ^(test/example_results/cheetah)
     -   id: check-yaml
     -   id: check-added-large-files
+- repo: https://github.com/psf/black
+  rev: '23.3.0'
+  hooks:
+    - id: black
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/asv/__init__.py
+++ b/asv/__init__.py
@@ -3,4 +3,4 @@
 from asv._version import version as __version__
 from asv import plugin_manager  # noqa F401 Needed to load the plugins
 
-__all__ = '__version__',
+__all__ = ("__version__",)

--- a/asv/__main__.py
+++ b/asv/__main__.py
@@ -2,5 +2,5 @@
 
 from .main import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -16,6 +16,7 @@ class Benchmarks(dict):
     """
     Manages and runs the set of benchmarks in the project.
     """
+
     api_version = 2
 
     def __init__(self, conf, benchmarks, regex=None):
@@ -50,19 +51,18 @@ class Benchmarks(dict):
         self._all_benchmarks = {}
         self._benchmark_selection = {}
         for benchmark in benchmarks:
-            self._all_benchmarks[benchmark['name']] = benchmark
-            if benchmark['params']:
-                self._benchmark_selection[benchmark['name']] = []
-                for idx, param_set in enumerate(
-                        itertools.product(*benchmark['params'])):
+            self._all_benchmarks[benchmark["name"]] = benchmark
+            if benchmark["params"]:
+                self._benchmark_selection[benchmark["name"]] = []
+                for idx, param_set in enumerate(itertools.product(*benchmark["params"])):
                     name = f"{benchmark['name']}({', '.join(param_set)})"
                     if not regex or any(re.search(reg, name) for reg in regex):
-                        self[benchmark['name']] = benchmark
-                        self._benchmark_selection[benchmark['name']].append(idx)
+                        self[benchmark["name"]] = benchmark
+                        self._benchmark_selection[benchmark["name"]].append(idx)
             else:
-                self._benchmark_selection[benchmark['name']] = None
-                if not regex or any(re.search(reg, benchmark['name']) for reg in regex):
-                    self[benchmark['name']] = benchmark
+                self._benchmark_selection[benchmark["name"]] = None
+                if not regex or any(re.search(reg, benchmark["name"]) for reg in regex):
+                    self[benchmark["name"]] = benchmark
 
     @property
     def benchmark_selection(self):
@@ -100,8 +100,7 @@ class Benchmarks(dict):
         return benchmarks
 
     @classmethod
-    def discover(cls, conf, repo, environments, commit_hash, regex=None,
-                 check=False):
+    def discover(cls, conf, repo, environments, commit_hash, regex=None, check=False):
         """
         Discover benchmarks in the given `benchmark_dir`.
 
@@ -186,17 +185,21 @@ class Benchmarks(dict):
                     env_vars = dict(os.environ)
                     env_vars.update(env.env_vars)
 
-                    result_file = os.path.join(result_dir, 'result.json')
+                    result_file = os.path.join(result_dir, "result.json")
                     env.run(
-                        [runner.BENCHMARK_RUN_SCRIPT, 'discover',
-                         os.path.abspath(root),
-                         os.path.abspath(result_file)],
+                        [
+                            runner.BENCHMARK_RUN_SCRIPT,
+                            "discover",
+                            os.path.abspath(root),
+                            os.path.abspath(result_file),
+                        ],
                         cwd=result_dir,
                         env=env_vars,
-                        dots=False)
+                        dots=False,
+                    )
 
                     try:
-                        with open(result_file, 'r') as fp:
+                        with open(result_file, "r") as fp:
                             benchmarks = json.load(fp)
                     except (IOError, ValueError):
                         log.error("Invalid discovery output")
@@ -219,14 +222,14 @@ class Benchmarks(dict):
                 result_dir = tempfile.mkdtemp()
                 try:
                     out, err, retcode = env.run(
-                        [runner.BENCHMARK_RUN_SCRIPT, 'check',
-                         os.path.abspath(root)],
+                        [runner.BENCHMARK_RUN_SCRIPT, "check", os.path.abspath(root)],
                         cwd=result_dir,
                         dots=False,
                         env=env_vars,
                         valid_return_codes=None,
                         return_stderr=True,
-                        redirect_stderr=True)
+                        redirect_stderr=True,
+                    )
                 finally:
                     util.long_path_rmtree(result_dir)
 
@@ -256,14 +259,13 @@ class Benchmarks(dict):
             A .py file and directory with the same name (excluding the
             extension) were found.
         """
-        if os.path.basename(root) == '__pycache__':
+        if os.path.basename(root) == "__pycache__":
             return
 
-        if not os.path.isfile(os.path.join(root, '__init__.py')):
+        if not os.path.isfile(os.path.join(root, "__init__.py")):
             # Not a Python package directory
             if require_init_py:
-                raise util.UserError(
-                    f"No __init__.py file in '{root}'")
+                raise util.UserError(f"No __init__.py file in '{root}'")
             else:
                 return
 
@@ -275,7 +277,7 @@ class Benchmarks(dict):
             path = os.path.join(root, filename)
             if os.path.isfile(path):
                 filename, ext = os.path.splitext(filename)
-                if ext == '.py':
+                if ext == ".py":
                     found.add(filename)
 
         for dirname in os.listdir(root):
@@ -284,7 +286,8 @@ class Benchmarks(dict):
                 if dirname in found:
                     raise util.UserError(
                         "Found a directory and python file with same name in "
-                        "benchmark tree: '{0}'".format(path))
+                        "benchmark tree: '{0}'".format(path)
+                    )
                 cls.check_tree(path, require_init_py=False)
 
     @classmethod
@@ -332,5 +335,7 @@ class Benchmarks(dict):
             if "asv update" in str(err):
                 # Don't give conflicting instructions
                 raise
-            raise util.UserError("{}\nUse `asv run --bench just-discover` to "
-                                 "regenerate benchmarks.json".format(str(err)))
+            raise util.UserError(
+                "{}\nUse `asv run --bench just-discover` to "
+                "regenerate benchmarks.json".format(str(err))
+            )

--- a/asv/build_cache.py
+++ b/asv/build_cache.py
@@ -31,8 +31,8 @@ class BuildCache:
 
     def __init__(self, conf, root):
         self._root = root
-        self._path = os.path.join(root, 'asv-build-cache')
-        self._cache_size = getattr(conf, 'build_cache_size', 2)
+        self._path = os.path.join(root, "asv-build-cache")
+        self._cache_size = getattr(conf, "build_cache_size", 2)
 
     def _get_cache_dir(self, commit_hash):
         """
@@ -79,14 +79,12 @@ class BuildCache:
 
         # Then remove old items
         names = self._get_cache_contents()
-        for name in names[self._cache_size:]:
+        for name in names[self._cache_size :]:
             self._remove_cache_dir(name)
 
     def get_cache_dir(self, commit_hash):
         path, stamp = self._get_cache_dir(commit_hash)
-        if (os.path.isdir(path) and
-                os.path.isfile(stamp) and
-                os.listdir(path)):
+        if os.path.isdir(path) and os.path.isfile(stamp) and os.listdir(path):
             return path
 
         return None
@@ -103,7 +101,7 @@ class BuildCache:
 
         if os.path.isdir(path) and os.listdir(path):
             # Finalize
-            with open(stamp, 'wb'):
+            with open(stamp, "wb"):
                 pass
 
         # Cleanup build cache

--- a/asv/commands/__init__.py
+++ b/asv/commands/__init__.py
@@ -9,20 +9,20 @@ from . import common_args
 
 # This list is ordered in order of average workflow
 command_order = [
-    'Quickstart',
-    'Machine',
-    'Setup',
-    'Run',
-    'Dev',
-    'Continuous',
-    'Find',
-    'Rm',
-    'Publish',
-    'Preview',
-    'Profile',
-    'Update',
-    'Show',
-    'Compare'
+    "Quickstart",
+    "Machine",
+    "Setup",
+    "Run",
+    "Dev",
+    "Continuous",
+    "Find",
+    "Rm",
+    "Publish",
+    "Preview",
+    "Profile",
+    "Update",
+    "Show",
+    "Compare",
 ]
 
 
@@ -42,6 +42,7 @@ class Command(abc.ABC):
     @classmethod
     def run_from_args(cls, args):
         from ..plugin_manager import plugin_manager
+
         conf = config.Config.load(args.config)
         for plugin in conf.plugins:
             plugin_manager.import_plugin(plugin)
@@ -64,22 +65,20 @@ def make_argparser():
     Most of the real work is handled by the subcommands in the
     commands subpackage.
     """
+
     def help(args):
         parser.print_help()
         sys.exit(0)
 
     parser = argparse.ArgumentParser(
-        "asv",
-        description="Airspeed Velocity: Simple benchmarking tool for Python")
+        "asv", description="Airspeed Velocity: Simple benchmarking tool for Python"
+    )
 
     common_args.add_global_arguments(parser, suppress_defaults=False)
 
-    subparsers = parser.add_subparsers(
-        title='subcommands',
-        description='valid subcommands')
+    subparsers = parser.add_subparsers(title="subcommands", description="valid subcommands")
 
-    help_parser = subparsers.add_parser(
-        "help", help="Display usage information")
+    help_parser = subparsers.add_parser("help", help="Display usage information")
     help_parser.set_defaults(func=help)
 
     commands = dict((x.__name__, x) for x in util.iter_subclasses(Command))
@@ -103,12 +102,12 @@ def _make_docstring():
 
     for p in subparsers.choices.values():
         lines.append(f".. _cmd-{p.prog.replace(' ', '-')}:")
-        lines.append('')
+        lines.append("")
         lines.append(p.prog)
-        lines.append('-' * len(p.prog))
-        lines.append('::')
-        lines.append('')
-        lines.extend('   ' + x for x in p.format_help().splitlines())
-        lines.append('')
+        lines.append("-" * len(p.prog))
+        lines.append("::")
+        lines.append("")
+        lines.extend("   " + x for x in p.format_help().splitlines())
+        lines.append("")
 
-    return '\n'.join(lines)
+    return "\n".join(lines)

--- a/asv/commands/check.py
+++ b/asv/commands/check.py
@@ -1,4 +1,3 @@
-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from ..benchmarks import Benchmarks
@@ -11,10 +10,12 @@ class Check(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "check", help="Import and check benchmark suite, but do not run benchmarks",
+            "check",
+            help="Import and check benchmark suite, but do not run benchmarks",
             description="""
                 This imports and checks basic validity of the benchmark suite, but
-                does not run the benchmark target code""")
+                does not run the benchmark target code""",
+        )
 
         common_args.add_environment(parser, default_same=False)
         parser.set_defaults(func=cls.run_from_args)

--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -19,62 +19,89 @@ def add_global_arguments(parser, suppress_defaults=True):
         suppressor = dict()
 
     parser.add_argument(
-        "--verbose", "-v", action="store_true",
-        help="Increase verbosity",
-        **suppressor)
+        "--verbose", "-v", action="store_true", help="Increase verbosity", **suppressor
+    )
 
     parser.add_argument(
         "--config",
         help="Benchmark configuration file",
-        default=(argparse.SUPPRESS if suppress_defaults else 'asv.conf.json'))
+        default=(argparse.SUPPRESS if suppress_defaults else "asv.conf.json"),
+    )
 
     parser.add_argument(
-        "--version", action="version", version="%(prog)s " + __version__,
+        "--version",
+        action="version",
+        version="%(prog)s " + __version__,
         help="Print program version",
-        **suppressor)
+        **suppressor,
+    )
 
 
-def add_compare(parser, only_changed_default=False, sort_default='name'):
+def add_compare(parser, only_changed_default=False, sort_default="name"):
     parser.add_argument(
-        '--factor', "-f", type=float, default=1.1,
+        "--factor",
+        "-f",
+        type=float,
+        default=1.1,
         help="""The factor above or below which a result is considered
         problematic.  For example, with a factor of 1.1 (the default
         value), if a benchmark gets 10%% slower or faster, it will
-        be displayed in the results list.""")
+        be displayed in the results list.""",
+    )
 
     parser.add_argument(
-        '--no-stats', action="store_false", dest="use_stats", default=True,
+        "--no-stats",
+        action="store_false",
+        dest="use_stats",
+        default=True,
         help="""Do not use result statistics in comparisons, only `factor`
-        and the median result.""")
+        and the median result.""",
+    )
 
     parser.add_argument(
-        '--split', '-s', action='store_true',
+        "--split",
+        "-s",
+        action="store_true",
         help="""Split the output into a table of benchmarks that have
-        improved, stayed the same, and gotten worse.""")
+        improved, stayed the same, and gotten worse.""",
+    )
 
     parser.add_argument(
-        '--only-changed', action='store_true', default=only_changed_default,
-        help="""Whether to show only changed results.""")
+        "--only-changed",
+        action="store_true",
+        default=only_changed_default,
+        help="""Whether to show only changed results.""",
+    )
 
-    parser.add_argument('--no-only-changed', dest='only_changed', action='store_false')
+    parser.add_argument("--no-only-changed", dest="only_changed", action="store_false")
 
     parser.add_argument(
-        '--sort', action='store', type=str, choices=('name', 'ratio', 'default'),
-        default=sort_default, help="""Sort order""")
+        "--sort",
+        action="store",
+        type=str,
+        choices=("name", "ratio", "default"),
+        default=sort_default,
+        help="""Sort order""",
+    )
 
 
 def add_show_stderr(parser):
     parser.add_argument(
-        "--show-stderr", "-e", action="store_true",
-        help="""Display the stderr output from the benchmarks.""")
+        "--show-stderr",
+        "-e",
+        action="store_true",
+        help="""Display the stderr output from the benchmarks.""",
+    )
 
 
 class DictionaryArgAction(argparse.Action):
     """
     Parses multiple key=value assignments into a dictionary.
     """
-    def __init__(self, option_strings, dest, converters=None, choices=None,
-                 dict_dest=None, **kwargs):
+
+    def __init__(
+        self, option_strings, dest, converters=None, choices=None, dict_dest=None, **kwargs
+    ):
         if converters is None:
             converters = {}
         self.converters = converters
@@ -88,15 +115,13 @@ class DictionaryArgAction(argparse.Action):
             try:
                 key, value = values.split("=", 1)
             except ValueError:
-                raise argparse.ArgumentError(self,
-                                             f"{values!r} is not a key=value assignment")
+                raise argparse.ArgumentError(self, f"{values!r} is not a key=value assignment")
         else:
             key = self.dict_dest
             value = values
 
         if self.__choices is not None and key not in self.__choices:
-            raise argparse.ArgumentError(self,
-                                         f"{key!r} cannot be set")
+            raise argparse.ArgumentError(self, f"{key!r} cannot be set")
 
         dest_key = key
         conv = self.converters.get(key, None)
@@ -107,8 +132,7 @@ class DictionaryArgAction(argparse.Action):
             try:
                 value = conv(value)
             except ValueError as exc:
-                raise argparse.ArgumentError(self,
-                                             f"{key!r}: {exc}")
+                raise argparse.ArgumentError(self, f"{key!r}: {exc}")
 
         # Store value
         result = getattr(namespace, self.dest, None)
@@ -120,9 +144,13 @@ class DictionaryArgAction(argparse.Action):
 
 def add_bench(parser):
     parser.add_argument(
-        "--bench", "-b", type=str, action="append",
+        "--bench",
+        "-b",
+        type=str,
+        action="append",
         help="""Regular expression(s) for benchmark to run.  When not
-        provided, all benchmarks are run.""")
+        provided, all benchmarks are run.""",
+    )
 
     def parse_repeat(value):
         try:
@@ -130,7 +158,7 @@ def add_bench(parser):
         except ValueError:
             pass
 
-        min_repeat, max_repeat, max_time = value.lstrip('(').rstrip(')').split(',')
+        min_repeat, max_repeat, max_time = value.lstrip("(").rstrip(")").split(",")
         value = (int(min_repeat), int(max_repeat), float(max_time))
         return value
 
@@ -158,37 +186,51 @@ def add_bench(parser):
         return affinity_list
 
     converters = {
-        'timeout': float,
-        'version': str,
-        'warmup_time': float,
-        'repeat': parse_repeat,
-        'number': int,
-        'rounds': int,
-        'processes': ('rounds', int),  # backward compatibility
-        'sample_time': float,
-        'cpu_affinity': parse_affinity
+        "timeout": float,
+        "version": str,
+        "warmup_time": float,
+        "repeat": parse_repeat,
+        "number": int,
+        "rounds": int,
+        "processes": ("rounds", int),  # backward compatibility
+        "sample_time": float,
+        "cpu_affinity": parse_affinity,
     }
 
     parser.add_argument(
-        "--attribute", "-a", action=DictionaryArgAction,
-        choices=tuple(converters.keys()), converters=converters,
-        help="""Override a benchmark attribute, e.g. `-a repeat=10`.""")
+        "--attribute",
+        "-a",
+        action=DictionaryArgAction,
+        choices=tuple(converters.keys()),
+        converters=converters,
+        help="""Override a benchmark attribute, e.g. `-a repeat=10`.""",
+    )
 
     parser.add_argument(
-        "--cpu-affinity", action=DictionaryArgAction, dest="attribute",
+        "--cpu-affinity",
+        action=DictionaryArgAction,
+        dest="attribute",
         dict_dest="cpu_affinity",
-        choices=tuple(converters.keys()), converters=converters,
-        help=("Set CPU affinity for running the benchmark, in format: "
-              "0 or 0,1,2 or 0-3. Default: not set"))
+        choices=tuple(converters.keys()),
+        converters=converters,
+        help=(
+            "Set CPU affinity for running the benchmark, in format: "
+            "0 or 0,1,2 or 0-3. Default: not set"
+        ),
+    )
 
 
 def add_machine(parser):
     parser.add_argument(
-        "--machine", "-m", type=str, default=None,
+        "--machine",
+        "-m",
+        type=str,
+        default=None,
         help="""Use the given name to retrieve machine information.
         If not provided, the hostname is used.  If no entry with that
         name is found, and there is only one entry in
-        ~/.asv-machine.json, that one entry will be used.""")
+        ~/.asv-machine.json, that one entry will be used.""",
+    )
 
 
 class PythonArgAction(argparse.Action):
@@ -196,6 +238,7 @@ class PythonArgAction(argparse.Action):
     Backward compatibility --python XYZ argument,
     will be interpreted as --environment :XYZ
     """
+
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         if nargs is not None:
             raise ValueError("nargs not allowed")
@@ -228,17 +271,14 @@ def add_environment(parser, default_same=False):
             configuration file."""
 
     parser.add_argument(
-        "-E", "--environment",
-        dest="env_spec",
-        action="append",
-        default=[],
-        help=help)
+        "-E", "--environment", dest="env_spec", action="append", default=[], help=help
+    )
 
     # The --python argument exists for backward compatibility.  It
     # will just set the part after ':' in the environment spec.
     parser.add_argument(
-        "--python", action=PythonArgAction, metavar="PYTHON",
-        help="Same as --environment=:PYTHON")
+        "--python", action=PythonArgAction, metavar="PYTHON", help="Same as --environment=:PYTHON"
+    )
 
 
 def add_launch_method(parser):
@@ -248,34 +288,55 @@ def add_launch_method(parser):
         action="store",
         choices=("auto", "spawn", "forkserver"),
         default="auto",
-        help="How to launch benchmarks. Choices: auto, spawn, forkserver")
+        help="How to launch benchmarks. Choices: auto, spawn, forkserver",
+    )
 
 
 def add_parallel(parser):
     parser.add_argument(
-        "--parallel", "-j", nargs='?', type=int, default=1, const=-1,
+        "--parallel",
+        "-j",
+        nargs="?",
+        type=int,
+        default=1,
+        const=-1,
         help="""Build (but don't benchmark) in parallel.  The value is
         the number of CPUs to use, or if no number provided, use the
-        number of cores on this machine.""")
+        number of cores on this machine.""",
+    )
 
 
 def add_record_samples(parser, record_default=False):
     grp = parser.add_mutually_exclusive_group()
     grp.add_argument(
-        "--record-samples", action="store_true", dest="record_samples",
-        help=(argparse.SUPPRESS if record_default else
-              """Store raw measurement samples, not only statistics"""),
-        default=record_default)
+        "--record-samples",
+        action="store_true",
+        dest="record_samples",
+        help=(
+            argparse.SUPPRESS
+            if record_default
+            else """Store raw measurement samples, not only statistics"""
+        ),
+        default=record_default,
+    )
     grp.add_argument(
-        "--no-record-samples", action="store_false", dest="record_samples",
-        help=(argparse.SUPPRESS if not record_default else
-              """Do not store raw measurement samples, but only statistics"""),
-        default=record_default)
+        "--no-record-samples",
+        action="store_false",
+        dest="record_samples",
+        help=(
+            argparse.SUPPRESS
+            if not record_default
+            else """Do not store raw measurement samples, but only statistics"""
+        ),
+        default=record_default,
+    )
     parser.add_argument(
-        "--append-samples", action="store_true",
+        "--append-samples",
+        action="store_true",
         help="""Combine new measurement samples with previous results,
         instead of discarding old results. Implies --record-samples.
-        The previous run must also have been run with --record/append-samples.""")
+        The previous run must also have been run with --record/append-samples.""",
+    )
 
 
 def positive_int(string):
@@ -296,7 +357,7 @@ def positive_int_or_inf(string):
     Parse a positive integer argument
     """
     try:
-        if string == 'all':
+        if string == "all":
             return math.inf
         value = int(string)
         if not value > 0:
@@ -306,7 +367,7 @@ def positive_int_or_inf(string):
         raise argparse.ArgumentTypeError(f"{string!r} is not a positive integer or 'all'")
 
 
-def time_period(string, base_period='d'):
+def time_period(string, base_period="d"):
     """
     Parse a time period argument with unit suffix
     """

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -15,39 +15,60 @@ class Continuous(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "continuous", help="Compare two commits directly",
+            "continuous",
+            help="Compare two commits directly",
             description="""Run a side-by-side comparison of two commits for
-            continuous integration.""")
+            continuous integration.""",
+        )
 
         parser.add_argument(
-            'base', nargs='?', default=None,
+            "base",
+            nargs="?",
+            default=None,
             help="""The commit/branch to compare against. By default, the
-            parent of the tested commit.""")
+            parent of the tested commit.""",
+        )
         parser.add_argument(
-            'branch', default=None,
-            help="""The commit/branch to test. By default, the first configured branch.""")
+            "branch",
+            default=None,
+            help="""The commit/branch to test. By default, the first configured branch.""",
+        )
         common_args.add_record_samples(parser, record_default=True)
         parser.add_argument(
-            "--quick", "-q", action="store_true",
+            "--quick",
+            "-q",
+            action="store_true",
             help="""Do a "quick" run, where each benchmark function is
             run only once.  This is useful to find basic errors in the
             benchmark functions faster.  The results are unlikely to
-            be useful, and thus are not saved.""")
+            be useful, and thus are not saved.""",
+        )
         parser.add_argument(
-            "--interleave-rounds", action="store_true", default=None,
+            "--interleave-rounds",
+            action="store_true",
+            default=None,
             help="""Interleave benchmarks with multiple rounds across
             commits. This can avoid measurement biases from commit ordering,
-            can take longer.""")
+            can take longer.""",
+        )
         parser.add_argument(
-            "--no-interleave-rounds", action="store_false", dest="interleave_rounds")
+            "--no-interleave-rounds", action="store_false", dest="interleave_rounds"
+        )
         # Backward compatibility for '--(no-)interleave-rounds'
         parser.add_argument(
-            "--interleave-processes", action="store_true", default=False, dest="interleave_rounds",
-            help=argparse.SUPPRESS)
+            "--interleave-processes",
+            action="store_true",
+            default=False,
+            dest="interleave_rounds",
+            help=argparse.SUPPRESS,
+        )
         parser.add_argument(
-            "--no-interleave-processes", action="store_false", dest="interleave_rounds",
-            help=argparse.SUPPRESS)
-        common_args.add_compare(parser, sort_default='ratio', only_changed_default=True)
+            "--no-interleave-processes",
+            action="store_false",
+            dest="interleave_rounds",
+            help=argparse.SUPPRESS,
+        )
+        common_args.add_compare(parser, sort_default="ratio", only_changed_default=True)
         common_args.add_show_stderr(parser)
         common_args.add_bench(parser)
         common_args.add_machine(parser)
@@ -60,25 +81,50 @@ class Continuous(Command):
     @classmethod
     def run_from_conf_args(cls, conf, args, **kwargs):
         return cls.run(
-            conf=conf, branch=args.branch, base=args.base,
-            factor=args.factor, split=args.split,
-            only_changed=args.only_changed, sort=args.sort,
+            conf=conf,
+            branch=args.branch,
+            base=args.base,
+            factor=args.factor,
+            split=args.split,
+            only_changed=args.only_changed,
+            sort=args.sort,
             use_stats=args.use_stats,
-            show_stderr=args.show_stderr, bench=args.bench, attribute=args.attribute,
+            show_stderr=args.show_stderr,
+            bench=args.bench,
+            attribute=args.attribute,
             machine=args.machine,
-            env_spec=args.env_spec, record_samples=args.record_samples,
+            env_spec=args.env_spec,
+            record_samples=args.record_samples,
             append_samples=args.append_samples,
-            quick=args.quick, interleave_rounds=args.interleave_rounds,
-            launch_method=args.launch_method, **kwargs
+            quick=args.quick,
+            interleave_rounds=args.interleave_rounds,
+            launch_method=args.launch_method,
+            **kwargs,
         )
 
     @classmethod
-    def run(cls, conf, branch=None, base=None,
-            factor=None, split=False, only_changed=True, sort='ratio', use_stats=True,
-            show_stderr=False, bench=None,
-            attribute=None, machine=None, env_spec=None,
-            record_samples=False, append_samples=False,
-            quick=False, interleave_rounds=None, launch_method=None, _machine_file=None):
+    def run(
+        cls,
+        conf,
+        branch=None,
+        base=None,
+        factor=None,
+        split=False,
+        only_changed=True,
+        sort="ratio",
+        use_stats=True,
+        show_stderr=False,
+        bench=None,
+        attribute=None,
+        machine=None,
+        env_spec=None,
+        record_samples=False,
+        append_samples=False,
+        quick=False,
+        interleave_rounds=None,
+        launch_method=None,
+        _machine_file=None,
+    ):
         repo = get_repo(conf)
         repo.pull()
 
@@ -99,21 +145,30 @@ class Continuous(Command):
         run_objs = {}
 
         result = Run.run(
-            conf, range_spec=commit_hashes, bench=bench, attribute=attribute,
-            show_stderr=show_stderr, machine=machine, env_spec=env_spec,
-            record_samples=record_samples, append_samples=append_samples, quick=quick,
+            conf,
+            range_spec=commit_hashes,
+            bench=bench,
+            attribute=attribute,
+            show_stderr=show_stderr,
+            machine=machine,
+            env_spec=env_spec,
+            record_samples=record_samples,
+            append_samples=append_samples,
+            quick=quick,
             interleave_rounds=interleave_rounds,
-            launch_method=launch_method, _returns=run_objs, _machine_file=_machine_file)
+            launch_method=launch_method,
+            _returns=run_objs,
+            _machine_file=_machine_file,
+        )
         if result:
             return result
 
         log.flush()
 
         def results_iter(commit_hash):
-            for env in run_objs['environments']:
-                machine_name = run_objs['machine_params']['machine']
-                filename = results.get_filename(
-                    machine_name, commit_hash, env.name)
+            for env in run_objs["environments"]:
+                machine_name = run_objs["machine_params"]["machine"]
+                filename = results.get_filename(machine_name, commit_hash, env.name)
                 filename = os.path.join(conf.results_dir, filename)
                 try:
                     result = results.Results.load(filename, machine_name)
@@ -121,35 +176,43 @@ class Continuous(Command):
                     log.warning(str(err))
                     continue
 
-                for name, benchmark in run_objs['benchmarks'].items():
-                    params = benchmark['params']
-                    version = benchmark['version']
+                for name, benchmark in run_objs["benchmarks"].items():
+                    params = benchmark["params"]
+                    version = benchmark["version"]
 
                     value = result.get_result_value(name, params)
                     stats = result.get_result_stats(name, params)
                     samples = result.get_result_samples(name, params)
                     yield name, params, value, stats, samples, version, machine_name, env.name
 
-        commit_names = {parent: repo.get_name_from_hash(parent),
-                        head: repo.get_name_from_hash(head)}
+        commit_names = {
+            parent: repo.get_name_from_hash(parent),
+            head: repo.get_name_from_hash(head),
+        }
 
-        status = Compare.print_table(conf, parent, head,
-                                     resultset_1=results_iter(parent),
-                                     resultset_2=results_iter(head),
-                                     factor=factor, split=split,
-                                     use_stats=use_stats,
-                                     only_changed=only_changed, sort=sort,
-                                     commit_names=commit_names)
+        status = Compare.print_table(
+            conf,
+            parent,
+            head,
+            resultset_1=results_iter(parent),
+            resultset_2=results_iter(head),
+            factor=factor,
+            split=split,
+            use_stats=use_stats,
+            only_changed=only_changed,
+            sort=sort,
+            commit_names=commit_names,
+        )
         worsened, improved = status
 
         color_print("")
         if worsened:
-            color_print("SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.", 'red')
-            color_print("PERFORMANCE DECREASED.", 'red')
+            color_print("SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.", "red")
+            color_print("PERFORMANCE DECREASED.", "red")
         elif improved:
-            color_print("SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.", 'green')
-            color_print("PERFORMANCE INCREASED.", 'green')
+            color_print("SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.", "green")
+            color_print("PERFORMANCE INCREASED.", "green")
         else:
-            color_print("BENCHMARKS NOT SIGNIFICANTLY CHANGED.", 'green')
+            color_print("BENCHMARKS NOT SIGNIFICANTLY CHANGED.", "green")
 
         return worsened

--- a/asv/commands/dev.py
+++ b/asv/commands/dev.py
@@ -7,11 +7,13 @@ class Dev(Run):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "dev", help="Do a test run of a benchmark suite during development",
+            "dev",
+            help="Do a test run of a benchmark suite during development",
             description="""
                 This runs a benchmark suite in a mode that is useful
                 during development.  It is equivalent to
-                ``asv run --python=same``""")
+                ``asv run --python=same``""",
+        )
 
         cls._setup_arguments(parser, env_default_same=True)
 

--- a/asv/commands/machine.py
+++ b/asv/commands/machine.py
@@ -8,21 +8,22 @@ class Machine(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "machine", help="Define information about this machine",
+            "machine",
+            help="Define information about this machine",
             description="""
             Defines information about this machine.  If no arguments
             are provided, an interactive console session will be used
             to ask questions about the machine.
-            """)
+            """,
+        )
 
         defaults = machine.Machine.get_defaults()
         for name, description in machine.Machine.fields:
-            parser.add_argument(
-                '--' + name, default=defaults[name],
-                help=description)
+            parser.add_argument("--" + name, default=defaults[name], help=description)
 
-        parser.add_argument('--yes', default=False, action='store_true',
-                            help="Accept all questions")
+        parser.add_argument(
+            "--yes", default=False, action="store_true", help="Accept all questions"
+        )
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -40,8 +41,8 @@ class Machine(Command):
             if kwargs.get(key) != val:
                 different[key] = kwargs.get(key)
 
-        use_defaults = kwargs['yes']
+        use_defaults = kwargs["yes"]
 
         machine.Machine.load(
-            force_interactive=(len(different) == 0),
-            use_defaults=use_defaults, **different)
+            force_interactive=(len(different) == 0), use_defaults=use_defaults, **different
+        )

--- a/asv/commands/preview.py
+++ b/asv/commands/preview.py
@@ -45,8 +45,7 @@ def create_httpd(handler_cls, port=0):
             else:
                 raise
     else:
-        raise util.UserError("Failed to find an unused port for "
-                             "serving web pages")
+        raise util.UserError("Failed to find an unused port for " "serving web pages")
 
     return httpd, base_url
 
@@ -57,16 +56,19 @@ class Preview(Command):
         parser = subparsers.add_parser(
             "preview",
             help="Preview the results using a local web server",
-            description="Preview the results using a local web server")
+            description="Preview the results using a local web server",
+        )
 
-        parser.add_argument("--port", "-p", type=int, default=0,
-                            help="Port to run webserver on.  [8080]")
-        parser.add_argument("--browser", "-b", action="store_true",
-                            help="Open in webbrowser")
         parser.add_argument(
-            '--html-dir', '-o', default=None, help=(
-                "Optional output directory. Default is 'html_dir' "
-                "from asv config"))
+            "--port", "-p", type=int, default=0, help="Port to run webserver on.  [8080]"
+        )
+        parser.add_argument("--browser", "-b", action="store_true", help="Open in webbrowser")
+        parser.add_argument(
+            "--html-dir",
+            "-o",
+            default=None,
+            help=("Optional output directory. Default is 'html_dir' " "from asv config"),
+        )
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -76,8 +78,7 @@ class Preview(Command):
     def run_from_conf_args(cls, conf, args):
         if args.html_dir:
             conf.html_dir = args.html_dir
-        return cls.run(conf=conf, port=args.port,
-                       browser=args.browser)
+        return cls.run(conf=conf, port=args.port, browser=args.browser)
 
     @classmethod
     def run(cls, conf, port=0, browser=False):
@@ -85,8 +86,7 @@ class Preview(Command):
 
         class Handler(http.server.SimpleHTTPRequestHandler):
             def translate_path(self, path):
-                path = http.server.SimpleHTTPRequestHandler.translate_path(
-                    self, path)
+                path = http.server.SimpleHTTPRequestHandler.translate_path(self, path)
                 return util.long_path(path)
 
         httpd, base_url = create_httpd(Handler, port=port)
@@ -95,6 +95,7 @@ class Preview(Command):
 
         if browser:
             import webbrowser
+
             webbrowser.open(base_url)
 
         log.info("Press ^C to abort\n")

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -24,7 +24,7 @@ from .. import util
 def temp_profile(profile_data):
     profile_fd, profile_path = tempfile.mkstemp()
     try:
-        with io.open(profile_fd, 'wb', closefd=True) as fd:
+        with io.open(profile_fd, "wb", closefd=True) as fd:
             fd.write(profile_data)
 
         yield profile_path
@@ -39,32 +39,43 @@ class Profile(Command):
             "profile",
             help="""Run the profiler on a particular benchmark on a
             particular revision""",
-            description="Profile a benchmark")
+            description="Profile a benchmark",
+        )
 
         parser.add_argument(
-            'benchmark',
+            "benchmark",
             help="""The benchmark to profile.  Must be a
             fully-specified benchmark name. For parameterized benchmark, it
             must include the parameter combination to use, e.g.:
-            benchmark_name\\(param0, param1, ...\\)""")
+            benchmark_name\\(param0, param1, ...\\)""",
+        )
         parser.add_argument(
-            'revision', nargs='?',
+            "revision",
+            nargs="?",
             help="""The revision of the project to profile.  May be a
-            commit hash, or a tag or branch name.""")
+            commit hash, or a tag or branch name.""",
+        )
         parser.add_argument(
-            '--gui', '-g',
+            "--gui",
+            "-g",
             help="""Display the profile in the given gui.  Use
-            --gui=list to list available guis.""")
+            --gui=list to list available guis.""",
+        )
         parser.add_argument(
-            '--output', '-o',
+            "--output",
+            "-o",
             help="""Save the profiling information to the given file.
             This file is in the format written by the `cProfile`
             standard library module.  If not provided, prints a simple
-            text-based profiling report to the console.""")
+            text-based profiling report to the console.""",
+        )
         parser.add_argument(
-            '--force', '-f', action='store_true',
+            "--force",
+            "-f",
+            action="store_true",
             help="""Forcibly re-run the profile, even if the data
-            already exists in the results database.""")
+            already exists in the results database.""",
+        )
         common_args.add_environment(parser)
         common_args.add_launch_method(parser)
 
@@ -82,18 +93,33 @@ class Profile(Command):
     @classmethod
     def run_from_conf_args(cls, conf, args, **kwargs):
         return cls.run(
-            conf=conf, benchmark=args.benchmark, revision=args.revision,
-            gui=args.gui, output=args.output, force=args.force,
-            env_spec=args.env_spec, launch_method=args.launch_method,
-            **kwargs)
+            conf=conf,
+            benchmark=args.benchmark,
+            revision=args.revision,
+            gui=args.gui,
+            output=args.output,
+            force=args.force,
+            env_spec=args.env_spec,
+            launch_method=args.launch_method,
+            **kwargs,
+        )
 
     @classmethod
-    def run(cls, conf, benchmark, revision=None, gui=None, output=None,
-            force=False, env_spec=None, launch_method=None,
-            _machine_file=None):
+    def run(
+        cls,
+        conf,
+        benchmark,
+        revision=None,
+        gui=None,
+        output=None,
+        force=False,
+        env_spec=None,
+        launch_method=None,
+        _machine_file=None,
+    ):
         cls.find_guis()
 
-        if gui == 'list':
+        if gui == "list":
             log.info("Available profiler GUIs:")
             with log.indent():
                 for x in cls.guis.values():
@@ -101,12 +127,10 @@ class Profile(Command):
             return
 
         if gui is not None and gui not in cls.guis:
-            raise util.UserError(
-                f"Unknown profiler GUI {gui}")
+            raise util.UserError(f"Unknown profiler GUI {gui}")
 
         if benchmark is None:
-            raise util.UserError(
-                "Must specify benchmark to run")
+            raise util.UserError("Must specify benchmark to run")
 
         environments = list(get_environments(conf, env_spec))
 
@@ -134,12 +158,10 @@ class Profile(Command):
         # First, we see if we already have the profile in the results
         # database
         if not force and commit_hash:
-            for result in iter_results_for_machine(
-                    conf.results_dir, machine_name):
+            for result in iter_results_for_machine(conf.results_dir, machine_name):
                 if hash_equal(commit_hash, result.commit_hash):
                     if result.has_profile(benchmark):
-                        env_matched = any(result.env.name == env.name
-                                          for env in environments)
+                        env_matched = any(result.env.name == env.name for env in environments)
                         if env_matched:
                             if result.env.name not in checked_out:
                                 # We need to checkout the correct commit so that
@@ -160,44 +182,51 @@ class Profile(Command):
                     if not env.can_install_project():
                         raise util.UserError(
                             "An explicit revision may not be specified when "
-                            "using an existing environment.")
+                            "using an existing environment."
+                        )
 
             env = environments[0]
 
             if env.python != "{0}.{1}".format(*sys.version_info[:2]):
                 raise util.UserError(
                     "Profiles must be run in the same version of Python as the "
-                    "asv master process")
+                    "asv master process"
+                )
 
-            benchmarks = Benchmarks.discover(conf, repo, environments,
-                                             [commit_hash],
-                                             regex=f'^{benchmark}$')
+            benchmarks = Benchmarks.discover(
+                conf, repo, environments, [commit_hash], regex=f"^{benchmark}$"
+            )
 
             if len(benchmarks) == 0:
                 raise util.UserError(f"'{benchmark}' benchmark not found")
             elif len(benchmarks) > 1:
                 exact_matches = benchmarks.filter_out([x for x in benchmarks if x != benchmark])
                 if len(exact_matches) == 1:
-                    log.warning("'{0}' matches more than one benchmark, "
-                                "using exact match".format(benchmark))
+                    log.warning(
+                        "'{0}' matches more than one benchmark, "
+                        "using exact match".format(benchmark)
+                    )
                     benchmarks = exact_matches
                 else:
                     raise util.UserError(f"'{benchmark}' matches more than one benchmark")
 
-            benchmark_name, = benchmarks.keys()
+            (benchmark_name,) = benchmarks.keys()
 
             if not force:
-                log.info(
-                    "Profile data does not already exist. "
-                    "Running profiler now.")
+                log.info("Profile data does not already exist. " "Running profiler now.")
             else:
                 log.info("Running profiler")
             with log.indent():
                 env.install_project(conf, repo, commit_hash)
 
                 results = run_benchmarks(
-                    benchmarks, env, show_stderr=True, quick=False, profile=True,
-                    launch_method=launch_method)
+                    benchmarks,
+                    env,
+                    show_stderr=True,
+                    quick=False,
+                    profile=True,
+                    launch_method=launch_method,
+                )
 
                 profile_data = results.get_profile(benchmark_name)
 
@@ -208,12 +237,12 @@ class Profile(Command):
             with temp_profile(profile_data) as profile_path:
                 return cls.guis[gui].open_profiler_gui(profile_path)
         elif output is not None:
-            with io.open(output, 'wb') as fd:
+            with io.open(output, "wb") as fd:
                 fd.write(profile_data)
         else:
-            color_print('')
+            color_print("")
             with temp_profile(profile_data) as profile_path:
                 stats = pstats.Stats(profile_path)
                 stats.strip_dirs()  # Addresses gh-71
-                stats.sort_stats('cumulative')
+                stats.sort_stats("cumulative")
                 stats.print_stats()

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -22,18 +22,17 @@ def check_benchmark_params(name, benchmark):
     assume this data is valid. It is checked in benchmark.py already when it
     is generated, but best to double check in any case.
     """
-    if 'params' not in benchmark:
+    if "params" not in benchmark:
         # Old-format benchmarks.json
-        benchmark['params'] = []
-        benchmark['param_names'] = []
+        benchmark["params"] = []
+        benchmark["param_names"] = []
 
     msg = f"Information in benchmarks.json for benchmark {name} is malformed"
-    if (not isinstance(benchmark['params'], list) or
-            not isinstance(benchmark['param_names'], list)):
+    if not isinstance(benchmark["params"], list) or not isinstance(benchmark["param_names"], list):
         raise ValueError(msg)
-    if len(benchmark['params']) != len(benchmark['param_names']):
+    if len(benchmark["params"]) != len(benchmark["param_names"]):
         raise ValueError(msg)
-    for item in benchmark['params']:
+    for item in benchmark["params"]:
         if not isinstance(item, list):
             raise ValueError(msg)
 
@@ -42,21 +41,25 @@ class Publish(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "publish", help="Collate results into a website",
+            "publish",
+            help="Collate results into a website",
             description="""
             Collate all results into a website.  This website will be
             written to the ``html_dir`` given in the ``asv.conf.json``
-            file, and may be served using any static web server.""")
+            file, and may be served using any static web server.""",
+        )
         parser.add_argument(
-            '--no-pull', action='store_true', dest='no_pull',
-            help="Do not pull the repository")
+            "--no-pull", action="store_true", dest="no_pull", help="Do not pull the repository"
+        )
         parser.add_argument(
-            'range', nargs='?', default=None,
-            help="""Optional commit range to consider""")
+            "range", nargs="?", default=None, help="""Optional commit range to consider"""
+        )
         parser.add_argument(
-            '--html-dir', '-o', default=None, help=(
-                "Optional output directory. Default is 'html_dir' "
-                "from asv config"))
+            "--html-dir",
+            "-o",
+            default=None,
+            help=("Optional output directory. Default is 'html_dir' " "from asv config"),
+        )
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -99,19 +102,23 @@ class Publish(Command):
 
         def copy_ignore(src, names):
             # Copy only *.js and *.css in vendor dir
-            ignore = [fn for fn in names
-                      if (os.path.basename(src).lower() == 'vendor' and
-                          not fn.lower().endswith('.js') and
-                          not fn.lower().endswith('.css'))]
+            ignore = [
+                fn
+                for fn in names
+                if (
+                    os.path.basename(src).lower() == "vendor"
+                    and not fn.lower().endswith(".js")
+                    and not fn.lower().endswith(".css")
+                )
+            ]
             return ignore
 
-        template_dir = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), '..', 'www')
+        template_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "www")
         shutil.copytree(template_dir, conf.html_dir, ignore=copy_ignore)
 
         # Ensure html_dir is writable even if template_dir is on a read-only FS
         os.chmod(conf.html_dir, 0o755)
-        for (pre, ds, fs) in os.walk(conf.html_dir):
+        for pre, ds, fs in os.walk(conf.html_dir):
             for x in fs:
                 os.chmod(os.path.join(pre, x), 0o644)
             for x in ds:
@@ -122,7 +129,7 @@ class Publish(Command):
         with log.indent():
             for path in iter_machine_files(conf.results_dir):
                 d = util.load_json(path)
-                machines[d['machine']] = d
+                machines[d["machine"]] = d
 
         log.step()
         log.info("Getting params, commits, tags and branches")
@@ -134,7 +141,7 @@ class Publish(Command):
                 for key, val in results.params.items():
                     if val is None:
                         # Backward compatibility -- null means ''
-                        val = ''
+                        val = ""
 
                     params.setdefault(key, set())
                     params[key].add(val)
@@ -157,9 +164,7 @@ class Publish(Command):
 
             revision_to_date = dict((r, hash_to_date[h]) for h, r in revisions.items())
 
-            branches = dict(
-                (branch, repo.get_branch_commits(branch))
-                for branch in conf.branches)
+            branches = dict((branch, repo.get_branch_commits(branch)) for branch in conf.branches)
 
         log.step()
         log.info("Loading results")
@@ -168,29 +173,39 @@ class Publish(Command):
             for results in cls.iter_results(conf, repo, range_spec):
                 log.dot()
 
-                branches_for_commit = [branch for branch, commits in branches.items() if
-                                       results.commit_hash in commits]
+                branches_for_commit = [
+                    branch
+                    for branch, commits in branches.items()
+                    if results.commit_hash in commits
+                ]
 
                 # Print a warning message if the commit isn't from a tag
                 if not len(branches_for_commit):
                     # Assume that these must be tags
                     repo_tags = repo.get_tags()
-                    branches_for_commit = [branch for branch, commits in branches.items() if
-                                           results.commit_hash in repo_tags.values()]
+                    branches_for_commit = [
+                        branch
+                        for branch, commits in branches.items()
+                        if results.commit_hash in repo_tags.values()
+                    ]
                     if not len(branches_for_commit):
                         # Not tags, print a warning
                         msg = "Couldn't find {} in branches ({})"
-                        log.warning(msg.format(results.commit_hash[:conf.hash_length],
-                                               ", ".join(str(branch) for
-                                                         branch in branches.keys())))
+                        log.warning(
+                            msg.format(
+                                results.commit_hash[: conf.hash_length],
+                                ", ".join(str(branch) for branch in branches.keys()),
+                            )
+                        )
 
                 for key in results.get_result_keys(benchmarks):
                     b = benchmarks[key]
-                    b_params = b['params']
+                    b_params = b["params"]
 
                     result = results.get_result_value(key, b_params)
-                    weight = [statistics.get_weight(s)
-                              for s in results.get_result_stats(key, b_params)]
+                    weight = [
+                        statistics.get_weight(s) for s in results.get_result_stats(key, b_params)
+                    ]
                     if not b_params:
                         result = result[0]
                         weight = weight[0]
@@ -199,15 +214,14 @@ class Publish(Command):
 
                     for branch in branches_for_commit:
                         cur_params = dict(results.params)
-                        cur_env = {f'env-{name}': val
-                                   for name, val in results.env_vars.items()}
+                        cur_env = {f"env-{name}": val for name, val in results.env_vars.items()}
                         cur_params.update(cur_env)
-                        cur_params['branch'] = repo.get_branch_name(branch)
+                        cur_params["branch"] = repo.get_branch_name(branch)
 
                         # Backward compatibility, see above
                         for param_key, param_value in list(cur_params.items()):
                             if param_value is None:
-                                cur_params[param_key] = ''
+                                cur_params[param_key] = ""
 
                         # Fill in missing params
                         for param_key in params.keys():
@@ -222,7 +236,7 @@ class Publish(Command):
             # Get the parameter sets for all graphs
             graph_param_list = []
             for path, graph in graphs:
-                if 'summary' not in graph.params:
+                if "summary" not in graph.params:
                     if graph.params not in graph_param_list:
                         graph_param_list.append(graph.params)
 
@@ -245,8 +259,7 @@ class Publish(Command):
             graphs.save(conf.html_dir, dots=log.dot)
 
         pages = []
-        classes = sorted(util.iter_subclasses(OutputPublisher),
-                         key=lambda cls: cls.order)
+        classes = sorted(util.iter_subclasses(OutputPublisher), key=lambda cls: cls.order)
         for cls in classes:
             log.step()
             log.info(f"Generating output for {cls.__name__}")
@@ -261,26 +274,33 @@ class Publish(Command):
             check_benchmark_params(key, benchmark_map[key])
         for key, val in params.items():
             val = list(val)
-            val.sort(key=lambda x: '[none]' if x is None else str(x))
+            val.sort(key=lambda x: "[none]" if x is None else str(x))
             params[key] = val
-        params['branch'] = [repo.get_branch_name(branch) for branch in conf.branches]
+        params["branch"] = [repo.get_branch_name(branch) for branch in conf.branches]
         revision_to_hash = dict((r, h) for h, r in revisions.items())
-        util.write_json(os.path.join(conf.html_dir, "index.json"), {
-            'project': conf.project,
-            'project_url': conf.project_url,
-            'show_commit_url': conf.show_commit_url,
-            'hash_length': conf.hash_length,
-            'revision_to_hash': revision_to_hash,
-            'revision_to_date': revision_to_date,
-            'params': params,
-            'graph_param_list': graph_param_list,
-            'benchmarks': benchmark_map,
-            'machines': machines,
-            'tags': tags,
-            'pages': pages,
-        }, compact=True)
+        util.write_json(
+            os.path.join(conf.html_dir, "index.json"),
+            {
+                "project": conf.project,
+                "project_url": conf.project_url,
+                "show_commit_url": conf.show_commit_url,
+                "hash_length": conf.hash_length,
+                "revision_to_hash": revision_to_hash,
+                "revision_to_date": revision_to_date,
+                "params": params,
+                "graph_param_list": graph_param_list,
+                "benchmarks": benchmark_map,
+                "machines": machines,
+                "tags": tags,
+                "pages": pages,
+            },
+            compact=True,
+        )
 
-        util.write_json(os.path.join(conf.html_dir, "info.json"), {
-            'asv-version': __version__,
-            'timestamp': util.datetime_to_js_timestamp(datetime.datetime.utcnow())
-        })
+        util.write_json(
+            os.path.join(conf.html_dir, "info.json"),
+            {
+                "asv-version": __version__,
+                "timestamp": util.datetime_to_js_timestamp(datetime.datetime.utcnow()),
+            },
+        )

--- a/asv/commands/quickstart.py
+++ b/asv/commands/quickstart.py
@@ -11,23 +11,34 @@ class Quickstart(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "quickstart", help="Create a new benchmarking suite",
-            description="Creates a new benchmarking suite")
+            "quickstart",
+            help="Create a new benchmarking suite",
+            description="Creates a new benchmarking suite",
+        )
 
         parser.add_argument(
-            "--dest", "-d", default=".",
-            help="The destination directory for the new benchmarking "
-            "suite")
+            "--dest",
+            "-d",
+            default=".",
+            help="The destination directory for the new benchmarking " "suite",
+        )
 
         grp = parser.add_mutually_exclusive_group()
         grp.add_argument(
-            "--top-level", action="store_true", dest="top_level", default=None,
+            "--top-level",
+            action="store_true",
+            dest="top_level",
+            default=None,
             help="Use layout suitable for putting the benchmark suite on "
-            "the top level of the project's repository")
+            "the top level of the project's repository",
+        )
         grp.add_argument(
-            "--no-top-level", action="store_false", dest="top_level", default=None,
-            help="Use layout suitable for putting the benchmark suite in "
-            "a separate repository")
+            "--no-top-level",
+            action="store_false",
+            dest="top_level",
+            default=None,
+            help="Use layout suitable for putting the benchmark suite in " "a separate repository",
+        )
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -58,8 +69,7 @@ class Quickstart(Command):
                     break
             color_print("")
 
-        template_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), '..', 'template')
+        template_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "template")
         for entry in os.listdir(template_path):
             path = os.path.join(template_path, entry)
             dest_path = os.path.join(dest, entry)
@@ -77,19 +87,21 @@ class Quickstart(Command):
                 shutil.copyfile(path, os.path.join(dest, entry))
 
         if top_level:
-            conf_file = os.path.join(dest, 'asv.conf.json')
+            conf_file = os.path.join(dest, "asv.conf.json")
 
-            with open(conf_file, 'r') as f:
+            with open(conf_file, "r") as f:
                 conf = f.read()
 
-            reps = [('"repo": "",', '"repo": ".",'),
-                    ('// "env_dir": "env",', '"env_dir": ".asv/env",'),
-                    ('// "results_dir": "results",', '"results_dir": ".asv/results",'),
-                    ('// "html_dir": "html",', '"html_dir": ".asv/html",')]
+            reps = [
+                ('"repo": "",', '"repo": ".",'),
+                ('// "env_dir": "env",', '"env_dir": ".asv/env",'),
+                ('// "results_dir": "results",', '"results_dir": ".asv/results",'),
+                ('// "html_dir": "html",', '"html_dir": ".asv/html",'),
+            ]
             for src, dst in reps:
                 conf = conf.replace(src, dst)
 
-            with open(conf_file, 'w') as f:
+            with open(conf_file, "w") as f:
                 f.write(conf)
 
         log.info("Edit asv.conf.json to get started.")

--- a/asv/commands/rm.py
+++ b/asv/commands/rm.py
@@ -12,20 +12,22 @@ class Rm(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "rm", help="Remove results from the database",
+            "rm",
+            help="Remove results from the database",
             description="""
             Removes entries from the results database.
-            """)
+            """,
+        )
 
         parser.add_argument(
-            'patterns', nargs='+',
+            "patterns",
+            nargs="+",
             help="""Pattern(s) to match, each of the form X=Y.  X may
             be one of "benchmark", "commit_hash", "python" or any of
             the machine or environment params.  Y is a case-sensitive
-            glob pattern.""")
-        parser.add_argument(
-            "-y", action="store_true",
-            help="""Don't prompt for confirmation.""")
+            glob pattern.""",
+        )
+        parser.add_argument("-y", action="store_true", help="""Don't prompt for confirmation.""")
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -43,28 +45,27 @@ class Rm(Command):
         count = 0
 
         for pattern in patterns:
-            parts = pattern.split('=', 1)
+            parts = pattern.split("=", 1)
             if len(parts) != 2:
                 raise util.UserError(f"Invalid pattern '{pattern}'")
 
-            if parts[0] == 'benchmark':
+            if parts[0] == "benchmark":
                 if single_benchmark is not None:
                     raise util.UserError("'benchmark' appears more than once")
                 single_benchmark = parts[1]
             else:
                 if parts[0] in global_patterns:
-                    raise util.UserError(
-                        f"'{parts[0]}' appears more than once")
+                    raise util.UserError(f"'{parts[0]}' appears more than once")
                 global_patterns[parts[0]] = parts[1]
 
         for result in iter_results(conf.results_dir):
             found = True
             for key, val in global_patterns.items():
-                if key == 'commit_hash':
+                if key == "commit_hash":
                     if not util.hash_equal(result.commit_hash, val):
                         found = False
                         break
-                elif key == 'python':
+                elif key == "python":
                     if not fnmatchcase(result.env.python, val):
                         found = False
                         break
@@ -93,7 +94,7 @@ class Rm(Command):
 
         if not y:
             do = console.get_answer_default("Perform operations", "n")
-            if len(do) and do.lower()[0] != 'y':
+            if len(do) and do.lower()[0] != "y":
                 sys.exit(0)
 
         if single_benchmark is not None:

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -52,7 +52,8 @@ class Run(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "run", help="Run a benchmark suite",
+            "run",
+            help="Run a benchmark suite",
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=textwrap.dedent(
                 """
@@ -62,7 +63,9 @@ class Run(Command):
                   asv run master             run for one branch
                   asv run master^!           run for one commit (git)
                   asv run "--merges master"  run for only merge commits (git)
-                """))
+                """
+            ),
+        )
 
         cls._setup_arguments(parser)
 
@@ -73,7 +76,9 @@ class Run(Command):
     @classmethod
     def _setup_arguments(cls, parser, env_default_same=False):
         parser.add_argument(
-            'range', nargs='?', default=None,
+            "range",
+            nargs="?",
+            default=None,
             help="""Range of commits to benchmark.  For a git
             repository, this is passed as the first argument to ``git
             rev-list``; or Mercurial log command. See 'specifying ranges'
@@ -87,108 +92,182 @@ class Run(Command):
             machine. 'HASHFILE:xxx' will benchmark only a specific set
             of hashes given in the file named 'xxx' ('-' means stdin),
             which must have one hash per line. By default, will benchmark
-            the head of each configured of the branches.""")
+            the head of each configured of the branches.""",
+        )
         parser.add_argument(
-            "--date-period", type=common_args.time_period, default=None,
+            "--date-period",
+            type=common_args.time_period,
+            default=None,
             help="""Pick only one commit in each given time period.
-            For example: 1d (daily), 1w (weekly), 1y (yearly).""")
+            For example: 1d (daily), 1w (weekly), 1y (yearly).""",
+        )
         parser.add_argument(
-            "--steps", "-s", type=common_args.positive_int, default=None,
+            "--steps",
+            "-s",
+            type=common_args.positive_int,
+            default=None,
             help="""Maximum number of steps to benchmark.  This is
             used to subsample the commits determined by range to a
-            reasonable number.""")
+            reasonable number.""",
+        )
         common_args.add_bench(parser)
         parser.add_argument(
-            "--profile", "-p", action="store_true",
+            "--profile",
+            "-p",
+            action="store_true",
             help="""In addition to timing, run the benchmarks through
-            the `cProfile` profiler and store the results.""")
+            the `cProfile` profiler and store the results.""",
+        )
         common_args.add_parallel(parser)
         common_args.add_show_stderr(parser)
         parser.add_argument(
-            "--durations", action="store", metavar='N', nargs='?',
-            type=common_args.positive_int_or_inf, default=0, const='all',
-            help="Display total duration for N (or 'all') slowest benchmarks")
+            "--durations",
+            action="store",
+            metavar="N",
+            nargs="?",
+            type=common_args.positive_int_or_inf,
+            default=0,
+            const="all",
+            help="Display total duration for N (or 'all') slowest benchmarks",
+        )
         parser.add_argument(
-            "--quick", "-q", action="store_true",
+            "--quick",
+            "-q",
+            action="store_true",
             help="""Do a "quick" run, where each benchmark function is
             run only once.  This is useful to find basic errors in the
             benchmark functions faster.  The results are unlikely to
-            be useful, and thus are not saved.""")
+            be useful, and thus are not saved.""",
+        )
         common_args.add_environment(parser, default_same=env_default_same)
         parser.add_argument(
-            "--set-commit-hash", default=None,
+            "--set-commit-hash",
+            default=None,
             help="""Set the commit hash to use when recording benchmark
             results. This makes results to be saved also when using an
-            existing environment.""")
+            existing environment.""",
+        )
         common_args.add_launch_method(parser)
         parser.add_argument(
-            "--dry-run", "-n", action="store_true",
+            "--dry-run",
+            "-n",
+            action="store_true",
             default=None,
-            help="""Do not save any results to disk.""")
+            help="""Do not save any results to disk.""",
+        )
         common_args.add_machine(parser)
         parser.add_argument(
-            "--skip-existing-successful", action="store_true",
+            "--skip-existing-successful",
+            action="store_true",
             help="""Skip running benchmarks that have previous successful
-            results""")
+            results""",
+        )
         parser.add_argument(
-            "--skip-existing-failed", action="store_true",
+            "--skip-existing-failed",
+            action="store_true",
             help="""Skip running benchmarks that have previous failed
-            results""")
+            results""",
+        )
         parser.add_argument(
-            "--skip-existing-commits", action="store_true",
+            "--skip-existing-commits",
+            action="store_true",
             help="""Skip running benchmarks for commits that have existing
-            results""")
+            results""",
+        )
         parser.add_argument(
-            "--skip-existing", "-k", action="store_true",
+            "--skip-existing",
+            "-k",
+            action="store_true",
             help="""Skip running benchmarks that have previous successful
-            or failed results""")
+            or failed results""",
+        )
         common_args.add_record_samples(parser)
         parser.add_argument(
-            "--interleave-rounds", action="store_true", default=False,
+            "--interleave-rounds",
+            action="store_true",
+            default=False,
             help="""Interleave benchmarks with multiple rounds across
             commits. This can avoid measurement biases from commit ordering,
-            can take longer.""")
+            can take longer.""",
+        )
         parser.add_argument(
-            "--no-interleave-rounds", action="store_false", dest="interleave_rounds")
+            "--no-interleave-rounds", action="store_false", dest="interleave_rounds"
+        )
         # Backward compatibility for '--(no-)interleave-rounds'
         parser.add_argument(
-            "--interleave-processes", action="store_true", default=False, dest="interleave_rounds",
-            help=argparse.SUPPRESS)
+            "--interleave-processes",
+            action="store_true",
+            default=False,
+            dest="interleave_rounds",
+            help=argparse.SUPPRESS,
+        )
         parser.add_argument(
-            "--no-interleave-processes", action="store_false", dest="interleave_rounds",
-            help=argparse.SUPPRESS)
-        parser.add_argument(
-            "--no-pull", action="store_true",
-            help="Do not pull the repository")
+            "--no-interleave-processes",
+            action="store_false",
+            dest="interleave_rounds",
+            help=argparse.SUPPRESS,
+        )
+        parser.add_argument("--no-pull", action="store_true", help="Do not pull the repository")
 
     @classmethod
     def run_from_conf_args(cls, conf, args, **kwargs):
         return cls.run(
-            conf=conf, range_spec=args.range, steps=args.steps, date_period=args.date_period,
-            bench=args.bench, attribute=args.attribute, parallel=args.parallel,
-            show_stderr=args.show_stderr, quick=args.quick,
-            profile=args.profile, env_spec=args.env_spec, set_commit_hash=args.set_commit_hash,
-            dry_run=args.dry_run, machine=args.machine,
+            conf=conf,
+            range_spec=args.range,
+            steps=args.steps,
+            date_period=args.date_period,
+            bench=args.bench,
+            attribute=args.attribute,
+            parallel=args.parallel,
+            show_stderr=args.show_stderr,
+            quick=args.quick,
+            profile=args.profile,
+            env_spec=args.env_spec,
+            set_commit_hash=args.set_commit_hash,
+            dry_run=args.dry_run,
+            machine=args.machine,
             skip_successful=args.skip_existing_successful or args.skip_existing,
             skip_failed=args.skip_existing_failed or args.skip_existing,
             skip_existing_commits=args.skip_existing_commits,
-            record_samples=args.record_samples, append_samples=args.append_samples,
-            pull=not args.no_pull, interleave_rounds=args.interleave_rounds,
-            launch_method=args.launch_method, durations=args.durations,
-            **kwargs
+            record_samples=args.record_samples,
+            append_samples=args.append_samples,
+            pull=not args.no_pull,
+            interleave_rounds=args.interleave_rounds,
+            launch_method=args.launch_method,
+            durations=args.durations,
+            **kwargs,
         )
 
     @classmethod
-    def run(cls, conf, range_spec=None, steps=None, date_period=None,
-            bench=None, attribute=None, parallel=1,
-            show_stderr=False, quick=False, profile=False, env_spec=None, set_commit_hash=None,
-            dry_run=False, machine=None, _machine_file=None, skip_successful=False,
-            skip_failed=False, skip_existing_commits=False, record_samples=False,
-            append_samples=False, pull=True, interleave_rounds=False,
-            launch_method=None, durations=0, _returns={}):
-        machine_params = Machine.load(
-            machine_name=machine,
-            _path=_machine_file, interactive=True)
+    def run(
+        cls,
+        conf,
+        range_spec=None,
+        steps=None,
+        date_period=None,
+        bench=None,
+        attribute=None,
+        parallel=1,
+        show_stderr=False,
+        quick=False,
+        profile=False,
+        env_spec=None,
+        set_commit_hash=None,
+        dry_run=False,
+        machine=None,
+        _machine_file=None,
+        skip_successful=False,
+        skip_failed=False,
+        skip_existing_commits=False,
+        record_samples=False,
+        append_samples=False,
+        pull=True,
+        interleave_rounds=False,
+        launch_method=None,
+        durations=0,
+        _returns={},
+    ):
+        machine_params = Machine.load(machine_name=machine, _path=_machine_file, interactive=True)
         machine_params.save(conf.results_dir)
 
         environments = list(environment.get_environments(conf, env_spec))
@@ -197,15 +276,18 @@ class Run(Command):
             # No repository required, so skip using it
             conf.dvcs = "none"
 
-        has_existing_env = any(isinstance(env, environment.ExistingEnvironment)
-                               for env in environments)
+        has_existing_env = any(
+            isinstance(env, environment.ExistingEnvironment) for env in environments
+        )
 
         if interleave_rounds:
             if dry_run:
                 raise util.UserError("--interleave-rounds and --dry-run cannot be used together")
             if has_existing_env:
-                raise util.UserError("--interleave-rounds cannot be used with existing "
-                                     "environment (or python=same)")
+                raise util.UserError(
+                    "--interleave-rounds cannot be used with existing "
+                    "environment (or python=same)"
+                )
         elif interleave_rounds is None:
             # Enable if possible
             interleave_rounds = not (dry_run or has_existing_env)
@@ -228,11 +310,12 @@ class Run(Command):
 
         if range_spec is None:
             try:
-                commit_hashes = list(set([repo.get_hash_from_name(branch) for
-                                         branch in conf.branches]))
+                commit_hashes = list(
+                    set([repo.get_hash_from_name(branch) for branch in conf.branches])
+                )
             except NoSuchNameError as exc:
-                raise util.UserError(f'Unknown branch {exc} in configuration')
-        elif range_spec == 'EXISTING':
+                raise util.UserError(f"Unknown branch {exc} in configuration")
+        elif range_spec == "EXISTING":
             commit_hashes = get_existing_hashes(conf.results_dir)
         elif range_spec == "NEW":
             # New commits on each configured branches
@@ -241,12 +324,12 @@ class Run(Command):
         elif range_spec == "ALL":
             # All commits on each configured branches
             commit_hashes = repo.get_new_branch_commits(conf.branches, [])
-        elif isinstance(range_spec, str) and range_spec.startswith('HASHFILE:'):
+        elif isinstance(range_spec, str) and range_spec.startswith("HASHFILE:"):
             hashfn = range_spec[9:]
-            if hashfn == '-':
+            if hashfn == "-":
                 hashstr = sys.stdin.read()
             elif os.path.isfile(hashfn):
-                with open(hashfn, 'r') as f:
+                with open(hashfn, "r") as f:
                     hashstr = f.read()
             else:
                 log.error(f'Requested commit hash file "{hashfn}" is not a file')
@@ -265,8 +348,7 @@ class Run(Command):
             commit_hashes = repo.get_hashes_from_range(range_spec)
 
         if date_period is not None:
-            commit_hashes = repo.filter_date_period(commit_hashes, date_period,
-                                                    old_commit_hashes)
+            commit_hashes = repo.filter_date_period(commit_hashes, date_period, old_commit_hashes)
 
         if steps is not None:
             commit_hashes = util.pick_n(commit_hashes, steps)
@@ -285,10 +367,10 @@ class Run(Command):
                 if not env.can_install_project():
                     raise util.UserError(
                         "No range spec may be specified if benchmarking in "
-                        "an existing environment")
+                        "an existing environment"
+                    )
 
-        benchmarks = Benchmarks.discover(conf, repo, environments,
-                                         commit_hashes, regex=bench)
+        benchmarks = Benchmarks.discover(conf, repo, environments, commit_hashes, regex=bench)
         benchmarks.save()
         if len(benchmarks) == 0:
             if bench == ["just-discover"]:
@@ -303,19 +385,19 @@ class Run(Command):
         log.info(
             f"Running {steps} total benchmarks "
             f"({len(commit_hashes)} commits * {len(environments)} "
-            f"environments * {len(benchmarks)} benchmarks)")
+            f"environments * {len(benchmarks)} benchmarks)"
+        )
 
         parallel, multiprocessing = util.get_multiprocessing(parallel)
 
-        _returns['benchmarks'] = benchmarks
-        _returns['environments'] = environments
-        _returns['machine_params'] = machine_params.__dict__
+        _returns["benchmarks"] = benchmarks
+        _returns["environments"] = environments
+        _returns["machine_params"] = machine_params.__dict__
 
-        if attribute and 'rounds' in attribute:
-            max_rounds = int(attribute['rounds'])
+        if attribute and "rounds" in attribute:
+            max_rounds = int(attribute["rounds"])
         else:
-            max_rounds = max(b.get('rounds', 1)
-                             for b in benchmarks.values())
+            max_rounds = max(b.get("rounds", 1) for b in benchmarks.values())
 
         log.set_nitems(steps * max_rounds)
 
@@ -325,8 +407,8 @@ class Run(Command):
             if skip_successful or skip_failed or skip_existing_commits:
                 try:
                     for result in iter_results_for_machine_and_hash(
-                            conf.results_dir, machine_params.machine, commit_hash):
-
+                        conf.results_dir, machine_params.machine, commit_hash
+                    ):
                         if skip_existing_commits:
                             skipped_benchmarks[commit_hash] = True
                             break
@@ -335,7 +417,7 @@ class Run(Command):
                             if key not in benchmarks:
                                 continue
 
-                            value = result.get_result_value(key, benchmarks[key]['params'])
+                            value = result.get_result_value(key, benchmarks[key]["params"])
 
                             failed = value is None or (isinstance(value, list) and None in value)
 
@@ -383,9 +465,11 @@ class Run(Command):
                             for j in range(max_rounds):
                                 log.step()
 
-            active_environments = [env for env in environments
-                                   if set(benchmarks.keys())
-                                   .difference(skipped_benchmarks[(commit_hash, env.name)])]
+            active_environments = [
+                env
+                for env in environments
+                if set(benchmarks.keys()).difference(skipped_benchmarks[(commit_hash, env.name)])
+            ]
 
             if not active_environments:
                 continue
@@ -397,20 +481,22 @@ class Run(Command):
                     round_info = ""
 
                 commit_name = repo.get_decorated_hash(commit_hash, 8)
-                log.info(
-                    f"For {conf.project} commit {commit_name}{round_info}:")
+                log.info(f"For {conf.project} commit {commit_name}{round_info}:")
 
             with log.indent():
-
                 for subenv in util.iter_chunks(active_environments, parallel):
+                    successes = dict(
+                        [
+                            (env.name, (env.installed_commit_hash == commit_hash, 0))
+                            for env in subenv
+                        ]
+                    )
 
-                    successes = dict([(env.name, (env.installed_commit_hash == commit_hash, 0))
-                                      for env in subenv])
+                    env_to_install = [
+                        env for env in subenv if env.installed_commit_hash != commit_hash
+                    ]
 
-                    env_to_install = [env for env in subenv
-                                      if env.installed_commit_hash != commit_hash]
-
-                    subenv_name = ', '.join([x.name for x in env_to_install])
+                    subenv_name = ", ".join([x.name for x in env_to_install])
 
                     if subenv_name:
                         log.info(f"Building for {subenv_name}")
@@ -449,12 +535,13 @@ class Run(Command):
                         build_duration = build_durations[build_duration_key]
 
                         params = dict(machine_params.__dict__)
-                        params['python'] = env.python
+                        params["python"] = env.python
                         params.update(env.requirements)
 
-                        skip_save = (dry_run or
-                                     (isinstance(env, environment.ExistingEnvironment) and
-                                      set_commit_hash is None))
+                        skip_save = dry_run or (
+                            isinstance(env, environment.ExistingEnvironment)
+                            and set_commit_hash is None
+                        )
 
                         skip_list = skipped_benchmarks[(commit_hash, env.name)]
                         benchmark_set = benchmarks.filter_out(skip_list)
@@ -469,7 +556,7 @@ class Run(Command):
                             repo.get_date(commit_hash),
                             env.python,
                             env.name,
-                            env.env_vars
+                            env.env_vars,
                         )
 
                         if not skip_save:
@@ -482,33 +569,36 @@ class Run(Command):
                         # append samples (except for the first round)
                         # and record samples (except for the final
                         # round).
-                        force_append_samples = (interleave_rounds and
-                                                run_rounds[0] < max_rounds)
-                        force_record_samples = (interleave_rounds and
-                                                run_rounds[0] > 1)
+                        force_append_samples = interleave_rounds and run_rounds[0] < max_rounds
+                        force_record_samples = interleave_rounds and run_rounds[0] > 1
 
                         if success:
                             run_benchmarks(
-                                benchmark_set, env, results=result,
-                                show_stderr=show_stderr, quick=quick,
-                                profile=profile, extra_params=attribute,
+                                benchmark_set,
+                                env,
+                                results=result,
+                                show_stderr=show_stderr,
+                                quick=quick,
+                                profile=profile,
+                                extra_params=attribute,
                                 record_samples=(record_samples or force_record_samples),
                                 append_samples=(append_samples or force_append_samples),
                                 run_rounds=run_rounds,
-                                launch_method=launch_method)
+                                launch_method=launch_method,
+                            )
                         else:
                             skip_benchmarks(benchmark_set, env, results=result)
 
                         if not skip_save:
                             result.save(conf.results_dir)
 
-                        failures = failures or any(
-                            code != 0 for code in result.errcode.values())
+                        failures = failures or any(code != 0 for code in result.errcode.values())
 
                         if durations > 0:
                             duration_set = Show._get_durations([(machine, result)], benchmark_set)
-                            log.info(cls.format_durations(
-                                duration_set[(machine, env.name)], durations))
+                            log.info(
+                                cls.format_durations(duration_set[(machine, env.name)], durations)
+                            )
 
         if failures:
             return 2

--- a/asv/commands/setup.py
+++ b/asv/commands/setup.py
@@ -26,11 +26,12 @@ class Setup(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "setup", help="Setup virtual environments",
+            "setup",
+            help="Setup virtual environments",
             description="""Setup virtual environments for each
             combination of Python version and third-party requirement.
             This is called by the ``run`` command implicitly, and
-            isn't generally required to be run on its own."""
+            isn't generally required to be run on its own.""",
         )
 
         common_args.add_parallel(parser)

--- a/asv/commands/update.py
+++ b/asv/commands/update.py
@@ -16,10 +16,10 @@ class Update(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "update", help="Update the results and config files "
-            "to the current version",
-            description="Update the results and config files "
-            "to the current version")
+            "update",
+            help="Update the results and config files " "to the current version",
+            description="Update the results and config files " "to the current version",
+        )
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -38,11 +38,11 @@ class Update(Command):
         for root, dirs, files in os.walk(conf.results_dir):
             for filename in files:
                 path = os.path.join(root, filename)
-                if filename == 'machine.json':
+                if filename == "machine.json":
                     Machine.update(path)
                 elif filename == "benchmarks.json":
                     pass
-                elif filename.endswith('.json'):
+                elif filename.endswith(".json"):
                     try:
                         Results.update(path)
                     except util.UserError as err:
@@ -51,7 +51,7 @@ class Update(Command):
                         continue
 
                     # Rename files if necessary
-                    m = re.match(r'^([0-9a-f]+)-(.*)\.json$', os.path.basename(path), re.I)
+                    m = re.match(r"^([0-9a-f]+)-(.*)\.json$", os.path.basename(path), re.I)
                     if m:
                         new_path = get_filename(root, m.group(1), m.group(2))
                         if new_path != path:
@@ -76,4 +76,4 @@ class Update(Command):
         if not ok:
             # Regenerating the file is needed
             with log.indent():
-                Run.run(conf, bench=['just-discover'])
+                Run.run(conf, bench=["just-discover"])

--- a/asv/config.py
+++ b/asv/config.py
@@ -13,6 +13,7 @@ class Config:
     """
     Manages the configuration for a benchmark project.
     """
+
     api_version = 1
 
     def __init__(self):
@@ -59,27 +60,26 @@ class Config:
         try:
             return cls.from_json(d)
         except ValueError:
-            raise util.UserError(
-                f"No repo specified in {path} config file.")
+            raise util.UserError(f"No repo specified in {path} config file.")
 
     @classmethod
     def from_json(cls, d):
-        if 'wheel_cache_size' in d:
-            log.warning("`wheel_cache_size` has been renamed to `build_cache_size`."
-                        " Update your `asv.conf.json` accordingly.")
-            d.setdefault('build_cache_size', d['wheel_cache_size'])
+        if "wheel_cache_size" in d:
+            log.warning(
+                "`wheel_cache_size` has been renamed to `build_cache_size`."
+                " Update your `asv.conf.json` accordingly."
+            )
+            d.setdefault("build_cache_size", d["wheel_cache_size"])
 
         conf = cls()
         conf.__dict__.update(d)
 
         if not getattr(conf, "repo", None):
-            raise util.UserError(
-                "No repo specified in config file.")
+            raise util.UserError("No repo specified in config file.")
 
         if not getattr(conf, "branches", [None]):
             # If 'branches' attribute is present, at least some must
             # be listed.
-            raise util.UserError(
-                "No branches specified in config file.")
+            raise util.UserError("No branches specified in config file.")
 
         return conf

--- a/asv/console.py
+++ b/asv/console.py
@@ -14,7 +14,7 @@ import time
 
 from . import util
 
-WIN = (os.name == "nt")
+WIN = os.name == "nt"
 
 
 def isatty(file):
@@ -25,7 +25,7 @@ def isatty(file):
     but some user-defined types may not, so this assumes those are not
     ttys.
     """
-    if hasattr(file, 'isatty'):
+    if hasattr(file, "isatty"):
         return file.isatty()
     return False
 
@@ -51,26 +51,27 @@ def _color_text(text, color):
         lightmagenta, lightcyan, white, or '' (the empty string).
     """
     color_mapping = {
-        'black': '0;30',
-        'red': '0;31',
-        'green': '0;32',
-        'brown': '0;33',
-        'blue': '0;34',
-        'magenta': '0;35',
-        'cyan': '0;36',
-        'lightgrey': '0;37',
-        'default': '0;39',
-        'darkgrey': '1;30',
-        'lightred': '1;31',
-        'lightgreen': '1;32',
-        'yellow': '1;33',
-        'lightblue': '1;34',
-        'lightmagenta': '1;35',
-        'lightcyan': '1;36',
-        'white': '1;37'}
+        "black": "0;30",
+        "red": "0;31",
+        "green": "0;32",
+        "brown": "0;33",
+        "blue": "0;34",
+        "magenta": "0;35",
+        "cyan": "0;36",
+        "lightgrey": "0;37",
+        "default": "0;39",
+        "darkgrey": "1;30",
+        "lightred": "1;31",
+        "lightgreen": "1;32",
+        "yellow": "1;33",
+        "lightblue": "1;34",
+        "lightmagenta": "1;35",
+        "lightcyan": "1;36",
+        "white": "1;37",
+    }
 
-    color_code = color_mapping.get(color, '0;39')
-    return f'\033[{color_code}m{text}\033[0m'
+    color_code = color_mapping.get(color, "0;39")
+    return f"\033[{color_code}m{text}\033[0m"
 
 
 # This is a table of Unicode characters that we want to have
@@ -83,11 +84,7 @@ def _color_text(text, color):
 #    grep -P  -n '[^\x00-\x7F]' -r *
 # in the `asv` source directory.
 
-_unicode_translations = {
-    ord('μ'): 'u',
-    ord('·'): '-',
-    ord('±'): '~'
-}
+_unicode_translations = {ord("μ"): "u", ord("·"): "-", ord("±"): "~"}
 
 
 def _write_with_fallback(s, fileobj):
@@ -113,7 +110,7 @@ def _write_with_fallback(s, fileobj):
         b = s.encode(enc)
     except UnicodeError:
         s = s.translate(_unicode_translations)
-        b = s.encode(enc, errors='replace')
+        b = s.encode(enc, errors="replace")
 
     fileobj.flush()
     fileobj.buffer.write(b)
@@ -150,14 +147,14 @@ def color_print(*args, **kwargs):
         be printed after resetting any color or font state.
     """
 
-    file = kwargs.get('file', sys.stdout)
-    end = kwargs.get('end', '\n')
+    file = kwargs.get("file", sys.stdout)
+    end = kwargs.get("end", "\n")
 
     if isatty(file) and not WIN:
         for i in range(0, len(args), 2):
             msg = args[i]
             if i + 1 == len(args):
-                color = ''
+                color = ""
             else:
                 color = args[i + 1]
 
@@ -174,20 +171,20 @@ def color_print(*args, **kwargs):
 
 
 def get_answer_default(prompt, default, use_defaults=False):
-    color_print(f"{prompt} [{default}]: ", end='')
+    color_print(f"{prompt} [{default}]: ", end="")
 
     if use_defaults:
         return default
 
     x = input()
-    if x.strip() == '':
+    if x.strip() == "":
         return default
     return x
 
 
 def truncate_left(s, l):
     if len(s) > l:
-        return '...' + s[-(l - 3):]
+        return "..." + s[-(l - 3) :]
     else:
         return s
 
@@ -200,21 +197,22 @@ class Log:
         self._logger = logging.getLogger()
         self._needs_newline = False
         self._last_dot = time.time()
-        if sys.platform in {'win32', 'cli'}:
+        if sys.platform in {"win32", "cli"}:
             try:
                 import colorama
+
                 colorama.init()
                 self._colorama = True
             except Exception as exc:
                 print(f"On Windows, colorama is suggested, but got {exc}")
 
     def _stream_formatter(self, record):
-        '''
+        """
         The formatter for standard output
-        '''
+        """
         if self._needs_newline:
-            color_print('')
-        parts = record.msg.split('\n', 1)
+            color_print("")
+        parts = record.msg.split("\n", 1)
         first_line = parts[0]
         if len(parts) == 1:
             rest = None
@@ -222,45 +220,45 @@ class Log:
             rest = parts[1]
 
         indent = self._indent + 1
-        continued = getattr(record, 'continued', False)
+        continued = getattr(record, "continued", False)
 
         if self._total:
-            progress_msg = f'[{self._count / self._total:6.02%}] '
+            progress_msg = f"[{self._count / self._total:6.02%}] "
             if not continued:
-                color_print(progress_msg, end='')
+                color_print(progress_msg, end="")
             indent += len(progress_msg)
 
         if not continued:
-            color_print('·' * self._indent, end='')
-            color_print(' ', end='')
+            color_print("·" * self._indent, end="")
+            color_print(" ", end="")
         else:
-            color_print(' ' * indent, end='')
+            color_print(" " * indent, end="")
 
-        if hasattr(record, 'color'):
+        if hasattr(record, "color"):
             color = record.color
         elif record.levelno < logging.DEBUG:
-            color = 'default'
+            color = "default"
         elif record.levelno < logging.INFO:
-            color = 'default'
+            color = "default"
         elif record.levelno < logging.WARN:
             if self._indent == 1:
-                color = 'green'
+                color = "green"
             elif self._indent == 2:
-                color = 'blue'
+                color = "blue"
             else:
-                color = 'default'
+                color = "default"
         elif record.levelno < logging.ERROR:
-            color = 'brown'
+            color = "brown"
         else:
-            color = 'red'
+            color = "red"
 
-        spaces = ' ' * indent
-        color_print(first_line, color, end='')
+        spaces = " " * indent
+        color_print(first_line, color, end="")
         if rest is not None:
-            color_print('')
+            color_print("")
             detail = textwrap.dedent(rest)
-            for line in detail.split('\n'):
-                color_print(spaces, end='')
+            for line in detail.split("\n"):
+                color_print(spaces, end="")
                 color_print(line)
 
         self._needs_newline = True
@@ -278,7 +276,7 @@ class Log:
     def dot(self):
         if isatty(sys.stdout):
             if time.time() > self._last_dot + 1.0:
-                color_print('.', 'darkgrey', end='')
+                color_print(".", "darkgrey", end="")
                 sys.stdout.flush()
                 self._last_dot = time.time()
 
@@ -331,16 +329,15 @@ class Log:
     def is_debug_enabled(self):
         return self._logger.getEffectiveLevel() <= logging.DEBUG
 
-    def _message(self, routine, message, reserve_space=False, color=None,
-                 continued=False):
+    def _message(self, routine, message, reserve_space=False, color=None, continued=False):
         kwargs = {}
         extra = {}
         if color is not None:
-            extra['color'] = color
+            extra["color"] = color
         if continued:
-            extra['continued'] = True
+            extra["continued"] = True
         if extra:
-            kwargs['extra'] = extra
+            kwargs["extra"] = extra
 
         if reserve_space:
             max_width = max(16, util.terminal_width - 33)
@@ -392,7 +389,7 @@ class Log:
         to stdout via other means, after using Log.
         """
         if self._needs_newline:
-            color_print('')
+            color_print("")
             self._needs_newline = False
         sys.stdout.flush()
 

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from .console import log
 from . import util, build_cache
 
-WIN = (os.name == "nt")
+WIN = os.name == "nt"
 
 
 def iter_matrix(environment_type, pythons, conf, explicit_selection=False):
@@ -43,8 +43,8 @@ def iter_matrix(environment_type, pythons, conf, explicit_selection=False):
         return env_type
 
     platform_keys = {
-        ('environment_type', None): environment_type,
-        ('sys_platform', None): sys.platform
+        ("environment_type", None): environment_type,
+        ("sys_platform", None): sys.platform,
     }
 
     # Parse requirement matrix
@@ -54,14 +54,14 @@ def iter_matrix(environment_type, pythons, conf, explicit_selection=False):
 
     # Convert values to lists in the expected format
     values = [value if isinstance(value, list) else [value] for value in values]
-    values = [[''] if value == [] else value for value in values]
+    values = [[""] if value == [] else value for value in values]
 
     # Process excludes
     for python in pythons:
         empty_matrix = True
 
         # Cartesian product of everything
-        all_keys = [('python', None)] + keys
+        all_keys = [("python", None)] + keys
         all_combinations = itertools.product([python], *values)
 
         for combination in all_combinations:
@@ -70,7 +70,7 @@ def iter_matrix(environment_type, pythons, conf, explicit_selection=False):
 
             if not environment_type:
                 try:
-                    target[('environment_type', None)] = get_env_type(target[('python', None)])
+                    target[("environment_type", None)] = get_env_type(target[("python", None)])
                 except EnvironmentUnavailable as err:
                     log.warning(str(err))
                     continue
@@ -84,13 +84,12 @@ def iter_matrix(environment_type, pythons, conf, explicit_selection=False):
             else:
                 # not excluded
                 empty_matrix = False
-                yield dict(item for item in zip(all_keys, combination)
-                           if item[1] is not None)
+                yield dict(item for item in zip(all_keys, combination) if item[1] is not None)
 
         # If the user explicitly selected environment/python, yield it
         # even if matrix contains no packages to be installed
         if empty_matrix and explicit_selection:
-            yield {('python', None): python}
+            yield {("python", None): python}
 
     # Process includes, unless explicit selection
     if explicit_selection:
@@ -104,7 +103,7 @@ def iter_matrix(environment_type, pythons, conf, explicit_selection=False):
 
         if not environment_type:
             try:
-                target[('environment_type', None)] = get_env_type(include[('python', None)])
+                target[("environment_type", None)] = get_env_type(include[("python", None)])
             except EnvironmentUnavailable as err:
                 log.warning(str(err))
                 continue
@@ -163,7 +162,7 @@ def _parse_matrix(matrix, bare_keys=()):
             result[key, None] = matrix.pop(key)
 
     # Insert remaining matrix entries
-    matrix_types = ('req', 'env', 'env_nobuild')
+    matrix_types = ("req", "env", "env_nobuild")
     if any(t in matrix for t in matrix_types):
         # New-style config
         matrices = []
@@ -174,11 +173,14 @@ def _parse_matrix(matrix, bare_keys=()):
         # Check if spurious keys left
         remaining_keys = tuple(matrix.keys())
         if remaining_keys:
-            raise util.UserError('Unknown keys in "matrix" configuration: {}, expected: {}'.format(
-                remaining_keys, matrix_types + tuple(bare_keys)))
+            raise util.UserError(
+                'Unknown keys in "matrix" configuration: {}, expected: {}'.format(
+                    remaining_keys, matrix_types + tuple(bare_keys)
+                )
+            )
     else:
         # Backward-compatibility for old-style config
-        matrices = [('req', matrix)]
+        matrices = [("req", matrix)]
 
     # Convert values
     for t, m in matrices:
@@ -204,10 +206,10 @@ def _parse_exclude_include_rule(rule, is_include=False):
     rule : dict
         Dictionary of {(key_type, key): value, ...}
     """
-    if is_include and 'python' not in rule:
+    if is_include and "python" not in rule:
         raise util.UserError(f"include rule '{rule}' does not specify Python version")
 
-    bare_keys = ('python', 'environment_type', 'sys_platform')
+    bare_keys = ("python", "environment_type", "sys_platform")
     return _parse_matrix(rule, bare_keys)
 
 
@@ -271,23 +273,23 @@ def get_env_name(tool_name, python, requirements, tagged_env_vars, build=False):
     reqs.sort()
     for key, val in reqs:
         if val:
-            name.append(''.join([key, val]))
+            name.append("".join([key, val]))
         else:
             name.append(key)
 
     env_vars = _untag_env_vars(tagged_env_vars, build=build)
 
     for env_var, value in sorted(env_vars.items()):
-        name.append(''.join([env_var, value]))
+        name.append("".join([env_var, value]))
 
-    return util.sanitize_filename('-'.join(name))
+    return util.sanitize_filename("-".join(name))
 
 
 def _untag_env_vars(tagged_env_vars, build=False):
     vars = {}
 
     for (tag, key), value in tagged_env_vars.items():
-        if not build or tag == 'build':
+        if not build or tag == "build":
             vars[key] = value
 
     return vars
@@ -320,7 +322,8 @@ def get_environments(conf, env_specifiers, verbose=True):
         if not conf.environment_type and verbose:
             log.warning(
                 "No `environment_type` specified in asv.conf.json. "
-                "This will be required in the future.")
+                "This will be required in the future."
+            )
     else:
         all_environments = list(get_environments(conf, None, verbose=verbose))
 
@@ -336,8 +339,8 @@ def get_environments(conf, env_specifiers, verbose=True):
 
         explicit_selection = False
 
-        if env_spec and ':' in env_spec:
-            env_type, python_spec = env_spec.split(':', 1)
+        if env_spec and ":" in env_spec:
+            env_type, python_spec = env_spec.split(":", 1)
             pythons = [python_spec]
             explicit_selection = True
         else:
@@ -349,11 +352,10 @@ def get_environments(conf, env_specifiers, verbose=True):
                 pythons = conf.pythons
 
         if env_type != "existing":
-            requirements_iter = iter_matrix(env_type, pythons, conf,
-                                            explicit_selection)
+            requirements_iter = iter_matrix(env_type, pythons, conf, explicit_selection)
         else:
             # Ignore requirement matrix
-            requirements_iter = [{('python', None): python} for python in pythons]
+            requirements_iter = [{("python", None): python} for python in pythons]
 
         for entries in requirements_iter:
             python, requirements, tagged_env_vars = _parse_matrix_entries(entries)
@@ -379,13 +381,13 @@ def _parse_matrix_entries(entries):
     requirements = {}
     tagged_env_vars = {}
     for (key_type, key), value in entries.items():
-        if key_type == 'python':
+        if key_type == "python":
             python = value
-        elif key_type == 'env':
+        elif key_type == "env":
             tagged_env_vars[("build", key)] = value
-        elif key_type == 'env_nobuild':
+        elif key_type == "env_nobuild":
             tagged_env_vars[("nobuild", key)] = value
-        elif key_type == 'req':
+        elif key_type == "req":
             requirements[key] = value
         else:
             # Shouldn't happen
@@ -414,7 +416,7 @@ def get_environment_class(conf, python):
           that all dependencies and the benchmarked project itself are
           already installed.
     """
-    if python == 'same':
+    if python == "same":
         return ExistingEnvironment
 
     # Try the subclasses in reverse order so custom plugins come first
@@ -428,8 +430,7 @@ def get_environment_class(conf, python):
     for cls in classes:
         if cls.matches_python_fallback and cls.matches(python):
             return cls
-    raise EnvironmentUnavailable(
-        f"No way to create environment for python='{python}'")
+    raise EnvironmentUnavailable(f"No way to create environment for python='{python}'")
 
 
 def get_environment_class_by_name(environment_type):
@@ -439,8 +440,7 @@ def get_environment_class_by_name(environment_type):
     for cls in util.iter_subclasses(Environment):
         if cls.tool_name == environment_type:
             return cls
-    raise EnvironmentUnavailable(
-        f"Unknown environment type '{environment_type}'")
+    raise EnvironmentUnavailable(f"Unknown environment type '{environment_type}'")
 
 
 def is_existing_only(environments):
@@ -460,6 +460,7 @@ class Environment:
     version of Python and a set of dependencies for the benchmarked
     project.
     """
+
     tool_name = None
     matches_python_fallback = True
 
@@ -494,14 +495,13 @@ class Environment:
         self._repo_subdir = conf.repo_subdir
         self._install_timeout = conf.install_timeout  # GH391
         self._tagged_env_vars = tagged_env_vars
-        self._path = os.path.abspath(os.path.join(
-            self._env_dir, self.dir_name))
+        self._path = os.path.abspath(os.path.join(self._env_dir, self.dir_name))
         self._project = conf.project
 
         self._is_setup = False
 
         self._cache = build_cache.BuildCache(conf, self._path)
-        self._build_root = os.path.abspath(os.path.join(self._path, 'project'))
+        self._build_root = os.path.abspath(os.path.join(self._path, "project"))
 
         self._requirements = requirements
         if (Path.cwd() / "poetry.lock").exists():
@@ -515,42 +515,42 @@ class Environment:
         self._uninstall_command = conf.uninstall_command
 
         self._global_env_vars = {}
-        self._global_env_vars['ASV'] = 'true'
-        self._global_env_vars['ASV_PROJECT'] = conf.project
-        self._global_env_vars['ASV_CONF_DIR'] = os.path.abspath(os.getcwd())
-        self._global_env_vars['ASV_ENV_NAME'] = self.name
-        self._global_env_vars['ASV_ENV_DIR'] = self._path
-        self._global_env_vars['ASV_ENV_TYPE'] = self.tool_name
+        self._global_env_vars["ASV"] = "true"
+        self._global_env_vars["ASV_PROJECT"] = conf.project
+        self._global_env_vars["ASV_CONF_DIR"] = os.path.abspath(os.getcwd())
+        self._global_env_vars["ASV_ENV_NAME"] = self.name
+        self._global_env_vars["ASV_ENV_DIR"] = self._path
+        self._global_env_vars["ASV_ENV_TYPE"] = self.tool_name
 
         installed_commit_hash = self._get_installed_commit_hash()
         self._set_commit_hash(installed_commit_hash)
 
     def _set_commit_hash(self, commit_hash):
         if commit_hash is None:
-            self._global_env_vars.pop('ASV_COMMIT', None)
+            self._global_env_vars.pop("ASV_COMMIT", None)
         else:
-            self._global_env_vars['ASV_COMMIT'] = commit_hash
+            self._global_env_vars["ASV_COMMIT"] = commit_hash
 
     def _set_build_dirs(self, build_dir, cache_dir):
         if build_dir is None:
-            self._global_env_vars.pop('ASV_BUILD_DIR', None)
+            self._global_env_vars.pop("ASV_BUILD_DIR", None)
         else:
-            self._global_env_vars['ASV_BUILD_DIR'] = build_dir
+            self._global_env_vars["ASV_BUILD_DIR"] = build_dir
 
         if cache_dir is None:
-            self._global_env_vars.pop('ASV_BUILD_CACHE_DIR', None)
+            self._global_env_vars.pop("ASV_BUILD_CACHE_DIR", None)
         else:
-            self._global_env_vars['ASV_BUILD_CACHE_DIR'] = cache_dir
+            self._global_env_vars["ASV_BUILD_CACHE_DIR"] = cache_dir
 
     def _set_installed_commit_hash(self, commit_hash):
         # Save status
         install_checksum = self._get_install_checksum()
-        hash_file = os.path.join(self._path, 'asv-install-status.json')
-        data = {'commit_hash': commit_hash, 'install_checksum': install_checksum}
+        hash_file = os.path.join(self._path, "asv-install-status.json")
+        data = {"commit_hash": commit_hash, "install_checksum": install_checksum}
         util.write_json(hash_file, data, api_version=1)
 
     def _get_installed_commit_hash(self):
-        hash_file = os.path.join(self._path, 'asv-install-status.json')
+        hash_file = os.path.join(self._path, "asv-install-status.json")
 
         data = {}
         if os.path.isfile(hash_file):
@@ -561,18 +561,20 @@ class Environment:
 
         # If configuration changed, force reinstall
         install_checksum = self._get_install_checksum()
-        if data.get('install_checksum', None) != install_checksum:
+        if data.get("install_checksum", None) != install_checksum:
             return None
 
-        return data.get('commit_hash', None)
+        return data.get("commit_hash", None)
 
     def _get_install_checksum(self):
-        return [self._repo_subdir,
-                self._install_timeout,
-                self._project,
-                self._build_command,
-                self._install_command,
-                self._uninstall_command]
+        return [
+            self._repo_subdir,
+            self._install_timeout,
+            self._project,
+            self._build_command,
+            self._install_command,
+            self._uninstall_command,
+        ]
 
     @property
     def installed_commit_hash(self):
@@ -591,17 +593,16 @@ class Environment:
         """
         Get a name to uniquely identify this environment.
         """
-        return get_env_name(self.tool_name,
-                            self._python,
-                            self._requirements,
-                            self._tagged_env_vars)
+        return get_env_name(
+            self.tool_name, self._python, self._requirements, self._tagged_env_vars
+        )
 
     @property
     def hashname(self):
         """
         Get a hash to uniquely identify this environment.
         """
-        return hashlib.md5(self.name.encode('utf-8')).hexdigest()
+        return hashlib.md5(self.name.encode("utf-8")).hexdigest()
 
     @property
     def dir_name(self):
@@ -610,12 +611,10 @@ class Environment:
         This is not necessarily unique, and may be shared across
         different environments.
         """
-        name = get_env_name(self.tool_name,
-                            self._python,
-                            self._requirements,
-                            self._tagged_env_vars,
-                            build=True)
-        return hashlib.md5(name.encode('utf-8')).hexdigest()
+        name = get_env_name(
+            self.tool_name, self._python, self._requirements, self._tagged_env_vars, build=True
+        )
+        return hashlib.md5(name.encode("utf-8")).hexdigest()
 
     @property
     def requirements(self):
@@ -653,23 +652,23 @@ class Environment:
             return False
 
         expected_info = {
-            'tool_name': self.tool_name,
-            'python': self._python,
-            'requirements': self._requirements,
-            'build_env_vars': self.build_env_vars
+            "tool_name": self.tool_name,
+            "python": self._python,
+            "requirements": self._requirements,
+            "build_env_vars": self.build_env_vars,
         }
 
         if info != expected_info:
             return False
 
-        for executable in ['pip', 'python']:
+        for executable in ["pip", "python"]:
             try:
                 self.find_executable(executable)
             except IOError:
                 return False
 
         try:
-            self.run_executable('python', ['-c', 'pass'])
+            self.run_executable("python", ["-c", "pass"])
         except (subprocess.CalledProcessError, OSError):
             return False
 
@@ -750,21 +749,21 @@ class Environment:
         # lowercased without the prefix.
         kwargs = dict()
         for key, value in self._global_env_vars.items():
-            if key == 'ASV':
+            if key == "ASV":
                 continue
-            assert key.startswith('ASV_')
+            assert key.startswith("ASV_")
             interp_key = key[4:].lower()
             kwargs[interp_key] = value
 
         # There is an additional {wheel_file} interpolation variable
-        if 'build_cache_dir' in kwargs:
-            cache_dir = kwargs['build_cache_dir']
+        if "build_cache_dir" in kwargs:
+            cache_dir = kwargs["build_cache_dir"]
 
             if os.path.isdir(cache_dir):
                 files = os.listdir(cache_dir)
-                wheels = [fn for fn in files if fn.lower().endswith('.whl')]
+                wheels = [fn for fn in files if fn.lower().endswith(".whl")]
                 if len(wheels) == 1:
-                    kwargs['wheel_file'] = os.path.join(cache_dir, wheels[0])
+                    kwargs["wheel_file"] = os.path.join(cache_dir, wheels[0])
 
         # Interpolate, and raise useful error message if it fails
         return [util.interpolate_command(c, kwargs) for c in commands]
@@ -779,8 +778,14 @@ class Environment:
             environ.update(env)
             if cwd is None:
                 cwd = default_cwd
-            self.run_executable(cmd[0], cmd[1:], timeout=self._install_timeout, cwd=cwd,
-                                env=environ, valid_return_codes=return_codes)
+            self.run_executable(
+                cmd[0],
+                cmd[1:],
+                timeout=self._install_timeout,
+                cwd=cwd,
+                env=environ,
+                valid_return_codes=return_codes,
+            )
 
     def checkout_project(self, repo, commit_hash):
         """
@@ -846,8 +851,9 @@ class Environment:
         if cmd:
             commit_name = repo.get_decorated_hash(commit_hash, 8)
             log.info(f"Installing {commit_name} into {self.name}")
-            self._interpolate_and_run_commands(cmd, default_cwd=build_dir,
-                                               extra_env=self.build_env_vars)
+            self._interpolate_and_run_commands(
+                cmd, default_cwd=build_dir, extra_env=self.build_env_vars
+            )
 
     def _uninstall_project(self):
         """
@@ -860,12 +866,13 @@ class Environment:
         if cmd is None:
             # Run pip via python -m pip, avoids shebang length limit on Linux
             # pip uninstall may fail if not installed, so allow any exit code
-            cmd = ['return-code=any python -mpip uninstall -y {project}']
+            cmd = ["return-code=any python -mpip uninstall -y {project}"]
 
         if cmd:
             log.info(f"Uninstalling from {self.name}")
-            self._interpolate_and_run_commands(cmd, default_cwd=self._env_dir,
-                                               extra_env=self.build_env_vars)
+            self._interpolate_and_run_commands(
+                cmd, default_cwd=self._env_dir, extra_env=self.build_env_vars
+            )
 
     def _build_project(self, repo, commit_hash, build_dir):
         """
@@ -879,24 +886,29 @@ class Environment:
         cmd = self._build_command
 
         if cmd is None:
-            if has_file('pyproject.toml'):
+            if has_file("pyproject.toml"):
                 cmd = [
-                    ("PIP_NO_BUILD_ISOLATION=false "
-                     "python -mpip wheel --no-deps --no-index "
-                     "-w {build_cache_dir} {build_dir}")
+                    (
+                        "PIP_NO_BUILD_ISOLATION=false "
+                        "python -mpip wheel --no-deps --no-index "
+                        "-w {build_cache_dir} {build_dir}"
+                    )
                 ]
             else:
                 cmd = [
                     "python setup.py build",
-                    ("PIP_NO_BUILD_ISOLATION=false "
-                     "python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}")
+                    (
+                        "PIP_NO_BUILD_ISOLATION=false "
+                        "python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+                    ),
                 ]
 
         if cmd:
             commit_name = repo.get_decorated_hash(commit_hash, 8)
             log.info(f"Building {commit_name} for {self.name}")
-            self._interpolate_and_run_commands(cmd, default_cwd=build_dir,
-                                               extra_env=self.build_env_vars)
+            self._interpolate_and_run_commands(
+                cmd, default_cwd=build_dir, extra_env=self.build_env_vars
+            )
 
     def can_install_project(self):
         """
@@ -914,11 +926,13 @@ class Environment:
 
         # Assume standard virtualenv/Conda layout
         if WIN:
-            paths = [self._path,
-                     os.path.join(self._path, 'Scripts'),
-                     os.path.join(self._path, 'bin')]
+            paths = [
+                self._path,
+                os.path.join(self._path, "Scripts"),
+                os.path.join(self._path, "bin"),
+            ]
         else:
-            paths = [os.path.join(self._path, 'bin')]
+            paths = [os.path.join(self._path, "bin")]
 
         return util.which(executable, paths)
 
@@ -936,10 +950,7 @@ class Environment:
             paths = []
 
         if WIN:
-            subpaths = ['Library\\mingw-w64\\bin',
-                        'Library\\bin',
-                        'Library\\usr\\bin',
-                        'Scripts']
+            subpaths = ["Library\\mingw-w64\\bin", "Library\\bin", "Library\\usr\\bin", "Scripts"]
             for sub in subpaths[::-1]:
                 paths.insert(0, os.path.join(self._path, sub))
             paths.insert(0, self._path)
@@ -948,23 +959,21 @@ class Environment:
 
         # Discard PYTHONPATH, which can easily break the environment
         # isolation
-        if 'ASV_PYTHONPATH' in env:
-            env['PYTHONPATH'] = env['ASV_PYTHONPATH']
-            env.pop('ASV_PYTHONPATH', None)
+        if "ASV_PYTHONPATH" in env:
+            env["PYTHONPATH"] = env["ASV_PYTHONPATH"]
+            env.pop("ASV_PYTHONPATH", None)
         else:
-            env.pop('PYTHONPATH', None)
+            env.pop("PYTHONPATH", None)
 
         # When running pip, we need to set PIP_USER to false, as --user (which
         # may have been set from a pip config file) is incompatible with
         # virtualenvs.
-        kwargs["env"] = dict(env,
-                             PIP_USER=str("false"),
-                             PATH=str(os.pathsep.join(paths)))
+        kwargs["env"] = dict(env, PIP_USER=str("false"), PATH=str(os.pathsep.join(paths)))
         exe = self.find_executable(executable)
         return util.check_output([exe] + args, **kwargs)
 
     def load_info_file(self, path):
-        path = os.path.join(path, 'asv-env-info.json')
+        path = os.path.join(path, "asv-env-info.json")
         return util.load_json(path)
 
     def save_info_file(self, path):
@@ -972,12 +981,12 @@ class Environment:
         Save a file with information about the environment into
         directory `path`.
         """
-        path = os.path.join(path, 'asv-env-info.json')
+        path = os.path.join(path, "asv-env-info.json")
         content = {
-            'tool_name': self.tool_name,
-            'python': self._python,
-            'requirements': self._requirements,
-            'build_env_vars': self.build_env_vars
+            "tool_name": self.tool_name,
+            "python": self._python,
+            "requirements": self._requirements,
+            "build_env_vars": self.build_env_vars,
         }
         util.write_json(path, content)
 
@@ -986,29 +995,28 @@ class ExistingEnvironment(Environment):
     tool_name = "existing"
 
     def __init__(self, conf, executable, requirements, tagged_env_vars):
-        if executable == 'same':
+        if executable == "same":
             executable = sys.executable
 
         try:
             executable = os.path.abspath(util.which(executable))
 
             self._python = util.check_output(
-                [executable,
-                 '-c',
-                 'import sys; '
-                 'print(str(sys.version_info[0]) + "." + str(sys.version_info[1]))'
-                 ]).strip()
+                [
+                    executable,
+                    "-c",
+                    "import sys; "
+                    'print(str(sys.version_info[0]) + "." + str(sys.version_info[1]))',
+                ]
+            ).strip()
         except (util.ProcessError, OSError, IOError):
             raise EnvironmentUnavailable()
 
         self._executable = executable
         self._requirements = {}
 
-        super(ExistingEnvironment, self).__init__(conf,
-                                                  executable,
-                                                  requirements,
-                                                  tagged_env_vars)
-        self._global_env_vars.pop('ASV_ENV_DIR')
+        super(ExistingEnvironment, self).__init__(conf, executable, requirements, tagged_env_vars)
+        self._global_env_vars.pop("ASV_ENV_DIR")
 
     @property
     def installed_commit_hash(self):
@@ -1016,7 +1024,7 @@ class ExistingEnvironment(Environment):
 
     @classmethod
     def matches(cls, python):
-        if python == 'same':
+        if python == "same":
             python = sys.executable
 
         try:
@@ -1028,10 +1036,9 @@ class ExistingEnvironment(Environment):
 
     @property
     def name(self):
-        return get_env_name(self.tool_name,
-                            self._executable.replace(os.path.sep, '_'),
-                            {},
-                            self._tagged_env_vars)
+        return get_env_name(
+            self.tool_name, self._executable.replace(os.path.sep, "_"), {}, self._tagged_env_vars
+        )
 
     def check_presence(self):
         return True
@@ -1050,5 +1057,4 @@ class ExistingEnvironment(Environment):
 
     def run(self, args, **kwargs):
         log.debug(f"Running '{' '.join(args)}' in {self.name}")
-        return util.check_output([
-            self._executable] + args, **kwargs)
+        return util.check_output([self._executable] + args, **kwargs)

--- a/asv/feed.py
+++ b/asv/feed.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as etree
 
 from . import util
 
-__all__ = ['FeedEntry', 'write_atom']
+__all__ = ["FeedEntry", "write_atom"]
 
 
 ATOM_NS = "{http://www.w3.org/2005/Atom}"
@@ -39,6 +39,7 @@ class FeedEntry:
         Default: same as *updated*
 
     """
+
     def __init__(self, title, updated, link=None, content=None, id_context=None, id_date=None):
         self.title = title
         self.link = link
@@ -48,7 +49,7 @@ class FeedEntry:
         self.id_date = id_date
 
     def get_atom(self, id_prefix, language):
-        item = etree.Element(ATOM_NS + 'entry')
+        item = etree.Element(ATOM_NS + "entry")
 
         id_context = ["entry"]
         if self.id_context is None:
@@ -61,38 +62,37 @@ class FeedEntry:
         else:
             id_date = self.id_date
 
-        el = etree.Element(ATOM_NS + 'id')
+        el = etree.Element(ATOM_NS + "id")
         el.text = _get_id(id_prefix, id_date, id_context)
         item.append(el)
 
-        el = etree.Element(ATOM_NS + 'title')
-        el.attrib[XML_NS + 'lang'] = language
+        el = etree.Element(ATOM_NS + "title")
+        el.attrib[XML_NS + "lang"] = language
         el.text = self.title
         item.append(el)
 
-        el = etree.Element(ATOM_NS + 'updated')
-        el.text = self.updated.strftime('%Y-%m-%dT%H:%M:%SZ')
+        el = etree.Element(ATOM_NS + "updated")
+        el.text = self.updated.strftime("%Y-%m-%dT%H:%M:%SZ")
         item.append(el)
 
         if self.link:
-            el = etree.Element(ATOM_NS + 'link')
-            el.attrib[ATOM_NS + 'href'] = self.link
+            el = etree.Element(ATOM_NS + "link")
+            el.attrib[ATOM_NS + "href"] = self.link
             item.append(el)
 
-        el = etree.Element(ATOM_NS + 'content')
-        el.attrib[XML_NS + 'lang'] = language
+        el = etree.Element(ATOM_NS + "content")
+        el.attrib[XML_NS + "lang"] = language
         if self.content:
             el.text = self.content
-            el.attrib[ATOM_NS + 'type'] = 'html'
+            el.attrib[ATOM_NS + "type"] = "html"
         else:
-            el.text = ' '
+            el.text = " "
         item.append(el)
 
         return item
 
 
-def write_atom(dest, entries, author, title, address, updated=None, link=None,
-               language="en"):
+def write_atom(dest, entries, author, title, address, updated=None, link=None, language="en"):
     """
     Write an atom feed to a file.
 
@@ -123,35 +123,35 @@ def write_atom(dest, entries, author, title, address, updated=None, link=None,
         else:
             updated = datetime.datetime.utcnow()
 
-    root = etree.Element(ATOM_NS + 'feed')
+    root = etree.Element(ATOM_NS + "feed")
 
     # id (obligatory)
-    el = etree.Element(ATOM_NS + 'id')
+    el = etree.Element(ATOM_NS + "id")
     el.text = _get_id(address, None, ["feed", author, title])
     root.append(el)
 
     # author (obligatory)
-    el = etree.Element(ATOM_NS + 'author')
-    el2 = etree.Element(ATOM_NS + 'name')
+    el = etree.Element(ATOM_NS + "author")
+    el2 = etree.Element(ATOM_NS + "name")
     el2.text = author
     el.append(el2)
     root.append(el)
 
     # title (obligatory)
-    el = etree.Element(ATOM_NS + 'title')
-    el.attrib[XML_NS + 'lang'] = language
+    el = etree.Element(ATOM_NS + "title")
+    el.attrib[XML_NS + "lang"] = language
     el.text = title
     root.append(el)
 
     # updated (obligatory)
-    el = etree.Element(ATOM_NS + 'updated')
-    el.text = updated.strftime('%Y-%m-%dT%H:%M:%SZ')
+    el = etree.Element(ATOM_NS + "updated")
+    el.text = updated.strftime("%Y-%m-%dT%H:%M:%SZ")
     root.append(el)
 
     # link
     if link is not None:
-        el = etree.Element(ATOM_NS + 'link')
-        el.attrib[ATOM_NS + 'href'] = link
+        el = etree.Element(ATOM_NS + "link")
+        el.attrib[ATOM_NS + "href"] = link
         root.append(el)
 
     # entries
@@ -163,10 +163,10 @@ def write_atom(dest, entries, author, title, address, updated=None, link=None,
     def write(f):
         tree.write(f, xml_declaration=True, default_namespace=ATOM_NS[1:-1], encoding="utf-8")
 
-    if hasattr(dest, 'write'):
+    if hasattr(dest, "write"):
         write(dest)
     else:
-        with util.long_path_open(dest, 'wb') as f:
+        with util.long_path_open(dest, "wb") as f:
             write(f)
 
 
@@ -176,13 +176,13 @@ def _get_id(owner, date, content):
     """
     h = hashlib.sha256()
     # Hash still contains the original project url, keep as is
-    h.update("github.com/spacetelescope/asv".encode('utf-8'))
+    h.update("github.com/spacetelescope/asv".encode("utf-8"))
     for x in content:
         if x is None:
-            h.update(",".encode('utf-8'))
+            h.update(",".encode("utf-8"))
         else:
-            h.update(x.encode('utf-8'))
-        h.update(",".encode('utf-8'))
+            h.update(x.encode("utf-8"))
+        h.update(",".encode("utf-8"))
 
     if date is None:
         date = datetime.datetime(1970, 1, 1)

--- a/asv/graph.py
+++ b/asv/graph.py
@@ -12,7 +12,7 @@ from .util import is_na, mean_na, geom_mean_na
 # a recent Retina MacBook Pro (3840 pixels across the screen, divided
 # by 5 summaries across, divided by 2 for good measure and to account
 # for width of the line).
-RESAMPLED_POINTS = (3840 / 5 / 2)
+RESAMPLED_POINTS = 3840 / 5 / 2
 
 
 class GraphSet:
@@ -81,6 +81,7 @@ class Graph:
     Unlike "results", which contain the timings for a single commit,
     these contain the timings for a single benchmark.
     """
+
     def __init__(self, benchmark_name, params):
         """
         Initially the graph contains no data.  It must be added using
@@ -118,14 +119,14 @@ class Graph:
         l = list(params.items())
         for key, val in l:
             if val is None:
-                part = f'{key}-null'
+                part = f"{key}-null"
             elif val:
-                part = f'{key}-{val}'
+                part = f"{key}-{val}"
             else:
-                part = f'{key}'
+                part = f"{key}"
             parts.append(util.sanitize_filename(part))
         parts.sort()
-        parts.insert(0, 'graphs')
+        parts.insert(0, "graphs")
         parts.append(util.sanitize_filename(benchmark_name))
         return os.path.join(*parts)
 
@@ -149,7 +150,7 @@ class Graph:
         self.data_points.setdefault(revision, [])
         self.data_weights.setdefault(revision, [])
         if not is_na(value):
-            if not hasattr(value, '__len__'):
+            if not hasattr(value, "__len__"):
                 value = [value]
                 weight = [weight]
             else:
@@ -178,8 +179,7 @@ class Graph:
         def mean_axis0(v):
             if not v:
                 return [None] * self.n_series
-            return [mean_na(x[j] for x in v)
-                    for j in range(self.n_series)]
+            return [mean_na(x[j] for x in v) for j in range(self.n_series)]
 
         # Average data over commit log
         val = []
@@ -203,7 +203,7 @@ class Graph:
             if any(not is_na(v) for v in val[j][1]):
                 break
 
-        val = val[i:j + 1]
+        val = val[i : j + 1]
 
         # Single-element series
         if self.scalar_series:
@@ -318,7 +318,7 @@ def make_summary_graph(graphs):
     val = resample_data(val)
 
     # Return as a graph
-    graph = Graph(graphs[0].benchmark_name, {'summary': ''})
+    graph = Graph(graphs[0].benchmark_name, {"summary": ""})
     for x, y in val:
         graph.add_data_point(x, y)
     return graph
@@ -380,8 +380,7 @@ def _fill_missing_data(y, max_gap_fraction=0.1):
             if 0 < gap_size <= max_gap_size and not is_na(prev):
                 # Interpolate gap
                 for k in range(1, gap_size + 1):
-                    filled[prev_idx + k] = (
-                        v * k + (gap_size + 1 - k) * prev) / (gap_size + 1)
+                    filled[prev_idx + k] = (v * k + (gap_size + 1 - k) * prev) / (gap_size + 1)
 
             prev = v
             prev_idx = i

--- a/asv/machine.py
+++ b/asv/machine.py
@@ -16,7 +16,7 @@ def iter_machine_files(results_dir):
     """
     for root, dirs, files in os.walk(results_dir):
         for filename in files:
-            if filename == 'machine.json':
+            if filename == "machine.json":
                 path = os.path.join(root, filename)
                 yield path
 
@@ -31,11 +31,12 @@ class MachineCollection:
     Stores information about 1 or more machines in the
     ~/.asv-machine.json file.
     """
+
     api_version = 1
 
     @staticmethod
     def get_machine_file_path():
-        return os.path.expanduser('~/.asv-machine.json')
+        return os.path.expanduser("~/.asv-machine.json")
 
     @classmethod
     def load(cls, machine_name, _path=None):
@@ -54,7 +55,8 @@ class MachineCollection:
 
         raise util.UserError(
             f"No information stored about machine '{machine_name}'. "
-            f"I know about {util.human_list(d.keys())}.")
+            f"I know about {util.human_list(d.keys())}."
+        )
 
     @classmethod
     def save(cls, machine_name, machine_info, _path=None):
@@ -83,11 +85,13 @@ class Machine:
     """
     Stores information about a particular machine.
     """
+
     api_version = 1
 
     fields = [
-        ("machine",
-         """
+        (
+            "machine",
+            """
          A unique name to identify this machine in the results.  May
          be anything, as long as it is unique across all the machines used
          to benchmark this project.
@@ -95,33 +99,39 @@ class Machine:
          NOTE: If changed from the default, it will no longer match
          the hostname of this machine, and you may need to explicitly
          use the --machine argument to asv.
-         """),
-
-        ("os",
-         """
+         """,
+        ),
+        (
+            "os",
+            """
          The OS type and version of this machine.  For example,
-         'Macintosh OS-X 10.8'."""),
-
-        ("arch",
-         """
+         'Macintosh OS-X 10.8'.""",
+        ),
+        (
+            "arch",
+            """
          The generic CPU architecture of this machine.  For
-         example, 'i386' or 'x86_64'."""),
-
-        ("cpu",
-         """
+         example, 'i386' or 'x86_64'.""",
+        ),
+        (
+            "cpu",
+            """
          A specific description of the CPU of this machine,
          including its speed and class.  For example, 'Intel(R)
-         Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)'."""),
-
-        ("num_cpu",
-         """
+         Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)'.""",
+        ),
+        (
+            "num_cpu",
+            """
          The number of CPUs in the system. For example,
-         '4'."""),
-
-        ("ram",
-         """
+         '4'.""",
+        ),
+        (
+            "ram",
+            """
          The amount of physical RAM on this machine.  For example,
-         '4GB'.""")
+         '4GB'.""",
+        ),
     ]
 
     hardcoded_machine_name = None
@@ -143,25 +153,28 @@ class Machine:
         num_cpu = str(mp.cpu_count())
 
         return {
-            'machine': node,
-            'os': f"{system} {release}",
-            'num_cpu': num_cpu,
-            'arch': platform.machine(),
-            'cpu': cpu,
-            'ram': ram}
+            "machine": node,
+            "os": f"{system} {release}",
+            "num_cpu": num_cpu,
+            "arch": platform.machine(),
+            "cpu": cpu,
+            "ram": ram,
+        }
 
     @staticmethod
     def generate_machine_file(use_defaults=False):
         if not sys.stdout.isatty() and not use_defaults and not log._colorama:
             raise util.UserError(
                 "Run asv at the console the first time to generate "
-                "one, or run `asv machine --yes`.")
+                "one, or run `asv machine --yes`."
+            )
 
         log.flush()
 
         color_print(
             "I will now ask you some questions about this machine to "
-            "identify it in the benchmarks.")
+            "identify it in the benchmarks."
+        )
         color_print("")
 
         defaults = Machine.get_defaults()
@@ -170,16 +183,25 @@ class Machine:
         for i, (name, description) in enumerate(Machine.fields):
             print(
                 textwrap.fill(
-                    f'{i + 1}. {name}: {textwrap.dedent(description)}',
-                    subsequent_indent='   '))
-            values[name] = console.get_answer_default(name, defaults[name],
-                                                      use_defaults=use_defaults)
+                    f"{i + 1}. {name}: {textwrap.dedent(description)}", subsequent_indent="   "
+                )
+            )
+            values[name] = console.get_answer_default(
+                name, defaults[name], use_defaults=use_defaults
+            )
 
         return values
 
     @classmethod
-    def load(cls, interactive=False, force_interactive=False, _path=None,
-             machine_name=None, use_defaults=False, **kwargs):
+    def load(
+        cls,
+        interactive=False,
+        force_interactive=False,
+        _path=None,
+        machine_name=None,
+        use_defaults=False,
+        **kwargs,
+    ):
         self = Machine()
 
         if machine_name is None:
@@ -187,20 +209,20 @@ class Machine:
         try:
             d = MachineCollection.load(machine_name, _path=_path)
         except util.UserError as e:
-            console.log.error(str(e) + '\n')
+            console.log.error(str(e) + "\n")
             d = {}
         d.update(kwargs)
         if (not len(d) and interactive) or force_interactive:
             d.update(self.generate_machine_file(use_defaults=use_defaults))
 
-        machine_name = d['machine']
+        machine_name = d["machine"]
 
         self.__dict__.update(d)
         MachineCollection.save(machine_name, self.__dict__, _path=_path)
         return self
 
     def save(self, results_dir):
-        path = os.path.join(results_dir, self.machine, 'machine.json')
+        path = os.path.join(results_dir, self.machine, "machine.json")
         util.write_json(path, self.__dict__, self.api_version)
 
     @classmethod

--- a/asv/main.py
+++ b/asv/main.py
@@ -12,7 +12,7 @@ def main():
 
     args = parser.parse_args()
 
-    if not hasattr(args, 'func'):
+    if not hasattr(args, "func"):
         parser.print_help()
         sys.exit(1)
 

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -33,19 +33,18 @@ class Git(Repo):
 
             # Clone is missing
             log.info("Cloning project")
-            self._run_git(['clone', '--mirror', url, self._path], cwd=None)
+            self._run_git(["clone", "--mirror", url, self._path], cwd=None)
 
     @classmethod
     def is_local_repo(cls, path):
         return os.path.isdir(path) and (
-            os.path.exists(os.path.join(path, '.git')) or
-            os.path.isdir(os.path.join(path, 'objects')))
+            os.path.exists(os.path.join(path, ".git"))
+            or os.path.isdir(os.path.join(path, "objects"))
+        )
 
     @classmethod
     def url_match(cls, url):
-        regexes = [
-            r'^https?://.*?\.git$',
-            r'^git@.*?\.git$']
+        regexes = [r"^https?://.*?\.git$", r"^git@.*?\.git$"]
 
         for regex in regexes:
             if re.match(regex, url):
@@ -60,20 +59,21 @@ class Git(Repo):
     def _run_git(self, args, cwd=True, **kwargs):
         if cwd is True:
             cwd = self._path
-        kwargs['cwd'] = cwd
-        env = dict(kwargs.pop('env', os.environ))
+        kwargs["cwd"] = cwd
+        env = dict(kwargs.pop("env", os.environ))
         if cwd is not None:
-            prev = env.get('GIT_CEILING_DIRECTORIES')
-            env['GIT_CEILING_DIRECTORIES'] = os.pathsep.join(
-                [os.path.join(os.path.abspath(cwd), os.pardir)] +
-                ([prev] if prev is not None else []))
+            prev = env.get("GIT_CEILING_DIRECTORIES")
+            env["GIT_CEILING_DIRECTORIES"] = os.pathsep.join(
+                [os.path.join(os.path.abspath(cwd), os.pardir)]
+                + ([prev] if prev is not None else [])
+            )
         return util.check_output([self._git] + args, env=env, **kwargs)
 
     def get_new_range_spec(self, latest_result, branch=None):
-        return f'{latest_result}..{self.get_branch_name(branch)}'
+        return f"{latest_result}..{self.get_branch_name(branch)}"
 
     def get_range_spec(self, commit_a, commit_b):
-        return f'{commit_a}..{commit_b}'
+        return f"{commit_a}..{commit_b}"
 
     def pull(self):
         # We assume the remote isn't updated during the run of asv
@@ -82,22 +82,32 @@ class Git(Repo):
             return
 
         log.info("Fetching recent changes")
-        self._run_git(['fetch', 'origin'])
+        self._run_git(["fetch", "origin"])
         self._pulled = True
 
     def checkout(self, path, commit_hash):
         def checkout_existing(display_error):
             # Deinit fails if no submodules, so ignore its failure
-            self._run_git(['-c', 'protocol.file.allow=always',
-                           'submodule', 'deinit', '-f', '.'],
-                          cwd=path, display_error=False, valid_return_codes=None)
-            self._run_git(['checkout', '-f', commit_hash],
-                          cwd=path, display_error=display_error)
-            self._run_git(['clean', '-fdx'],
-                          cwd=path, display_error=display_error)
-            self._run_git(['-c', 'protocol.file.allow=always',
-                           'submodule', 'update', '--init', '--recursive'],
-                          cwd=path, display_error=display_error)
+            self._run_git(
+                ["-c", "protocol.file.allow=always", "submodule", "deinit", "-f", "."],
+                cwd=path,
+                display_error=False,
+                valid_return_codes=None,
+            )
+            self._run_git(["checkout", "-f", commit_hash], cwd=path, display_error=display_error)
+            self._run_git(["clean", "-fdx"], cwd=path, display_error=display_error)
+            self._run_git(
+                [
+                    "-c",
+                    "protocol.file.allow=always",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--recursive",
+                ],
+                cwd=path,
+                display_error=display_error,
+            )
 
         if os.path.isdir(path):
             try:
@@ -107,17 +117,25 @@ class Git(Repo):
                 util.long_path_rmtree(path)
 
         if not os.path.isdir(path):
-            self._run_git(['clone', '--shared', '--recursive', self._path, path],
-                          cwd=None)
+            self._run_git(["clone", "--shared", "--recursive", self._path, path], cwd=None)
             checkout_existing(display_error=True)
 
     def get_date(self, hash):
-        return int(self._run_git(
-            ['rev-list', '-n', '1', '--format=%at', hash],
-            valid_return_codes=(0, 1), dots=False).strip().split()[-1]) * 1000
+        return (
+            int(
+                self._run_git(
+                    ["rev-list", "-n", "1", "--format=%at", hash],
+                    valid_return_codes=(0, 1),
+                    dots=False,
+                )
+                .strip()
+                .split()[-1]
+            )
+            * 1000
+        )
 
     def get_hashes_from_range(self, range_spec):
-        args = ['rev-list', '--first-parent']
+        args = ["rev-list", "--first-parent"]
         if range_spec != "":
             args += shlex.split(range_spec)
         output = self._run_git(args, valid_return_codes=(0, 1), dots=False)
@@ -128,12 +146,14 @@ class Git(Repo):
             name = self.get_branch_name()
 
         # In case of annotated tags, return the hash for the commit
-        lookup_name = name + '^{commit}'
+        lookup_name = name + "^{commit}"
 
         try:
-            return self._run_git(['rev-parse', lookup_name],
-                                 display_error=False,
-                                 dots=False).strip().split()[0]
+            return (
+                self._run_git(["rev-parse", lookup_name], display_error=False, dots=False)
+                .strip()
+                .split()[0]
+            )
         except util.ProcessError as err:
             if err.stdout.strip() == lookup_name:
                 # Name does not exist
@@ -141,14 +161,14 @@ class Git(Repo):
             raise
 
     def get_hash_from_parent(self, name):
-        return self.get_hash_from_name(name + '^')
+        return self.get_hash_from_name(name + "^")
 
     def get_name_from_hash(self, commit):
         try:
-            name = self._run_git(["name-rev", "--name-only",
-                                  "--exclude=remotes/*",
-                                  "--no-undefined", commit],
-                                 display_error=False).strip()
+            name = self._run_git(
+                ["name-rev", "--name-only", "--exclude=remotes/*", "--no-undefined", commit],
+                display_error=False,
+            ).strip()
             if not name:
                 return None
         except util.ProcessError:
@@ -156,9 +176,9 @@ class Git(Repo):
             return None
 
         # Return tags without prefix
-        for prefix in ['tags/']:
+        for prefix in ["tags/"]:
             if name.startswith(prefix):
-                return name[len(prefix):]
+                return name[len(prefix) :]
 
         return name
 
@@ -176,9 +196,16 @@ class Git(Repo):
 
     def get_revisions(self, commits):
         revisions = {}
-        for i, commit in enumerate(self._run_git([
-            "rev-list", "--all", "--date-order", "--reverse",
-        ]).splitlines()):
+        for i, commit in enumerate(
+            self._run_git(
+                [
+                    "rev-list",
+                    "--all",
+                    "--date-order",
+                    "--reverse",
+                ]
+            ).splitlines()
+        ):
             if commit in commits:
                 revisions[commit] = i
         return revisions

--- a/asv/plugins/github.py
+++ b/asv/plugins/github.py
@@ -12,20 +12,26 @@ class GithubPages(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
         parser = subparsers.add_parser(
-            "gh-pages", help="Publish the results to Github pages",
+            "gh-pages",
+            help="Publish the results to Github pages",
             description="""
             Publish the results to github pages
 
             Updates the 'gh-pages' branch in the current repository,
             and pushes it to 'origin'.
-            """)
+            """,
+        )
         parser.add_argument(
-            "--no-push", action="store_true",
-            help="Update local gh-pages branch but don't push")
+            "--no-push", action="store_true", help="Update local gh-pages branch but don't push"
+        )
         parser.add_argument(
-            "--rewrite", action="store_true",
-            help=("Rewrite gh-pages branch to contain only a single commit, "
-                  "instead of adding a new commit"))
+            "--rewrite",
+            action="store_true",
+            help=(
+                "Rewrite gh-pages branch to contain only a single commit, "
+                "instead of adding a new commit"
+            ),
+        )
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -37,7 +43,7 @@ class GithubPages(Command):
 
     @classmethod
     def run(cls, conf, no_push, rewrite):
-        git = util.which('git')
+        git = util.which("git")
 
         # Publish
         Publish.run(conf)
@@ -47,49 +53,54 @@ class GithubPages(Command):
         log.info("Updating gh-pages branch")
         try:
             # Create new repo for the html data
-            util.check_call([git, 'init'], cwd=conf.html_dir)
-            util.check_call([git, 'checkout', '-b', 'gh-pages'], cwd=conf.html_dir)
+            util.check_call([git, "init"], cwd=conf.html_dir)
+            util.check_call([git, "checkout", "-b", "gh-pages"], cwd=conf.html_dir)
 
             if not rewrite:
                 # Fetch the old branch
-                _, _, retcode = util.check_output([git, 'fetch', cwd, 'gh-pages'],
-                                                  cwd=conf.html_dir,
-                                                  return_stderr=True,
-                                                  valid_return_codes=None)
+                _, _, retcode = util.check_output(
+                    [git, "fetch", cwd, "gh-pages"],
+                    cwd=conf.html_dir,
+                    return_stderr=True,
+                    valid_return_codes=None,
+                )
                 if retcode == 0:
-                    util.check_call([git, 'reset', '--soft', 'FETCH_HEAD'], cwd=conf.html_dir)
+                    util.check_call([git, "reset", "--soft", "FETCH_HEAD"], cwd=conf.html_dir)
 
             # We need to tell github this is not a Jekyll document
-            with open(os.path.join(conf.html_dir, '.nojekyll'), 'wb') as fd:
-                fd.write(b'\n')
+            with open(os.path.join(conf.html_dir, ".nojekyll"), "wb") as fd:
+                fd.write(b"\n")
 
             # Add all files
-            util.check_call([git, 'add', '--all', '.'], cwd=conf.html_dir)
+            util.check_call([git, "add", "--all", "."], cwd=conf.html_dir)
 
             # Commit (if needed)
-            _, _, retcode = util.check_output([git, "diff-index", "--quiet", "HEAD", "--"],
-                                              cwd=conf.html_dir,
-                                              return_stderr=True,
-                                              valid_return_codes=None)
+            _, _, retcode = util.check_output(
+                [git, "diff-index", "--quiet", "HEAD", "--"],
+                cwd=conf.html_dir,
+                return_stderr=True,
+                valid_return_codes=None,
+            )
             if retcode != 0:
-                util.check_call([git, 'commit', '-m', 'Generated from sources'], cwd=conf.html_dir)
+                util.check_call([git, "commit", "-m", "Generated from sources"], cwd=conf.html_dir)
 
             # Fetch branch here
             if rewrite:
-                util.check_call([git, 'fetch', os.path.abspath(conf.html_dir)])
-                util.check_call([git, 'branch', '-f', 'gh-pages', 'FETCH_HEAD'])
+                util.check_call([git, "fetch", os.path.abspath(conf.html_dir)])
+                util.check_call([git, "branch", "-f", "gh-pages", "FETCH_HEAD"])
             else:
-                util.check_call([git, 'fetch', os.path.abspath(conf.html_dir),
-                                 'gh-pages:gh-pages'])
+                util.check_call(
+                    [git, "fetch", os.path.abspath(conf.html_dir), "gh-pages:gh-pages"]
+                )
         finally:
             # Cleanup the child repo under html
-            util.long_path_rmtree(os.path.join(conf.html_dir, '.git'))
+            util.long_path_rmtree(os.path.join(conf.html_dir, ".git"))
 
         # Push branch
         if not no_push:
             if rewrite:
                 log.info("Force-pushing gh-pages branch")
-                util.check_call([git, 'push', '-f', 'origin', 'gh-pages'])
+                util.check_call([git, "push", "-f", "origin", "gh-pages"])
             else:
                 log.info("Pushing gh-pages branch")
-                util.check_call([git, 'push', 'origin', 'gh-pages'])
+                util.check_call([git, "push", "origin", "gh-pages"])

--- a/asv/plugins/kcachegrind.py
+++ b/asv/plugins/kcachegrind.py
@@ -4,18 +4,15 @@ from .. import profiling, util
 
 
 class KCachegrindGui(profiling.ProfilerGui):
-    name = 'kcachegrind'
+    name = "kcachegrind"
     description = "kcachegrind through pyprof2calltree"
 
     @classmethod
     def is_available(cls):
-        return (
-            util.has_command("kcachegrind") and
-            util.has_command("pyprof2calltree"))
+        return util.has_command("kcachegrind") and util.has_command("pyprof2calltree")
 
     @classmethod
     def open_profiler_gui(cls, profiler_file):
         command = util.which("pyprof2calltree")
 
-        return util.check_call(
-            [command, '-i', profiler_file, '-k'], timeout=None)
+        return util.check_call([command, "-i", profiler_file, "-k"], timeout=None)

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -71,7 +71,7 @@ class Mamba(environment.Environment):
 
     @classmethod
     def _matches(cls, python):
-        if not re.match(r'^[0-9].*$', python):
+        if not re.match(r"^[0-9].*$", python):
             return False
         else:
             mamba_path = str(Path(os.getenv("CONDA_EXE")).parent / "mamba")
@@ -91,9 +91,7 @@ class Mamba(environment.Environment):
         if not self._mamba_environment_file:
             # Construct payload, env file sets python version
             mamba_pkgs = [f"python={self._python}", "wheel", "pip"] + mamba_args
-            solver = MambaSolver(
-                self._mamba_channels, None, self.context  # or target_platform
-            )
+            solver = MambaSolver(self._mamba_channels, None, self.context)  # or target_platform
 
             with _mamba_lock():
                 transaction = solver.solve(mamba_pkgs)
@@ -112,9 +110,7 @@ class Mamba(environment.Environment):
                     ["env", "create", "-f", env_file_name, "-p", self._path, "--force"],
                     env=env,
                 )
-            solver = MambaSolver(
-                self._mamba_channels, None, self.context  # or target_platform
-            )
+            solver = MambaSolver(self._mamba_channels, None, self.context)  # or target_platform
             with _mamba_lock():
                 transaction = solver.solve(mamba_pkgs + mamba_args)
                 transaction.execute(libmambapy.PrefixData(self._path))

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -50,9 +50,9 @@ class Hg(Repo):
 
             # Mercurial branches are global, so there is no need for
             # an analog of git --mirror
-            hglib.clone(self._encode_filename(url),
-                        dest=self._encode_filename(self._path),
-                        noupdate=True)
+            hglib.clone(
+                self._encode_filename(url), dest=self._encode_filename(self._path), noupdate=True
+            )
 
         self._repo = hglib.open(self._encode_filename(self._path))
 
@@ -72,15 +72,11 @@ class Hg(Repo):
 
     @classmethod
     def is_local_repo(cls, path):
-        return (os.path.isdir(path) and
-                os.path.isdir(os.path.join(path, '.hg')))
+        return os.path.isdir(path) and os.path.isdir(os.path.join(path, ".hg"))
 
     @classmethod
     def url_match(cls, url):
-        regexes = [
-            r'^hg\+https?://.*$',
-            r'^https?://.*?\.hg$',
-            r'^ssh://hg@.*$']
+        regexes = [r"^hg\+https?://.*$", r"^https?://.*?\.hg$", r"^ssh://hg@.*$"]
 
         for regex in regexes:
             if re.match(regex, url):
@@ -93,10 +89,10 @@ class Hg(Repo):
         return False
 
     def get_range_spec(self, commit_a, commit_b):
-        return '{0}::{1} and not {0}'.format(commit_a, commit_b)
+        return "{0}::{1} and not {0}".format(commit_a, commit_b)
 
     def get_new_range_spec(self, latest_result, branch=None):
-        return f'{latest_result}::{self.get_branch_name(branch)}'
+        return f"{latest_result}::{self.get_branch_name(branch)}"
 
     def pull(self):
         # We assume the remote isn't updated during the run of asv
@@ -116,10 +112,7 @@ class Hg(Repo):
             with hglib.open(self._encode_filename(path)) as subrepo:
                 subrepo.pull()
                 subrepo.update(self._encode(commit_hash), clean=True)
-                subrepo.rawcommand([b"--config",
-                                    b"extensions.purge=",
-                                    b"purge",
-                                    b"--all"])
+                subrepo.rawcommand([b"--config", b"extensions.purge=", b"purge", b"--all"])
 
         if os.path.isdir(path):
             try:
@@ -129,8 +122,7 @@ class Hg(Repo):
                 util.long_path_rmtree(path)
 
         if not os.path.isdir(path):
-            hglib.clone(self._encode_filename(self._path),
-                        dest=self._encode_filename(path))
+            hglib.clone(self._encode_filename(self._path), dest=self._encode_filename(path))
             checkout_existing()
 
     def get_date(self, hash):
@@ -148,12 +140,12 @@ class Hg(Repo):
         try:
             return self._decode(self._repo.log(self._encode(name))[0].node)
         except hglib.error.CommandError as err:
-            if b'unknown revision' in err.err:
+            if b"unknown revision" in err.err:
                 raise NoSuchNameError(name)
             raise
 
     def get_hash_from_parent(self, name):
-        return self.get_hash_from_name(f'p1({name})')
+        return self.get_hash_from_name(f"p1({name})")
 
     def get_name_from_hash(self, commit):
         # XXX: implement
@@ -173,8 +165,9 @@ class Hg(Repo):
             query = "branch({0})"
         else:
             query = "ancestors({0})"
-        return self.get_hashes_from_range(query.format(self.get_branch_name(branch)),
-                                          followfirst=True)
+        return self.get_hashes_from_range(
+            query.format(self.get_branch_name(branch)), followfirst=True
+        )
 
     def get_revisions(self, commits):
         revisions = {}

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -31,7 +31,7 @@ class Regressions(OutputPublisher):
         all_params = graphs.get_params()
 
         for j, (file_name, graph) in enumerate(graphs):
-            if 'summary' in graph.params:
+            if "summary" in graph.params:
                 continue
 
             benchmark_name = os.path.basename(file_name)
@@ -42,15 +42,17 @@ class Regressions(OutputPublisher):
             log.dot()
 
             for graph_data in data_filter.get_graph_data(graph, benchmark):
-                cls._process_regression(regressions, revision_to_hash, repo, all_params,
-                                        graph_data, graph)
+                cls._process_regression(
+                    regressions, revision_to_hash, repo, all_params, graph_data, graph
+                )
 
-        cls._save(conf, {'regressions': regressions})
+        cls._save(conf, {"regressions": regressions})
         cls._save_feed(conf, benchmarks, regressions, revisions, revision_to_hash)
 
     @classmethod
-    def _process_regression(cls, regressions, revision_to_hash, repo,
-                            all_params, graph_data, graph):
+    def _process_regression(
+        cls, regressions, revision_to_hash, repo, all_params, graph_data, graph
+    ):
         j, entry_name, steps, threshold = graph_data
 
         last_v, best_v, jumps = detect_regressions(steps, threshold)
@@ -64,7 +66,7 @@ class Regressions(OutputPublisher):
             if len(all_params[name]) > 1:
                 graph_params[name] = value
 
-        graph_path = graph.path + '.json'
+        graph_path = graph.path + ".json"
 
         # Check which ranges are a single commit
         for k, jump in enumerate(jumps):
@@ -81,7 +83,7 @@ class Regressions(OutputPublisher):
 
     @classmethod
     def _save(cls, conf, data):
-        fn = os.path.join(conf.html_dir, 'regressions.json')
+        fn = os.path.join(conf.html_dir, "regressions.json")
         util.write_json(fn, data, compact=True)
 
     @classmethod
@@ -90,7 +92,7 @@ class Regressions(OutputPublisher):
         Save the results as an Atom feed
         """
 
-        filename = os.path.join(conf.html_dir, 'regressions.xml')
+        filename = os.path.join(conf.html_dir, "regressions.xml")
 
         # Determine publication date as the date when the benchmark
         # was run --- if it is missing, use the date of the commit
@@ -120,8 +122,8 @@ class Regressions(OutputPublisher):
         entries = []
 
         for name, graph_path, graph_params, idx, last_value, best_value, jumps in data:
-            if '(' in name:
-                benchmark_name = name[:name.index('(')]
+            if "(" in name:
+                benchmark_name = name[: name.index("(")]
             else:
                 benchmark_name = name
 
@@ -131,14 +133,16 @@ class Regressions(OutputPublisher):
                 graph_params = dict(graph_params)
 
                 # Add URL parameters
-                param_values, = itertools.islice(itertools.product(*benchmark['params']),
-                                                 idx, idx + 1)
-                for k, v in zip(benchmark['param_names'], param_values):
-                    graph_params['p-' + k] = v
+                (param_values,) = itertools.islice(
+                    itertools.product(*benchmark["params"]), idx, idx + 1
+                )
+                for k, v in zip(benchmark["param_names"], param_values):
+                    graph_params["p-" + k] = v
 
             for rev1, rev2, value1, value2 in jumps:
-                timestamps = (run_timestamps[benchmark_name, t]
-                              for t in (rev1, rev2) if t is not None)
+                timestamps = (
+                    run_timestamps[benchmark_name, t] for t in (rev1, rev2) if t is not None
+                )
                 last_timestamp = max(timestamps)
 
                 updated = datetime.datetime.fromtimestamp(last_timestamp / 1000)
@@ -146,16 +150,18 @@ class Regressions(OutputPublisher):
                 params = dict(graph_params)
 
                 if rev1 is None:
-                    params['commits'] = f'{revision_to_hash[rev2]}'
+                    params["commits"] = f"{revision_to_hash[rev2]}"
                 else:
-                    params['commits'] = '{0}-{1}'.format(revision_to_hash[rev1],
-                                                         revision_to_hash[rev2])
+                    params["commits"] = "{0}-{1}".format(
+                        revision_to_hash[rev1], revision_to_hash[rev2]
+                    )
 
-                link = f'index.html#{benchmark_name}?{urllib.parse.urlencode(params)}'
+                link = f"index.html#{benchmark_name}?{urllib.parse.urlencode(params)}"
 
                 try:
-                    best_percentage = "{0:.2f}%".format(100 *
-                                                        (last_value - best_value) / best_value)
+                    best_percentage = "{0:.2f}%".format(
+                        100 * (last_value - best_value) / best_value
+                    )
                 except ZeroDivisionError:
                     best_percentage = f"{last_value - best_value:.2g} units"
 
@@ -165,25 +171,26 @@ class Regressions(OutputPublisher):
                     percentage = f"{value2 - value1:.2g} units"
 
                 jump_date = datetime.datetime.fromtimestamp(revision_timestamps[rev2] / 1000)
-                jump_date_str = jump_date.strftime('%Y-%m-%d %H:%M:%S')
+                jump_date_str = jump_date.strftime("%Y-%m-%d %H:%M:%S")
 
                 if rev1 is not None:
                     commit_a = revision_to_hash[rev1]
                     commit_b = revision_to_hash[rev2]
-                    if 'github.com' in conf.show_commit_url:
-                        commit_url = (conf.show_commit_url + '../compare/' +
-                                      commit_a + "..." + commit_b)
+                    if "github.com" in conf.show_commit_url:
+                        commit_url = (
+                            conf.show_commit_url + "../compare/" + commit_a + "..." + commit_b
+                        )
                     else:
                         commit_url = conf.show_commit_url + commit_a
-                    commit_ref = 'in commits <a href="{0}">{1}...{2}</a>'.format(commit_url,
-                                                                                 commit_a[:8],
-                                                                                 commit_b[:8])
+                    commit_ref = 'in commits <a href="{0}">{1}...{2}</a>'.format(
+                        commit_url, commit_a[:8], commit_b[:8]
+                    )
                 else:
                     commit_a = revision_to_hash[rev2]
                     commit_url = conf.show_commit_url + commit_a
                     commit_ref = f'in commit <a href="{commit_url}">{commit_a[:8]}</a>'
 
-                unit = benchmark.get('unit', '')
+                unit = benchmark.get("unit", "")
                 best_value_str = util.human_value(best_value, unit)
                 last_value_str = util.human_value(last_value, unit)
                 value1_str = util.human_value(value1, unit)
@@ -195,7 +202,9 @@ class Regressions(OutputPublisher):
                 New value: {value2_str}, old value: {value1_str}.<br>
                 Latest value: {last_value_str} ({best_percentage} worse
                 than best value {best_value_str}).
-                """.format(**locals()).strip()
+                """.format(
+                    **locals()
+                ).strip()
 
                 # Information that uniquely identifies a regression
                 # --- if the values and the texts change on later
@@ -209,10 +218,13 @@ class Regressions(OutputPublisher):
 
         entries.sort(key=lambda x: x.updated, reverse=True)
 
-        feed.write_atom(filename, entries,
-                        title=f'{conf.project} performance regressions',
-                        author='Airspeed Velocity',
-                        address=f'{conf.project}.asv')
+        feed.write_atom(
+            filename,
+            entries,
+            title=f"{conf.project} performance regressions",
+            author="Airspeed Velocity",
+            address=f"{conf.project}.asv",
+        )
 
 
 class _GraphDataFilter:
@@ -244,17 +256,16 @@ class _GraphDataFilter:
             User-specified threshold for regression detection.
 
         """
-        if benchmark.get('params'):
-            param_iter = enumerate(zip(itertools.product(*benchmark['params']),
-                                       graph.get_steps()))
+        if benchmark.get("params"):
+            param_iter = enumerate(zip(itertools.product(*benchmark["params"]), graph.get_steps()))
         else:
             param_iter = [(None, (None, graph.get_steps()))]
 
         for j, (param, steps) in param_iter:
             if param is None:
-                entry_name = benchmark['name']
+                entry_name = benchmark["name"]
             else:
-                entry_name = benchmark['name'] + f"({', '.join(param)})"
+                entry_name = benchmark["name"] + f"({', '.join(param)})"
 
             start_revision = self._get_start_revision(graph, benchmark, entry_name)
             threshold = self._get_threshold(graph, benchmark, entry_name)
@@ -277,10 +288,10 @@ class _GraphDataFilter:
         """
         start_revision = min(self.revisions.values())
 
-        if graph.params.get('branch'):
-            branch_suffix = '@' + graph.params.get('branch')
+        if graph.params.get("branch"):
+            branch_suffix = "@" + graph.params.get("branch")
         else:
-            branch_suffix = ''
+            branch_suffix = ""
 
         for regex, start_commit in self.conf.regressions_first_commits.items():
             if re.match(regex, entry_name + branch_suffix):
@@ -291,7 +302,7 @@ class _GraphDataFilter:
                 if self.conf.branches == [None]:
                     key = (start_commit, None)
                 else:
-                    key = (start_commit, graph.params.get('branch'))
+                    key = (start_commit, graph.params.get("branch"))
 
                 if key not in self._start_revisions:
                     spec = self.repo.get_new_range_spec(*key)
@@ -304,8 +315,12 @@ class _GraphDataFilter:
                             break
                     else:
                         # Commit not found in the branch --- warn and ignore.
-                        log.warning(("Commit {0} specified in `regressions_first_commits` "
-                                     "not found in branch").format(start_commit))
+                        log.warning(
+                            (
+                                "Commit {0} specified in `regressions_first_commits` "
+                                "not found in branch"
+                            ).format(start_commit)
+                        )
                         self._start_revisions[key] = -1
 
                 start_revision = max(start_revision, self._start_revisions[key] + 1)
@@ -316,10 +331,10 @@ class _GraphDataFilter:
         """
         Compute the regression threshold in asv.conf.json.
         """
-        if graph.params.get('branch'):
-            branch_suffix = '@' + graph.params.get('branch')
+        if graph.params.get("branch"):
+            branch_suffix = "@" + graph.params.get("branch")
         else:
-            branch_suffix = ''
+            branch_suffix = ""
 
         max_threshold = None
 
@@ -328,8 +343,9 @@ class _GraphDataFilter:
                 try:
                     threshold = float(threshold)
                 except ValueError:
-                    raise util.UserError("Non-float threshold in asv.conf.json: {!r}"
-                                         .format(threshold))
+                    raise util.UserError(
+                        "Non-float threshold in asv.conf.json: {!r}".format(threshold)
+                    )
 
                 if max_threshold is None:
                     max_threshold = threshold

--- a/asv/plugins/runsnake.py
+++ b/asv/plugins/runsnake.py
@@ -4,15 +4,15 @@ from .. import profiling, util
 
 
 class RunSnakeRunGui(profiling.ProfilerGui):
-    name = 'runsnake'
+    name = "runsnake"
     description = "RunSnakeRun http://www.vrplumber.com/programming/runsnakerun/"
 
     @classmethod
     def is_available(cls):
-        return util.has_command('runsnake')
+        return util.has_command("runsnake")
 
     @classmethod
     def open_profiler_gui(cls, profiler_file):
-        command = util.which('runsnake')
+        command = util.which("runsnake")
 
         return util.check_call([command, profiler_file], timeout=None)

--- a/asv/plugins/snakeviz.py
+++ b/asv/plugins/snakeviz.py
@@ -4,17 +4,15 @@ from .. import profiling, util
 
 
 class SnakevizGui(profiling.ProfilerGui):
-    name = 'snakeviz'
+    name = "snakeviz"
     description = "snakeviz http://jiffyclub.github.io/snakeviz/"
 
     @classmethod
     def is_available(cls):
-        return util.has_command('snakeviz')
+        return util.has_command("snakeviz")
 
     @classmethod
     def open_profiler_gui(cls, profiler_file):
-        command = util.which('snakeviz')
+        command = util.which("snakeviz")
 
-        return util.check_call(
-            [command, profiler_file],
-            valid_return_codes=(0, -15), timeout=None)
+        return util.check_call([command, profiler_file], valid_return_codes=(0, -15), timeout=None)

--- a/asv/plugins/summarylist.py
+++ b/asv/plugins/summarylist.py
@@ -20,10 +20,10 @@ def benchmark_param_iter(benchmark):
         Tuple of parameter values.
 
     """
-    if not benchmark['params']:
+    if not benchmark["params"]:
         yield None, ()
     else:
-        for item in enumerate(itertools.product(*benchmark['params'])):
+        for item in enumerate(itertools.product(*benchmark["params"])):
             yield item
 
 
@@ -47,12 +47,12 @@ class SummaryList(OutputPublisher):
             for idx, benchmark_param in benchmark_param_iter(benchmark):
                 pretty_name = benchmark_name
 
-                if benchmark.get('pretty_name'):
-                    pretty_name = benchmark['pretty_name']
+                if benchmark.get("pretty_name"):
+                    pretty_name = benchmark["pretty_name"]
 
                 if idx is not None:
                     bench_param = ", ".join(benchmark_param)
-                    pretty_name = f'{pretty_name}({bench_param})'
+                    pretty_name = f"{pretty_name}({bench_param})"
 
                 # Each environment parameter combination is reported
                 # separately on the summarylist page
@@ -89,23 +89,26 @@ class SummaryList(OutputPublisher):
                                 # Revision range (left-exclusive)
                                 change_rev = [prev_piece[1] - 1, last_piece[0]]
 
-                    row = dict(name=benchmark_name,
-                               idx=idx,
-                               pretty_name=pretty_name,
-                               last_rev=last_rev,
-                               last_value=last_value,
-                               last_err=last_err,
-                               prev_value=prev_value,
-                               change_rev=change_rev)
+                    row = dict(
+                        name=benchmark_name,
+                        idx=idx,
+                        pretty_name=pretty_name,
+                        last_rev=last_rev,
+                        last_value=last_value,
+                        last_err=last_err,
+                        prev_value=prev_value,
+                        change_rev=change_rev,
+                    )
 
                     # Generate summary data filename.
                     # Note that 'summary' is not a valid benchmark name, so that we can
                     # be sure it can be always used.
-                    path = Graph.get_file_path(graph.params, 'summary') + ".json"
+                    path = Graph.get_file_path(graph.params, "summary") + ".json"
                     results.setdefault(path, []).append(row)
 
         # Write results to files
         for path, data in results.items():
             filename = os.path.join(conf.html_dir, path)
-            util.write_json(filename, sorted(data, key=lambda x: (x['name'], x['idx'])),
-                            compact=True)
+            util.write_json(
+                filename, sorted(data, key=lambda x: (x["name"], x["idx"])), compact=True
+            )

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -8,13 +8,14 @@ from packaging.version import Version
 from .. import environment, util
 from ..console import log
 
-WIN = (os.name == "nt")
+WIN = os.name == "nt"
 
 
 class Virtualenv(environment.Environment):
     """
     Manage an environment using virtualenv.
     """
+
     tool_name = "virtualenv"
 
     def __init__(self, conf, python, requirements, tagged_env_vars):
@@ -35,22 +36,17 @@ class Virtualenv(environment.Environment):
         """
         executable = Virtualenv._find_python(python)
         if executable is None:
-            raise environment.EnvironmentUnavailable(
-                f"No executable found for python {python}")
+            raise environment.EnvironmentUnavailable(f"No executable found for python {python}")
 
         self._executable = executable
         self._python = python
         self._requirements = requirements
-        super(Virtualenv, self).__init__(conf,
-                                         python,
-                                         requirements,
-                                         tagged_env_vars)
+        super(Virtualenv, self).__init__(conf, python, requirements, tagged_env_vars)
 
         try:
             import virtualenv  # noqa F401 unused, but required to test whether virtualenv is installed or not
         except ImportError:
-            raise environment.EnvironmentUnavailable(
-                "virtualenv package not installed")
+            raise environment.EnvironmentUnavailable("virtualenv package not installed")
 
     @staticmethod
     def _find_python(python):
@@ -60,8 +56,8 @@ class Virtualenv(environment.Environment):
         # Parse python specifier
         if is_pypy:
             executable = python
-            if python == 'pypy':
-                python_version = '2'
+            if python == "pypy":
+                python_version = "2"
             else:
                 python_version = python[4:]
         else:
@@ -75,9 +71,11 @@ class Virtualenv(environment.Environment):
             pass
 
         # Maybe the current one is correct?
-        current_is_pypy = hasattr(sys, 'pypy_version_info')
-        current_versions = [f'{sys.version_info[0]}',
-                            f'{sys.version_info[0]}.{sys.version_info[1]}']
+        current_is_pypy = hasattr(sys, "pypy_version_info")
+        current_versions = [
+            f"{sys.version_info[0]}",
+            f"{sys.version_info[0]}.{sys.version_info[1]}",
+        ]
 
         if is_pypy == current_is_pypy and python_version in current_versions:
             return sys.executable
@@ -90,17 +88,16 @@ class Virtualenv(environment.Environment):
         Get a name to uniquely identify this environment.
         """
         python = self._python
-        if self._python.startswith('pypy'):
+        if self._python.startswith("pypy"):
             # get_env_name adds py-prefix
             python = python[2:]
-        return environment.get_env_name(self.tool_name,
-                                        python,
-                                        self._requirements,
-                                        self._tagged_env_vars)
+        return environment.get_env_name(
+            self.tool_name, python, self._requirements, self._tagged_env_vars
+        )
 
     @classmethod
     def matches(self, python):
-        if not (re.match(r'^[0-9].*$', python) or re.match(r'^pypy[0-9.]*$', python)):
+        if not (re.match(r"^[0-9].*$", python) or re.match(r"^pypy[0-9.]*$", python)):
             # The python name should be a version number, or pypy+number
             return False
 
@@ -109,13 +106,12 @@ class Virtualenv(environment.Environment):
         except ImportError:
             return False
         else:
-            if Version(virtualenv.__version__) == Version('1.11.0'):
+            if Version(virtualenv.__version__) == Version("1.11.0"):
                 log.warning(
-                    "asv is not compatible with virtualenv 1.11 due to a bug in "
-                    "setuptools.")
-            if Version(virtualenv.__version__) < Version('1.10'):
-                log.warning(
-                    "If using virtualenv, it much be at least version 1.10")
+                    "asv is not compatible with virtualenv 1.11 due to a bug in " "setuptools."
+                )
+            if Version(virtualenv.__version__) < Version("1.10"):
+                log.warning("If using virtualenv, it much be at least version 1.10")
 
         executable = Virtualenv._find_python(python)
         return executable is not None
@@ -130,18 +126,15 @@ class Virtualenv(environment.Environment):
         env.update(self.build_env_vars)
 
         log.info(f"Creating virtualenv for {self.name}")
-        util.check_call([
-            sys.executable,
-            "-mvirtualenv",
-            "-p",
-            self._executable,
-            self._path], env=env)
+        util.check_call(
+            [sys.executable, "-mvirtualenv", "-p", self._executable, self._path], env=env
+        )
 
         log.info(f"Installing requirements for {self.name}")
         self._install_requirements()
 
     def _install_requirements(self):
-        pip_args = ['install', '-v', 'wheel', 'pip>=8']
+        pip_args = ["install", "-v", "wheel", "pip>=8"]
 
         env = dict(os.environ)
         env.update(self.build_env_vars)
@@ -149,10 +142,10 @@ class Virtualenv(environment.Environment):
         self._run_pip(pip_args, env=env)
 
         if self._requirements:
-            args = ['install', '-v', '--upgrade']
+            args = ["install", "-v", "--upgrade"]
             for key, val in self._requirements.items():
                 pkg = key
-                if key.startswith('pip+'):
+                if key.startswith("pip+"):
                     pkg = key[4:]
 
                 if val:
@@ -164,9 +157,9 @@ class Virtualenv(environment.Environment):
     def _run_pip(self, args, **kwargs):
         # Run pip via python -m pip, so that it works on Windows when
         # upgrading pip itself, and avoids shebang length limit on Linux
-        return self.run_executable('python', ['-mpip'] + list(args), **kwargs)
+        return self.run_executable("python", ["-mpip"] + list(args), **kwargs)
 
     def run(self, args, **kwargs):
-        joined_args = ' '.join(args)
+        joined_args = " ".join(args)
         log.debug(f"Running '{joined_args}' in {self.name}")
-        return self.run_executable('python', args, **kwargs)
+        return self.run_executable("python", args, **kwargs)

--- a/asv/profiling.py
+++ b/asv/profiling.py
@@ -1,10 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+
 class ProfilerGui:
     """
     A base class to define a Profiler GUI that is available through
     the ``asv profile`` command.
     """
+
     name = None
     description = None
 

--- a/asv/publishing.py
+++ b/asv/publishing.py
@@ -7,6 +7,7 @@ class OutputPublisher:
     """
     A base class for pages displaying output in the JS application
     """
+
     name = None
     button_label = None
     description = None

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -9,6 +9,7 @@ class NoSuchNameError(RuntimeError):
     """
     Exception raised if requested branch or commit does not exist.
     """
+
     pass
 
 
@@ -44,12 +45,14 @@ class Repo:
         Internal routine for raising an error message if mirror directory already exists,
         but appears incorrect.
         """
-        raise util.UserError(f"Directory '{path}' already exists, but is not a mirror "
-                             "of the project repository. Please remove it and try again. "
-                             "If the benchmark suite is in the project repository, you can "
-                             "also adjust the configuration to use the current "
-                             "repository (e.g. \"repo\": \".\") instead of a remote URL "
-                             "as the source.")
+        raise util.UserError(
+            f"Directory '{path}' already exists, but is not a mirror "
+            "of the project repository. Please remove it and try again. "
+            "If the benchmark suite is in the project repository, you can "
+            "also adjust the configuration to use the current "
+            'repository (e.g. "repo": ".") instead of a remote URL '
+            "as the source."
+        )
 
     def checkout(self, path, commit_hash):
         """
@@ -237,8 +240,10 @@ class NoRepository(Repo):
         self.path = None
 
     def _raise_error(self):
-        raise ValueError("Using the currently installed project version: "
-                         "operations requiring repository are not possible")
+        raise ValueError(
+            "Using the currently installed project version: "
+            "operations requiring repository are not possible"
+        )
 
     def _check_branch(self, branch):
         if branch is not None:
@@ -298,12 +303,11 @@ def get_repo(conf):
 
     if conf.dvcs is not None:
         for cls in util.iter_subclasses(Repo):
-            if getattr(cls, 'dvcs') == conf.dvcs:
+            if getattr(cls, "dvcs") == conf.dvcs:
                 return cls(conf.repo, conf.project)
     else:
         for cls in util.iter_subclasses(Repo):
             if cls.url_match(conf.repo):
                 return cls(conf.repo, conf.project)
 
-    raise util.UserError(
-        f"Can not determine what kind of DVCS to use for URL '{conf.repo}'")
+    raise util.UserError(f"Can not determine what kind of DVCS to use for URL '{conf.repo}'")

--- a/asv/statistics.py
+++ b/asv/statistics.py
@@ -56,12 +56,14 @@ def compute_stats(samples, number):
     # Produce results
     result = y_50
 
-    stats = {'ci_99_a': ci_50[0],
-             'ci_99_b': ci_50[1],
-             'q_25': y_25,
-             'q_75': y_75,
-             'repeat': len(Y),
-             'number': number}
+    stats = {
+        "ci_99_a": ci_50[0],
+        "ci_99_b": ci_50[1],
+        "q_25": y_25,
+        "q_75": y_75,
+        "repeat": len(Y),
+        "number": number,
+    }
 
     return result, stats
 
@@ -71,7 +73,7 @@ def get_err(result, stats):
     Return an 'error measure' suitable for informing the user
     about the spread of the measurement results.
     """
-    a, b = stats['q_25'], stats['q_75']
+    a, b = stats["q_25"], stats["q_75"]
     return (b - a) / 2
 
 
@@ -79,12 +81,12 @@ def get_weight(stats):
     """
     Return a data point weight for the result.
     """
-    if stats is None or 'ci_99_a' not in stats or 'ci_99_b' not in stats:
+    if stats is None or "ci_99_a" not in stats or "ci_99_b" not in stats:
         return None
 
     try:
-        a = stats['ci_99_a']
-        b = stats['ci_99_b']
+        a = stats["ci_99_a"]
+        b = stats["ci_99_b"]
 
         if math.isinf(a) or math.isinf(b):
             # Infinite interval is due to too few samples --- consider
@@ -129,8 +131,8 @@ def is_different(samples_a, samples_b, stats_a, stats_b, p_threshold=0.002):
     # which generally can be significantly smaller than p <= 0.01
     # depending on the actual data. For normal test (known variance),
     # 0.00027 <= p <= 0.01.
-    ci_a = (stats_a['ci_99_a'], stats_a['ci_99_b'])
-    ci_b = (stats_b['ci_99_a'], stats_b['ci_99_b'])
+    ci_a = (stats_a["ci_99_a"], stats_a["ci_99_b"])
+    ci_b = (stats_b["ci_99_a"], stats_b["ci_99_b"])
 
     if ci_a[1] >= ci_b[0] and ci_a[0] <= ci_b[1]:
         return False
@@ -238,7 +240,7 @@ def quantile(x, q):
 _mann_whitney_u_memo = {}
 
 
-def mann_whitney_u(x, y, method='auto'):
+def mann_whitney_u(x, y, method="auto"):
     """
     Mann-Whitney U test
 
@@ -273,11 +275,11 @@ def mann_whitney_u(x, y, method='auto'):
     m = len(x)
     n = len(y)
 
-    if method == 'auto':
+    if method == "auto":
         if max(m, n) > 20:
-            method = 'normal'
+            method = "normal"
         else:
-            method = 'exact'
+            method = "exact"
 
     u, ties = mann_whitney_u_u(x, y)
 
@@ -295,11 +297,11 @@ def mann_whitney_u(x, y, method='auto'):
         ux = ux2
 
     # Get p-value
-    if method == 'exact':
+    if method == "exact":
         p1 = mann_whitney_u_cdf(m, n, ux, memo)
         p2 = 1.0 - mann_whitney_u_cdf(m, n, max(m * n // 2, m * n - ux - 1), memo)
         p = p1 + p2
-    elif method == 'normal':
+    elif method == "normal":
         N = m + n
         var = m * n * (N + 1) / 12
         z = (ux - m * n / 2) / math.sqrt(var)
@@ -363,8 +365,7 @@ def mann_whitney_u_r(m, n, u, memo=None):
         if value is not None:
             return value
 
-        value = (mann_whitney_u_r(m, n - 1, u, memo) +
-                 mann_whitney_u_r(m - 1, n, u - n, memo))
+        value = mann_whitney_u_r(m, n - 1, u, memo) + mann_whitney_u_r(m - 1, n, u - n, memo)
 
         memo[key] = value
     return value
@@ -464,7 +465,7 @@ class LaplacePosterior:
         # when computing the unnormalized CDF integrals below.
         self.mle = quantile(y, 0.5)
         self._y_scale = sum(abs(yp - self.mle) for yp in y)
-        self._y_scale *= self.nu**(1 / (self.nu + 1))
+        self._y_scale *= self.nu ** (1 / (self.nu + 1))
 
         # Shift and scale
         if self._y_scale != 0:
@@ -520,9 +521,9 @@ class LaplacePosterior:
                 b = self.y[k]
 
             if c == 0:
-                term = (b - a) / y**(nu + 1)
+                term = (b - a) / y ** (nu + 1)
             else:
-                term = 1 / (nu * c) * ((a * c + y)**(-nu) - (b * c + y)**(-nu))
+                term = 1 / (nu * c) * ((a * c + y) ** (-nu) - (b * c + y) ** (-nu))
 
             cdf += max(0, term)  # avoid rounding error
 
@@ -556,15 +557,15 @@ class LaplacePosterior:
         if k == 0:
             z = -nu * c * term
             if z > 0:
-                beta = (z**(-1 / nu) - y) / c
+                beta = (z ** (-1 / nu) - y) / c
             else:
                 beta = -math.inf
         elif c == 0:
-            beta = a + term * y**(nu + 1)
+            beta = a + term * y ** (nu + 1)
         else:
-            z = (a * c + y)**(-nu) - nu * c * term
+            z = (a * c + y) ** (-nu) - nu * c * term
             if z > 0:
-                beta = (z**(-1 / nu) - y) / c
+                beta = (z ** (-1 / nu) - y) / c
             else:
                 beta = math.inf
 

--- a/asv/step_detect.py
+++ b/asv/step_detect.py
@@ -373,6 +373,7 @@ except ImportError:
 # Detecting regressions
 #
 
+
 def detect_steps(y, w=None):
     """
     Detect steps in a (noisy) signal.
@@ -436,11 +437,9 @@ def detect_steps(y, w=None):
     steps = []
     l = 0
     for r, v, d in zip(right, values, dists):
-        steps.append((index_map[l],
-                     index_map[r - 1] + 1,
-                     v,
-                     min(y_filtered[l:r]),
-                     abs(d / (r - l))))
+        steps.append(
+            (index_map[l], index_map[r - 1] + 1, v, min(y_filtered[l:r]), abs(d / (r - l)))
+        )
         l = r
     return steps
 
@@ -530,8 +529,8 @@ def detect_regressions(steps, threshold=0, min_size=2):
 # Fitting piecewise constant functions to noisy data
 #
 
-def solve_potts(y, w, gamma, min_size=1, max_size=None,
-                min_pos=None, max_pos=None, mu_dist=None):
+
+def solve_potts(y, w, gamma, min_size=1, max_size=None, min_pos=None, max_pos=None, mu_dist=None):
     """Fit penalized stepwise constant function (Potts model) to data.
 
     Given a time series y = {y_1, ..., y_n}, fit series x = {x_1, ..., x_n}
@@ -616,7 +615,7 @@ def solve_potts(y, w, gamma, min_size=1, max_size=None,
     #     the best (exclusive) left edge is at l=p[r].
     #     Where intervals overlap, the rightmost one has priority.
 
-    if hasattr(mu_dist, 'find_best_partition'):
+    if hasattr(mu_dist, "find_best_partition"):
         p = mu_dist.find_best_partition(gamma, min_size, max_size, min_pos, max_pos)
     else:
         i0 = min_pos
@@ -718,8 +717,9 @@ def solve_potts_autogamma(y, w, beta=None, **kw):
                 l = r
             return s
 
-        rho_best = golden_search(lambda rho: sigma_star(r, v, rho), -1, 1,
-                                 xatol=0.05, expand_bounds=True)
+        rho_best = golden_search(
+            lambda rho: sigma_star(r, v, rho), -1, 1, xatol=0.05, expand_bounds=True
+        )
 
         # Measurement noise floor
         if len(v) > 2:
@@ -765,10 +765,10 @@ def solve_potts_approx(y, w, gamma=None, min_size=1, **kw):
     if n == 0:
         return [], [], []
 
-    mu_dist = kw.get('mu_dist')
+    mu_dist = kw.get("mu_dist")
     if mu_dist is None:
         mu_dist = get_mu_dist(y, w)
-        kw['mu_dist'] = mu_dist
+        kw["mu_dist"] = mu_dist
 
     if gamma is None:
         dist = mu_dist.dist
@@ -805,8 +805,9 @@ def merge_pieces(gamma, right, values, dists, mu_dist, max_size):
 
             # Check whether merging consecutive intervals results to
             # decrease in the cost function
-            change = (dist(l, right[j] - 1) -
-                      (dist(l, right[j - 1] - 1) + dist(right[j - 1], right[j] - 1) + gamma))
+            change = dist(l, right[j] - 1) - (
+                dist(l, right[j - 1] - 1) + dist(right[j - 1], right[j] - 1) + gamma
+            )
             if change <= min_change:
                 min_change = change
                 min_change_j = j - 1
@@ -865,6 +866,7 @@ class L1Dist:
     prefactors, which for Python means minimal code.
 
     """
+
     def __init__(self, y, w):
         self.y = y
         self.w = w
@@ -872,7 +874,7 @@ class L1Dist:
         class mu_dict(collections.defaultdict):
             def __missing__(self, a):
                 l, r = a
-                v = weighted_median(y[l:r + 1], w[l:r + 1])
+                v = weighted_median(y[l : r + 1], w[l : r + 1])
                 self[a] = v
                 return v
 
@@ -882,7 +884,7 @@ class L1Dist:
             def __missing__(self, a):
                 l, r = a
                 m = mu[l, r]
-                v = sum(wx * abs(x - m) for x, wx in zip(y[l:r + 1], w[l:r + 1]))
+                v = sum(wx * abs(x - m) for x, wx in zip(y[l : r + 1], w[l : r + 1]))
                 self[a] = v
                 return v
 
@@ -920,8 +922,8 @@ def rolling_median_dev(items):
     """
     min_heap = []
     max_heap = []
-    min_heap_sum = 0   # equal to -sum(min_heap)
-    max_heap_sum = 0   # equal to sum(max_heap)
+    min_heap_sum = 0  # equal to -sum(min_heap)
+    max_heap_sum = 0  # equal to sum(max_heap)
     s = iter(items)
     try:
         while True:
@@ -1028,9 +1030,9 @@ def _plot_potts(x, sol):
     t = np.arange(len(x))
 
     plt.clf()
-    plt.plot(t, x, 'k.')
+    plt.plot(t, x, "k.")
 
     l = 0
     for r, v in zip(sol[0], sol[1]):
-        plt.plot([l, r - 1], [v, v], 'b-o', hold=1)
+        plt.plot([l, r - 1], [v, v], "b-o", hold=1)
         l = r

--- a/asv/template/benchmarks/benchmarks.py
+++ b/asv/template/benchmarks/benchmarks.py
@@ -7,6 +7,7 @@ class TimeSuite:
     An example benchmark that times the performance of various kinds
     of iterating over dictionaries in Python.
     """
+
     def setup(self):
         self.d = {}
         for x in range(500):

--- a/asv/util.py
+++ b/asv/util.py
@@ -26,7 +26,7 @@ import multiprocessing
 
 import json5
 
-WIN = (os.name == 'nt')
+WIN = os.name == "nt"
 
 if not WIN:
     from select import PIPE_BUF
@@ -45,6 +45,7 @@ class ParallelFailure(Exception):
     Custom exception to work around a multiprocessing bug
     https://bugs.python.org/issue9400
     """
+
     def __new__(cls, message, exc_cls, traceback_str):
         self = Exception.__new__(cls)
         self.message = message
@@ -56,9 +57,9 @@ class ParallelFailure(Exception):
         return (ParallelFailure, (self.message, self.exc_cls, self.traceback_str))
 
     def __str__(self):
-        return "{0}: {1}\n    {2}".format(self.exc_cls.__name__,
-                                          self.message,
-                                          self.traceback_str.replace("\n", "\n    "))
+        return "{0}: {1}\n    {2}".format(
+            self.exc_cls.__name__, self.message, self.traceback_str.replace("\n", "\n    ")
+        )
 
     def reraise(self):
         if self.exc_cls is UserError:
@@ -74,13 +75,13 @@ def human_list(input_list):
     input_list = [f"'{x}'" for x in input_list]
 
     if len(input_list) == 0:
-        return 'nothing'
+        return "nothing"
     elif len(input_list) == 1:
         return input_list[0]
     elif len(input_list) == 2:
-        return ' and '.join(input_list)
+        return " and ".join(input_list)
     else:
-        return ', '.join(input_list[:-1]) + ' and ' + input_list[-1]
+        return ", ".join(input_list[:-1]) + " and " + input_list[-1]
 
 
 def human_float(value, significant=3, truncate_small=None, significant_zeros=False):
@@ -123,12 +124,12 @@ def human_float(value, significant=3, truncate_small=None, significant_zeros=Fal
 
     formatted = sign + fmt.format(value)
 
-    if not significant_zeros and '.' in formatted and 'e' not in fmt:
-        formatted = formatted.rstrip('0')
-        if formatted[-1] == '.':
+    if not significant_zeros and "." in formatted and "e" not in fmt:
+        formatted = formatted.rstrip("0")
+        if formatted[-1] == ".":
             formatted = formatted[:-1]
 
-    if significant_zeros and '.' not in formatted:
+    if significant_zeros and "." not in formatted:
         if len(formatted) < significant:
             formatted += "." + "0" * (significant - len(formatted))
 
@@ -162,13 +163,13 @@ def human_file_size(size, err=None):
     if size < 1:
         size = 0.0
 
-    suffixes = ' kMGTPEH'
+    suffixes = " kMGTPEH"
     if size == 0:
         num_scale = 0
     else:
         num_scale = int(math.floor(math.log(size) / math.log(1000)))
     if num_scale > 7:
-        suffix = '?'
+        suffix = "?"
     else:
         suffix = suffixes[num_scale].strip()
     scale = int(math.pow(1000, num_scale))
@@ -184,16 +185,16 @@ def human_file_size(size, err=None):
 
 
 _human_time_units = (
-    ('ns', 0.000000001),
-    ('μs', 0.000001),
-    ('ms', 0.001),
-    ('s', 1),
-    ('m', 60),
-    ('h', 60 * 60),
-    ('d', 60 * 60 * 24),
-    ('w', 60 * 60 * 24 * 7),
-    ('y', 60 * 60 * 24 * 7 * 52),
-    ('C', 60 * 60 * 24 * 7 * 52 * 100)
+    ("ns", 0.000000001),
+    ("μs", 0.000001),
+    ("ms", 0.001),
+    ("s", 1),
+    ("m", 60),
+    ("h", 60 * 60),
+    ("d", 60 * 60 * 24),
+    ("w", 60 * 60 * 24 * 7),
+    ("y", 60 * 60 * 24 * 7 * 52),
+    ("C", 60 * 60 * 24 * 7 * 52 * 100),
 )
 
 
@@ -233,7 +234,7 @@ def human_time(seconds, err=None):
 
     if scale == 0:
         # Represent zero in reasonable units
-        units = [('s', 1), ('m', 60)]
+        units = [("s", 1), ("m", 60)]
 
     if scale != scale:
         # nan
@@ -247,7 +248,7 @@ def human_time(seconds, err=None):
             else:
                 str_err = human_float(err / units[i][1], 1, truncate_small=2)
                 return f"{str_time:s}±{str_err:s}{units[i][0]}"
-    return '~0'
+    return "~0"
 
 
 def human_value(value, unit, err=None):
@@ -269,9 +270,9 @@ def human_value(value, unit, err=None):
         if value != value:
             # nan
             display = "n/a"
-        elif unit == 'seconds':
+        elif unit == "seconds":
             display = human_time(value, err=err)
-        elif unit == 'bytes':
+        elif unit == "bytes":
             display = human_file_size(value, err=err)
         else:
             display = json.dumps(value)
@@ -285,7 +286,7 @@ def human_value(value, unit, err=None):
     return display
 
 
-def parse_human_time(string, base_period='d'):
+def parse_human_time(string, base_period="d"):
     """
     Parse a human-specified time period to an integer number of seconds.
     The following format is accepted: <number><suffix>
@@ -293,18 +294,17 @@ def parse_human_time(string, base_period='d'):
     Raises a ValueError on parse error.
     """
     units = dict(_human_time_units)
-    units[''] = units[base_period]
+    units[""] = units[base_period]
 
-    suffixes = '|'.join(units.keys())
+    suffixes = "|".join(units.keys())
 
     try:
-        m = re.match(r'^\s*([0-9.]+)\s*({})\s*$'.format(suffixes), string)
+        m = re.match(r"^\s*([0-9.]+)\s*({})\s*$".format(suffixes), string)
         if m is None:
             raise ValueError()
         return float(m.group(1)) * units[m.group(2)]
     except ValueError:
-        raise ValueError("%r is not a valid time period (valid units: %s)"
-                         % (string, suffixes))
+        raise ValueError("%r is not a valid time period (valid units: %s)" % (string, suffixes))
 
 
 def which(filename, paths=None):
@@ -314,21 +314,23 @@ def which(filename, paths=None):
     Raises an IOError if no result is found.
     """
     # Hide traceback from expected exceptions in pytest reports
-    __tracebackhide__ = operator.methodcaller('errisinstance', IOError)
+    __tracebackhide__ = operator.methodcaller("errisinstance", IOError)
 
     if os.path.sep in filename:
-        locations = ['']
+        locations = [""]
     elif paths is not None:
         locations = paths
     else:
         locations = os.environ.get("PATH", "").split(os.pathsep)
         if WIN:
             # On windows, an entry in %PATH% may be quoted
-            locations = [path[1:-1] if len(path) > 2 and path[0] == path[-1] == '"' else path
-                         for path in locations]
+            locations = [
+                path[1:-1] if len(path) > 2 and path[0] == path[-1] == '"' else path
+                for path in locations
+            ]
 
     if WIN:
-        filenames = [filename + ext for ext in ('.exe', '.bat', '.com', '')]
+        filenames = [filename + ext for ext in (".exe", ".bat", ".com", "")]
     else:
         filenames = [filename]
 
@@ -341,7 +343,7 @@ def which(filename, paths=None):
 
     if len(candidates) == 0:
         if paths is None:
-            loc_info = 'PATH'
+            loc_info = "PATH"
         else:
             loc_info = os.pathsep.join(locations)
         raise IOError(f"Could not find '{filename}' in {loc_info}")
@@ -373,11 +375,20 @@ class ProcessError(subprocess.CalledProcessError):
             return f"Command '{' '.join(self.args)}' timed out"
         else:
             return "Command '{0}' returned non-zero exit status {1}".format(
-                ' '.join(self.args), self.retcode)
+                " ".join(self.args), self.retcode
+            )
 
 
-def check_call(args, valid_return_codes=(0,), timeout=600, dots=True,
-               display_error=True, shell=False, env=None, cwd=None):
+def check_call(
+    args,
+    valid_return_codes=(0,),
+    timeout=600,
+    dots=True,
+    display_error=True,
+    shell=False,
+    env=None,
+    cwd=None,
+):
     """
     Runs the given command in a subprocess, raising ProcessError if it
     fails.
@@ -385,19 +396,25 @@ def check_call(args, valid_return_codes=(0,), timeout=600, dots=True,
     See `check_output` for parameters.
     """
     # Hide traceback from expected exceptions in pytest reports
-    __tracebackhide__ = operator.methodcaller('errisinstance', ProcessError)
+    __tracebackhide__ = operator.methodcaller("errisinstance", ProcessError)
 
     check_output(
-        args, valid_return_codes=valid_return_codes, timeout=timeout,
-        dots=dots, display_error=display_error, shell=shell, env=env,
-        cwd=cwd)
+        args,
+        valid_return_codes=valid_return_codes,
+        timeout=timeout,
+        dots=dots,
+        display_error=display_error,
+        shell=shell,
+        env=env,
+        cwd=cwd,
+    )
 
 
 class DebugLogBuffer:
     def __init__(self, log):
         self.buf = []
         self.first = True
-        self.linebreak_re = re.compile(b'.*\n')
+        self.linebreak_re = re.compile(b".*\n")
         self.log = log
         self.lock = threading.Lock()
 
@@ -409,7 +426,7 @@ class DebugLogBuffer:
         if c is None:
             text = b"".join(self.buf)
             del self.buf[:]
-        elif b'\n' in c:
+        elif b"\n" in c:
             m = self.linebreak_re.match(c)
             j = m.end()
             self.buf.append(c[:j])
@@ -419,20 +436,30 @@ class DebugLogBuffer:
             self.buf.append(c)
             return
 
-        text = text.decode('utf-8', 'replace')
-        if text.endswith('\n'):
+        text = text.decode("utf-8", "replace")
+        if text.endswith("\n"):
             text = text[:-1]
 
         if text:
             if self.first:
-                self.log.debug('OUTPUT -------->', continued=True)
+                self.log.debug("OUTPUT -------->", continued=True)
                 self.first = False
             self.log.debug(text, continued=True)
 
 
-def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
-                 display_error=True, shell=False, return_stderr=False,
-                 env=None, cwd=None, redirect_stderr=False, return_popen=False):
+def check_output(
+    args,
+    valid_return_codes=(0,),
+    timeout=600,
+    dots=True,
+    display_error=True,
+    shell=False,
+    return_stderr=False,
+    env=None,
+    cwd=None,
+    redirect_stderr=False,
+    return_popen=False,
+):
     """
     Runs the given command in a subprocess, raising ProcessError if it
     fails.  Returns stdout as a string on success.
@@ -488,48 +515,39 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
     from .console import log
 
     # Hide traceback from expected exceptions in pytest reports
-    __tracebackhide__ = operator.methodcaller('errisinstance', ProcessError)
+    __tracebackhide__ = operator.methodcaller("errisinstance", ProcessError)
 
     def get_content(header=None):
         content = []
         if header is not None:
             content.append(header)
         if redirect_stderr:
-            content.extend([
-                'OUTPUT -------->',
-                stdout[:-1]
-            ])
+            content.extend(["OUTPUT -------->", stdout[:-1]])
         else:
-            content.extend([
-                'STDOUT -------->',
-                stdout[:-1],
-                'STDERR -------->',
-                stderr[:-1]
-            ])
-        return '\n'.join(content)
+            content.extend(["STDOUT -------->", stdout[:-1], "STDERR -------->", stderr[:-1]])
+        return "\n".join(content)
 
     if isinstance(args, str):
         args = [args]
 
     log.debug(f"Running '{' '.join(args)}'")
 
-    kwargs = dict(shell=shell, env=env, cwd=cwd,
-                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    kwargs = dict(shell=shell, env=env, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if redirect_stderr:
-        kwargs['stderr'] = subprocess.STDOUT
+        kwargs["stderr"] = subprocess.STDOUT
     if WIN:
-        kwargs['close_fds'] = False
-        kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
+        kwargs["close_fds"] = False
+        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
     else:
-        kwargs['close_fds'] = True
-        posix = getattr(os, 'setpgid', None)
+        kwargs["close_fds"] = True
+        posix = getattr(os, "setpgid", None)
         if posix:
             # Run the subprocess in a separate process group, so that we
             # can kill it and all child processes it spawns e.g. on
             # timeouts. Note that subprocess.Popen will wait until exec()
             # before returning in parent process, so there is no race
             # condition in setting the process group vs. calls to os.killpg
-            kwargs['preexec_fn'] = lambda: os.setpgid(0, 0)
+            kwargs["preexec_fn"] = lambda: os.setpgid(0, 0)
 
     proc = subprocess.Popen(args, **kwargs)
 
@@ -545,6 +563,7 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
         debug_log = DebugLogBuffer(log)
         dots = False
     else:
+
         def debug_log(c):
             return None
 
@@ -572,8 +591,9 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
         all_threads = [stdout_reader]
 
         if not redirect_stderr:
-            stderr_reader = threading.Thread(target=stream_reader,
-                                             args=(proc.stderr, stderr_chunks))
+            stderr_reader = threading.Thread(
+                target=stream_reader, args=(proc.stderr, stderr_chunks)
+            )
             stderr_reader.daemon = True
             stderr_reader.start()
             all_threads.append(stderr_reader)
@@ -636,6 +656,7 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
                     _killpg_safe(proc.pid, signum)
                     if signum == signal.SIGTSTP:
                         os.kill(os.getpid(), signal.SIGSTOP)
+
                 signal.signal(signal.SIGTSTP, sig_forward)
                 signal.signal(signal.SIGCONT, sig_forward)
 
@@ -646,11 +667,9 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
             while proc.poll() is None:
                 try:
                     if timeout is None:
-                        rlist, wlist, xlist = select.select(
-                            list(fds.keys()), [], [])
+                        rlist, wlist, xlist = select.select(list(fds.keys()), [], [])
                     else:
-                        rlist, wlist, xlist = select.select(
-                            list(fds.keys()), [], [], timeout)
+                        rlist, wlist, xlist = select.select(list(fds.keys()), [], [], timeout)
                 except select.error as err:
                     if err.args[0] == errno.EINTR:
                         # interrupted by signal handler; try again
@@ -713,11 +732,11 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
     def debug_log(c):
         return None
 
-    stdout = b''.join(stdout_chunks)
-    stderr = b''.join(stderr_chunks)
+    stdout = b"".join(stdout_chunks)
+    stderr = b"".join(stderr_chunks)
 
-    stdout = stdout.decode('utf-8', 'replace')
-    stderr = stderr.decode('utf-8', 'replace')
+    stdout = stdout.decode("utf-8", "replace")
+    stderr = stderr.decode("utf-8", "replace")
 
     if is_timeout:
         retcode = TIMEOUT_RETCODE
@@ -786,11 +805,11 @@ def write_json(path, data, api_version=None, compact=False):
 
     if api_version is not None:
         data = dict(data)
-        data['version'] = api_version
+        data["version"] = api_version
 
     open_kwargs = {}
-    open_kwargs['encoding'] = 'utf-8'
-    with long_path_open(path, 'w', **open_kwargs) as fd:
+    open_kwargs["encoding"] = "utf-8"
+    with long_path_open(path, "w", **open_kwargs) as fd:
         if not compact:
             json.dump(data, fd, indent=4, sort_keys=True)
         else:
@@ -813,13 +832,13 @@ def load_json(path, api_version=None, js_comments=False):
         significantly.
     """
     # Hide traceback from expected exceptions in pytest reports
-    __tracebackhide__ = operator.methodcaller('errisinstance', UserError)
+    __tracebackhide__ = operator.methodcaller("errisinstance", UserError)
 
     path = os.path.abspath(path)
 
     open_kwargs = {}
-    open_kwargs['encoding'] = 'utf-8'
-    with long_path_open(path, 'r', **open_kwargs) as fd:
+    open_kwargs["encoding"] = "utf-8"
+    with long_path_open(path, "r", **open_kwargs) as fd:
         content = fd.read()
 
     if js_comments:
@@ -829,25 +848,25 @@ def load_json(path, api_version=None, js_comments=False):
         try:
             data = json.loads(content)
         except ValueError as err:
-            raise UserError(
-                f"Error parsing JSON in file '{path}': {str(err)}")
+            raise UserError(f"Error parsing JSON in file '{path}': {str(err)}")
 
     if api_version is not None:
-        if 'version' in data:
-            if data['version'] < api_version:
+        if "version" in data:
+            if data["version"] < api_version:
                 raise UserError(
                     "{0} is stored in an old file format.  Run "
-                    "`asv update` to update it.".format(path))
-            elif data['version'] > api_version:
+                    "`asv update` to update it.".format(path)
+                )
+            elif data["version"] > api_version:
                 raise UserError(
                     "{0} is stored in a format that is newer than "
                     "what this version of asv understands.  Update "
-                    "asv to use this file.".format(path))
+                    "asv to use this file.".format(path)
+                )
 
-            del data['version']
+            del data["version"]
         else:
-            raise UserError(
-                f"No version specified in {path}.")
+            raise UserError(f"No version specified in {path}.")
 
     return data
 
@@ -869,23 +888,23 @@ def update_json(cls, path, api_version, compact=False):
         The current API version
     """
     # Hide traceback from expected exceptions in pytest reports
-    __tracebackhide__ = operator.methodcaller('errisinstance', UserError)
+    __tracebackhide__ = operator.methodcaller("errisinstance", UserError)
 
     d = load_json(path)
-    if 'version' not in d:
-        raise UserError(
-            f"No version specified in {path}.")
+    if "version" not in d:
+        raise UserError(f"No version specified in {path}.")
 
-    if d['version'] < api_version:
-        for x in range(d['version'] + 1, api_version + 1):
-            d = getattr(cls, f'update_to_{x}', lambda x: x)(d)
+    if d["version"] < api_version:
+        for x in range(d["version"] + 1, api_version + 1):
+            d = getattr(cls, f"update_to_{x}", lambda x: x)(d)
         write_json(path, d, api_version, compact=compact)
-    elif d['version'] > api_version:
+    elif d["version"] > api_version:
         raise UserError(
             "{0} is stored in a format that is newer than "
             "what this version of asv understands. "
             "Upgrade asv in order to use or add to "
-            "these results.".format(path))
+            "these results.".format(path)
+        )
 
 
 def iter_chunks(s, n):
@@ -903,8 +922,7 @@ def iter_chunks(s, n):
 
 
 def pick_n(items, n):
-    """Pick n items, attempting to get equal index spacing.
-    """
+    """Pick n items, attempting to get equal index spacing."""
     if not (n > 0):
         raise ValueError("Invalid number of items to pick")
     spacing = max(float(len(items)) / n, 1)
@@ -924,6 +942,7 @@ def get_multiprocessing(parallel):
     """
     if parallel != 1:
         import multiprocessing
+
         if parallel <= 0:
             parallel = multiprocessing.cpu_count()
         return parallel, multiprocessing
@@ -954,27 +973,28 @@ def get_cpu_info():
 
     Returns '' if it can't be obtained.
     """
-    if sys.platform.startswith('linux'):
+    if sys.platform.startswith("linux"):
         with open("/proc/cpuinfo", "rb") as fd:
             lines = fd.readlines()
         for line in lines:
-            if b':' in line:
-                key, val = line.split(b':', 1)
+            if b":" in line:
+                key, val = line.split(b":", 1)
                 key = key.strip()
                 val = val.strip()
-                if key == b'model name':
-                    return val.decode('ascii')
-    elif sys.platform.startswith('darwin'):
-        sysctl = which('sysctl')
-        return check_output([sysctl, '-n', 'machdep.cpu.brand_string']).strip()
-    elif sys.platform.startswith('win'):
+                if key == b"model name":
+                    return val.decode("ascii")
+    elif sys.platform.startswith("darwin"):
+        sysctl = which("sysctl")
+        return check_output([sysctl, "-n", "machdep.cpu.brand_string"]).strip()
+    elif sys.platform.startswith("win"):
         try:
             from win32com.client import GetObject
+
             cimv = GetObject(r"winmgmts:root\cimv2")
             return cimv.ExecQuery("Select Name from Win32_Processor")[0].name
         except Exception:
             pass
-    return ''
+    return ""
 
 
 def get_memsize():
@@ -983,25 +1003,23 @@ def get_memsize():
 
     Returns '' if it can't be obtained.
     """
-    if sys.platform.startswith('linux'):
+    if sys.platform.startswith("linux"):
         with open("/proc/meminfo", "rb") as fd:
             lines = fd.readlines()
         for line in lines:
-            if b':' in line:
-                key, val = line.split(b':', 1)
+            if b":" in line:
+                key, val = line.split(b":", 1)
                 key = key.strip()
                 val = val.strip()
-                if key == b'MemTotal':
+                if key == b"MemTotal":
                     return int(val.split()[0])
-    elif sys.platform.startswith('darwin'):
-        sysctl = which('sysctl')
-        return int(check_output([sysctl, '-n', 'hw.memsize']).strip())
-    return ''
+    elif sys.platform.startswith("darwin"):
+        sysctl = which("sysctl")
+        return int(check_output([sysctl, "-n", "hw.memsize"]).strip())
+    return ""
 
 
-def format_text_table(rows, num_headers=0,
-                      top_header_span_start=0,
-                      top_header_text=None):
+def format_text_table(rows, num_headers=0, top_header_span_start=0, top_header_text=None):
     """
     Format rows in as a reStructuredText table, in the vein of::
 
@@ -1017,21 +1035,18 @@ def format_text_table(rows, num_headers=0,
     """
 
     # Format content
-    text_rows = [[f"{item}".replace("\n", " ") for item in row]
-                 for row in rows]
+    text_rows = [[f"{item}".replace("\n", " ") for item in row] for row in rows]
 
     # Ensure same number of items on all rows
     num_items = max(len(row) for row in text_rows)
     for row in text_rows:
-        row.extend([''] * (num_items - len(row)))
+        row.extend([""] * (num_items - len(row)))
 
     # Determine widths
-    col_widths = [max(len(row[j]) for row in text_rows) + 2
-                  for j in range(num_items)]
+    col_widths = [max(len(row[j]) for row in text_rows) + 2 for j in range(num_items)]
 
     # Pad content
-    text_rows = [[item.center(w) for w, item in zip(col_widths, row)]
-                 for row in text_rows]
+    text_rows = [[item.center(w) for w, item in zip(col_widths, row)] for row in text_rows]
 
     # Generate result
     headers = [" ".join(row) for row in text_rows[:num_headers]]
@@ -1128,7 +1143,7 @@ def geom_mean_na(values):
         prod = 1.0
         acc = 0
         for x in values:
-            prod *= abs(x)**exponent
+            prod *= abs(x) ** exponent
             acc += x
         return prod if acc >= 0 else -prod
     else:
@@ -1146,7 +1161,9 @@ if not WIN:
 
     def long_path(path):
         return path
+
 else:
+
     def long_path(path):
         if path.startswith("\\\\"):
             return path
@@ -1175,9 +1192,7 @@ else:
             onerror = None
         else:
             onerror = _remove_readonly
-        shutil.rmtree(long_path(path),
-                      ignore_errors=ignore_errors,
-                      onerror=onerror)
+        shutil.rmtree(long_path(path), ignore_errors=ignore_errors, onerror=onerror)
 
 
 def sanitize_filename(filename):
@@ -1192,13 +1207,33 @@ def sanitize_filename(filename):
         filename = filename.decode(sys.getfilesystemencoding())
 
     # ntfs & ext3
-    filename = re.sub('[<>:"/\\^|?*\x00-\x1f]', '_', filename)
+    filename = re.sub('[<>:"/\\^|?*\x00-\x1f]', "_", filename)
 
     # ntfs
-    forbidden = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3",
-                 "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1",
-                 "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8",
-                 "LPT9"]
+    forbidden = [
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        "COM1",
+        "COM2",
+        "COM3",
+        "COM4",
+        "COM5",
+        "COM6",
+        "COM7",
+        "COM8",
+        "COM9",
+        "LPT1",
+        "LPT2",
+        "LPT3",
+        "LPT4",
+        "LPT5",
+        "LPT6",
+        "LPT7",
+        "LPT8",
+        "LPT9",
+    ]
     if filename.upper() in forbidden:
         filename = filename + "_"
 
@@ -1220,8 +1255,9 @@ def recvall(sock, size):
         s = sock.recv(size - len(data))
         data += s
         if not s:
-            raise RuntimeError("did not receive data from socket "
-                               "(size {}, got only {!r})".format(size, data))
+            raise RuntimeError(
+                "did not receive data from socket " "(size {}, got only {!r})".format(size, data)
+            )
     return data
 
 
@@ -1262,10 +1298,12 @@ def interpolate_command(command, variables):
     try:
         result = [c.format(**variables) for c in parts]
     except KeyError as exc:
-        raise UserError("Configuration error: {{{0}}} not available "
-                        "when substituting into command {1!r} "
-                        "Available: {2!r}"
-                        "".format(exc.args[0], command, variables))
+        raise UserError(
+            "Configuration error: {{{0}}} not available "
+            "when substituting into command {1!r} "
+            "Available: {2!r}"
+            "".format(exc.args[0], command, variables)
+        )
 
     env = {}
 
@@ -1274,26 +1312,28 @@ def interpolate_command(command, variables):
     cwd = None
 
     while result:
-        m = re.match('^([A-Za-z_][A-Za-z0-9_]*)=(.*)$', result[0])
+        m = re.match("^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", result[0])
         if m:
             env[m.group(1)] = m.group(2)
             del result[0]
             continue
 
-        if result[0].startswith('return-code='):
+        if result[0].startswith("return-code="):
             if return_codes_set:
-                raise UserError("Configuration error: multiple return-code specifications "
-                                "in command {0!r} "
-                                "".format(command))
+                raise UserError(
+                    "Configuration error: multiple return-code specifications "
+                    "in command {0!r} "
+                    "".format(command)
+                )
                 break
 
-            if result[0] == 'return-code=any':
+            if result[0] == "return-code=any":
                 return_codes = None
                 return_codes_set = True
                 del result[0]
                 continue
 
-            m = re.match('^return-code=([0-9,]+)$', result[0])
+            m = re.match("^return-code=([0-9,]+)$", result[0])
             if m:
                 try:
                     return_codes = set(int(x) for x in m.group(1).split(","))
@@ -1303,15 +1343,19 @@ def interpolate_command(command, variables):
                 except ValueError:
                     pass
 
-            raise UserError("Configuration error: invalid return-code specification "
-                            "{0!r} when substituting into command {1!r} "
-                            "".format(result[0], command))
+            raise UserError(
+                "Configuration error: invalid return-code specification "
+                "{0!r} when substituting into command {1!r} "
+                "".format(result[0], command)
+            )
 
-        if result[0].startswith('in-dir='):
+        if result[0].startswith("in-dir="):
             if cwd is not None:
-                raise UserError("Configuration error: multiple in-dir specifications "
-                                "in command {0!r} "
-                                "".format(command))
+                raise UserError(
+                    "Configuration error: multiple in-dir specifications "
+                    "in command {0!r} "
+                    "".format(command)
+                )
                 break
 
             cwd = result[0][7:]
@@ -1330,7 +1374,7 @@ def truncate_float_list(item, digits=5):
     representation.
     """
     if isinstance(item, float):
-        fmt = f'{{:.{digits - 1}e}}'
+        fmt = f"{{:.{digits - 1}e}}"
         return float(fmt.format(item))
     elif isinstance(item, list):
         return [truncate_float_list(x, digits) for x in item]
@@ -1358,14 +1402,13 @@ def get_multiprocessing_lock(name):
 
 def get_multiprocessing_pool(parallel=None):
     """Create a multiprocessing.Pool, managing global locks properly"""
-    return multiprocessing.Pool(initializer=_init_global_locks,
-                                initargs=(_global_locks,))
+    return multiprocessing.Pool(initializer=_init_global_locks, initargs=(_global_locks,))
 
 
 try:
     from shlex import quote as shlex_quote
 except ImportError:
-    _find_unsafe = re.compile(r'[^\w@%+=:,./-]').search
+    _find_unsafe = re.compile(r"[^\w@%+=:,./-]").search
 
     def shlex_quote(s):
         """Return a shell-escaped version of the string *s*."""
@@ -1383,36 +1426,33 @@ def git_default_branch():
     try:
         # Local name gets precedence
         default_branch = check_output(
-            [which('git'), 'config', 'init.defaultBranch'],
-            display_error=False).strip()
+            [which("git"), "config", "init.defaultBranch"], display_error=False
+        ).strip()
     except ProcessError:
         # Check global
         try:
             default_branch = check_output(
-                [which('git'), 'config', '--global', 'init.defaultBranch'],
-                display_error=False).strip()
+                [which("git"), "config", "--global", "init.defaultBranch"], display_error=False
+            ).strip()
         except ProcessError:
             # Check system
             try:
                 default_branch = check_output(
-                    [which('git'), 'config', '--system', 'init.defaultBranch'],
-                    display_error=False).strip()
+                    [which("git"), "config", "--system", "init.defaultBranch"], display_error=False
+                ).strip()
             except ProcessError:
                 # Default to master when global and system are not set
-                default_branch = 'master'
+                default_branch = "master"
     return default_branch
 
 
 def search_channels(cli_path, pkg, version):
     try:
-        result = subprocess.run([cli_path, "search",
-                                 f"{pkg}=={version}"],
-                                capture_output=True,
-                                text=True,
-                                check=False)
+        result = subprocess.run(
+            [cli_path, "search", f"{pkg}=={version}"], capture_output=True, text=True, check=False
+        )
     except subprocess.CalledProcessError as e:
-        print(f"Error searching for {pkg} {version}, got:\n {e}",
-              file=sys.stderr)
+        print(f"Error searching for {pkg} {version}, got:\n {e}", file=sys.stderr)
         return False
     if f"No match found for: {pkg}=={version}." in result.stdout:
         return False

--- a/benchmarks/step_detect.py
+++ b/benchmarks/step_detect.py
@@ -8,11 +8,14 @@ class Simple:
     def setup(self):
         self.y = ([1] * 20 + [2] * 30) * 50
 
-    if hasattr(step_detect, 'detect_steps'):
+    if hasattr(step_detect, "detect_steps"):
+
         def time_detect_regressions(self):
             steps = step_detect.detect_steps(self.y)
             step_detect.detect_regressions(steps)
+
     else:
+
         def time_detect_regressions(self):
             step_detect.detect_regressions(self.y)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,8 @@ try:
 except ImportError:
     raise ImportError(
         "sphinx_bootstrap_theme must be installed to build the docs."
-        "  Try `pip install sphinx_bootstrap_theme`.")
+        "  Try `pip install sphinx_bootstrap_theme`."
+    )
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -30,35 +31,33 @@ except ImportError:
 # If your documentation needs a minimal Sphinx version, state it here.
 # needs_sphinx = '1.0'
 
-intersphinx_mapping = {
-    'python': ('http://docs.python.org/', None)
-}
+intersphinx_mapping = {"python": ("http://docs.python.org/", None)}
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
-    'sphinx.ext.mathjax'
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.mathjax",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'airspeed velocity'
-copyright = u'2013-2023, Michael Droettboom, Pauli Virtanen'
+project = "airspeed velocity"
+copyright = "2013-2023, Michael Droettboom, Pauli Virtanen"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -85,7 +84,7 @@ exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-default_role = 'obj'
+default_role = "obj"
 
 # Warn about all references where the target cannot be found.
 nitpicky = True
@@ -102,7 +101,7 @@ nitpicky = True
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
@@ -115,7 +114,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'bootstrap'
+html_theme = "bootstrap"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -123,7 +122,7 @@ html_theme = 'bootstrap'
 html_theme_options = {
     # This is a workaround for a bug in `sphinx_bootstrap_theme` for
     # Python 3.x
-    'bootswatch_theme': None
+    "bootswatch_theme": None
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -143,12 +142,12 @@ html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = '_static/swallow.ico'
+html_favicon = "_static/swallow.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -164,9 +163,7 @@ html_static_path = ['_static']
 # html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-    '**': []
-}
+html_sidebars = {"**": []}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
@@ -199,7 +196,7 @@ html_show_sourcelink = False
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'airspeedvelocitydoc'
+htmlhelp_basename = "airspeedvelocitydoc"
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -207,10 +204,8 @@ htmlhelp_basename = 'airspeedvelocitydoc'
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
 }
@@ -219,8 +214,13 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ('index', 'airspeedvelocity.tex', 'airspeed velocity Documentation',
-     'Michael Droettboom', 'manual'),
+    (
+        "index",
+        "airspeedvelocity.tex",
+        "airspeed velocity Documentation",
+        "Michael Droettboom",
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -249,7 +249,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('manindex', 'asv', u'Airspeed Velocity', [u'Michael Droettboom', u'Pauli Virtanen'], '1'),
+    ("manindex", "asv", "Airspeed Velocity", ["Michael Droettboom", "Pauli Virtanen"], "1"),
 ]
 
 # If true, show URL addresses after external links.
@@ -262,9 +262,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'airspeedvelocity', 'airspeed velocity Documentation',
-     'Michael Droettboom', 'airspeedvelocity', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        "index",
+        "airspeedvelocity",
+        "airspeed velocity Documentation",
+        "Michael Droettboom",
+        "airspeedvelocity",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ doc = [
 dev = [
     "ruff",
     "isort >= 5.11.5",
+    "black",
 ]
 hg = [
     "python-hglib",
@@ -100,9 +101,14 @@ extend-exclude = [
     "test/example_results/cheetah",
 ]
 
+[tool.black]
+line-length = 99
+target-version = ['py37']
+
 [tool.isort]
 line_length = 99
 only_sections = true
+profile = "black"
 
 [tool.setuptools_scm]
 write_to = "asv/_version.py"

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from asv.console import log
+
 # Monkey-patch the machine name
 from asv import machine
 
 log.enable()
 
-machine.Machine.hardcoded_machine_name = 'orangutan'
+machine.Machine.hardcoded_machine_name = "orangutan"

--- a/test/benchmark/cache_examples.py
+++ b/test/benchmark/cache_examples.py
@@ -18,27 +18,27 @@ class ClassLevelSetup:
 def setup_cache():
     with open("data.txt", "wb") as fd:
         fd.write(b"42\n")
-    return {'foo': 42, 'bar': 12}
+    return {"foo": 42, "bar": 12}
 
 
 def track_cache_foo(d):
     assert os.path.isfile("data.txt")
     with open("data.txt", "rb") as fd:
-        assert fd.read().strip() == b'42'
-    return d['foo']
+        assert fd.read().strip() == b"42"
+    return d["foo"]
 
 
 def track_cache_bar(d):
-    return d['bar']
+    return d["bar"]
 
 
 def my_setup_cache():
-    return {'foo': 0, 'bar': 1}
+    return {"foo": 0, "bar": 1}
 
 
 def track_my_cache_foo(d):
     assert not os.path.isfile("data.txt")
-    return d['foo']
+    return d["foo"]
 
 
 track_my_cache_foo.setup_cache = my_setup_cache

--- a/test/benchmark/code_extraction.py
+++ b/test/benchmark/code_extraction.py
@@ -17,10 +17,10 @@ def track_pretty_source_test():
     return 0
 
 
-track_pretty_source_test.pretty_source = '''
+track_pretty_source_test.pretty_source = """
     int track_pretty_source_test() {
         return 0;
-    }'''
+    }"""
 
 
 class MyClass:

--- a/test/benchmark/mem_examples.py
+++ b/test/benchmark/mem_examples.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+
 def mem_list():
     return [0] * 255

--- a/test/benchmark/named.py
+++ b/test/benchmark/named.py
@@ -1,30 +1,29 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-class Suite:
 
+class Suite:
     def named_method(self):
         return 0
 
-    named_method.benchmark_name = 'custom.track_method'
+    named_method.benchmark_name = "custom.track_method"
 
 
 def named_function():
     pass
 
 
-named_function.benchmark_name = 'custom.time_function'
-named_function.pretty_name = 'My Custom Function'
+named_function.benchmark_name = "custom.time_function"
+named_function.pretty_name = "My Custom Function"
 
 
 def track_custom_pretty_name():
     return 42
 
 
-track_custom_pretty_name.pretty_name = 'this.is/the.answer'
+track_custom_pretty_name.pretty_name = "this.is/the.answer"
 
 
 class BaseSuite:
-
     def some_func(self):
         return 0
 

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+
 class ClassOne:
     pass
 
@@ -20,14 +21,14 @@ def mem_param(n, m):
 
 
 mem_param.params = ([10, 20], [2, 3])
-mem_param.param_names = ['number', 'depth']
+mem_param.param_names = ["number", "depth"]
 
 
 class ParamSuite:
-    params = ['a', 'b', 'c']
+    params = ["a", "b", "c"]
 
     def setup(self, p):
-        values = {'a': 1, 'b': 2, 'c': 3}
+        values = {"a": 1, "b": 2, "c": 3}
         self.count = 0
         self.value = values[p]
 
@@ -40,12 +41,11 @@ class ParamSuite:
 
 
 class FunctionParamSuite:
-    params = [track_param,
-              lambda x: x]
-    param_names = ['func']
+    params = [track_param, lambda x: x]
+    param_names = ["func"]
 
     def time_func(self, func):
-        return func('foo')
+        return func("foo")
 
 
 class TuningTest:
@@ -68,8 +68,9 @@ class TuningTest:
     def teardown(self, n):
         # The time benchmark may call it one additional time
         if not (self.counter[0] <= n + 1 and self.counter[1] == 1):
-            raise RuntimeError("Number and repeat didn't have effect: {} {}".format(
-                self.counter, n))
+            raise RuntimeError(
+                "Number and repeat didn't have effect: {} {}".format(self.counter, n)
+            )
 
 
 def setup_skip(n):
@@ -99,6 +100,7 @@ def time_find_test_timeout():
     import time
 
     import asv_test_repo
+
     if asv_test_repo.dummy_value[1] < 0:
         time.sleep(100)
 
@@ -113,7 +115,7 @@ def track_param_selection(a, b):
     return a + b
 
 
-track_param_selection.param_names = ['a', 'b']
+track_param_selection.param_names = ["a", "b"]
 track_param_selection.params = [[1, 2], [3, 5]]
 
 

--- a/test/benchmark/peakmem_examples.py
+++ b/test/benchmark/peakmem_examples.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+
 def peakmem_list():
     # One element takes sizeof(void*) bytes; the code below uses up
     # 4MB (32-bit) or 8MB (64-bit)

--- a/test/benchmark/time_examples.py
+++ b/test/benchmark/time_examples.py
@@ -15,15 +15,15 @@ class TimeSuite:
         self.n = 100
 
     def time_example_benchmark_1(self):
-        s = ''
+        s = ""
         for i in xrange(self.n):
-            s = s + 'x'
+            s = s + "x"
 
     def time_example_benchmark_2(self):
         s = []
         for i in xrange(self.n):
-            s.append('x')
-        ''.join(s)
+            s.append("x")
+        "".join(s)
 
 
 class TimeSuiteSub(TimeSuite):
@@ -31,10 +31,10 @@ class TimeSuiteSub(TimeSuite):
 
 
 def time_with_warnings():
-    print('hi')
-    warnings.warn('before')
+    print("hi")
+    warnings.warn("before")
     1 / 0
-    warnings.warn('after')
+    warnings.warn("after")
 
 
 time_with_warnings.sample_time = 0.1

--- a/test/benchmark/time_secondary.py
+++ b/test/benchmark/time_secondary.py
@@ -15,6 +15,7 @@ if sys.version_info[0] < 3:
     import commands
 try:
     import commands.quickstart  # noqa F401 unused import
+
     assert False
 except ImportError:
     # OK
@@ -47,7 +48,7 @@ def test_shared_code():
 
 
 def track_environment_value():
-    v = os.environ.get('SOME_TEST_VAR', '0')
+    v = os.environ.get("SOME_TEST_VAR", "0")
     try:
         return int(v)
     except (ValueError, TypeError):
@@ -55,7 +56,7 @@ def track_environment_value():
 
 
 def track_fail_errcode_123():
-    if hasattr(os, '_exit'):
+    if hasattr(os, "_exit"):
         os._exit(123)
     else:
         sys.exit(123)

--- a/test/benchmark/timeraw_examples.py
+++ b/test/benchmark/timeraw_examples.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+
 class TimerawSuite:
     def timeraw_fresh(self):
         # The test interpreter should not be polluted with anything.
@@ -19,6 +20,7 @@ class TimerawSuite:
         while True:
             pass
         """
+
     timeraw_timeout.timeout = 0.1
 
     def timeraw_count(self):
@@ -27,6 +29,7 @@ class TimerawSuite:
         import sys
         sys.stderr.write('0')
         """
+
     timeraw_count.repeat = 7
     timeraw_count.number = 3
     timeraw_count.warmup_time = 0

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -14,18 +14,15 @@ from asv.repo import get_repo
 
 from . import tools
 
-BENCHMARK_DIR = join(dirname(__file__), 'benchmark')
+BENCHMARK_DIR = join(dirname(__file__), "benchmark")
 
-INVALID_BENCHMARK_DIR = join(
-    dirname(__file__), 'benchmark.invalid')
+INVALID_BENCHMARK_DIR = join(dirname(__file__), "benchmark.invalid")
 
-ASV_CONF_JSON = {
-    'project': 'asv'
-}
+ASV_CONF_JSON = {"project": "asv"}
 
-if hasattr(sys, 'pypy_version_info'):
+if hasattr(sys, "pypy_version_info"):
     ON_PYPY = True
-    ASV_CONF_JSON['pythons'] = ["pypy{0[0]}.{0[1]}".format(sys.version_info)]
+    ASV_CONF_JSON["pythons"] = ["pypy{0[0]}.{0[1]}".format(sys.version_info)]
 else:
     ON_PYPY = False
 
@@ -33,64 +30,75 @@ else:
 def test_discover_benchmarks(benchmarks_fixture):
     conf, repo, envs, commit_hash = benchmarks_fixture
 
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex='secondary')
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex="secondary")
     assert len(b) == 6
 
     old_branches = conf.branches
-    conf.branches = [f"{util.git_default_branch()}",
-                     "some-missing-branch"]  # missing branches ignored
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex='example')
+    conf.branches = [
+        f"{util.git_default_branch()}",
+        "some-missing-branch",
+    ]  # missing branches ignored
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex="example")
     conf.branches = old_branches
     assert len(b) == 36
 
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex='time_example_benchmark_1')
+    b = benchmarks.Benchmarks.discover(
+        conf, repo, envs, [commit_hash], regex="time_example_benchmark_1"
+    )
     assert len(b) == 2
 
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex=['time_example_benchmark_1',
-                                       'some regexp that does not match anything'])
+    b = benchmarks.Benchmarks.discover(
+        conf,
+        repo,
+        envs,
+        [commit_hash],
+        regex=["time_example_benchmark_1", "some regexp that does not match anything"],
+    )
     assert len(b) == 2
 
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex='custom')
-    assert sorted(b.keys()) == ['custom.time_function', 'custom.track_method',
-                                'named.track_custom_pretty_name']
-    assert 'pretty_name' not in b['custom.track_method']
-    assert b['custom.time_function']['pretty_name'] == 'My Custom Function'
-    assert b['named.track_custom_pretty_name']['pretty_name'] == 'this.is/the.answer'
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex="custom")
+    assert sorted(b.keys()) == [
+        "custom.time_function",
+        "custom.track_method",
+        "named.track_custom_pretty_name",
+    ]
+    assert "pretty_name" not in b["custom.track_method"]
+    assert b["custom.time_function"]["pretty_name"] == "My Custom Function"
+    assert b["named.track_custom_pretty_name"]["pretty_name"] == "this.is/the.answer"
 
     # benchmark param selection with regex
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex=r'track_param_selection\(.*, 3\)')
-    assert list(b.keys()) == ['params_examples.track_param_selection']
-    assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 2]
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex=r'track_param_selection\(1, ')
-    assert list(b.keys()) == ['params_examples.track_param_selection']
-    assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1]
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex='track_param_selection')
-    assert list(b.keys()) == ['params_examples.track_param_selection']
-    assert b._benchmark_selection['params_examples.track_param_selection'] == [0, 1, 2, 3]
+    b = benchmarks.Benchmarks.discover(
+        conf, repo, envs, [commit_hash], regex=r"track_param_selection\(.*, 3\)"
+    )
+    assert list(b.keys()) == ["params_examples.track_param_selection"]
+    assert b._benchmark_selection["params_examples.track_param_selection"] == [0, 2]
+    b = benchmarks.Benchmarks.discover(
+        conf, repo, envs, [commit_hash], regex=r"track_param_selection\(1, "
+    )
+    assert list(b.keys()) == ["params_examples.track_param_selection"]
+    assert b._benchmark_selection["params_examples.track_param_selection"] == [0, 1]
+    b = benchmarks.Benchmarks.discover(
+        conf, repo, envs, [commit_hash], regex="track_param_selection"
+    )
+    assert list(b.keys()) == ["params_examples.track_param_selection"]
+    assert b._benchmark_selection["params_examples.track_param_selection"] == [0, 1, 2, 3]
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
     assert len(b) == 50
 
-    assert 'named.OtherSuite.track_some_func' in b
+    assert "named.OtherSuite.track_some_func" in b
 
-    params = b['params_examples.FunctionParamSuite.time_func']['params']
+    params = b["params_examples.FunctionParamSuite.time_func"]["params"]
     assert len(params) == 1
     assert len(params[0]) == 2
-    assert params[0][0] == '<function track_param>'
+    assert params[0][0] == "<function track_param>"
     # repr is a bit different on py2 vs py3 here
-    assert params[0][1] in ['<function FunctionParamSuite.<lambda>>', '<function <lambda>>']
+    assert params[0][1] in ["<function FunctionParamSuite.<lambda>>", "<function <lambda>>"]
 
     # Raw timing benchmarks
-    assert b['timeraw_examples.TimerawSuite.timeraw_count']['repeat'] == 7
-    assert b['timeraw_examples.TimerawSuite.timeraw_count']['number'] == 3
-    assert b['timeraw_examples.TimerawSuite.timeraw_setup']['number'] == 1
+    assert b["timeraw_examples.TimerawSuite.timeraw_count"]["repeat"] == 7
+    assert b["timeraw_examples.TimerawSuite.timeraw_count"]["number"] == 3
+    assert b["timeraw_examples.TimerawSuite.timeraw_setup"]["number"] == 1
 
 
 def test_invalid_benchmark_tree(tmpdir):
@@ -99,9 +107,9 @@ def test_invalid_benchmark_tree(tmpdir):
 
     d = {}
     d.update(ASV_CONF_JSON)
-    d['benchmark_dir'] = INVALID_BENCHMARK_DIR
-    d['env_dir'] = "env"
-    d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
+    d["benchmark_dir"] = INVALID_BENCHMARK_DIR
+    d["env_dir"] = "env"
+    d["repo"] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
     repo = get_repo(conf)
@@ -119,12 +127,13 @@ def test_find_benchmarks_cwd_imports(tmpdir):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
-    os.makedirs('benchmark')
-    with open(os.path.join('benchmark', '__init__.py'), 'w') as f:
+    os.makedirs("benchmark")
+    with open(os.path.join("benchmark", "__init__.py"), "w") as f:
         pass
 
-    with open(os.path.join('benchmark', 'test.py'), 'w') as f:
-        f.write("""
+    with open(os.path.join("benchmark", "test.py"), "w") as f:
+        f.write(
+            """
 try:
     import this_should_really_not_be_here
     raise AssertionError('This should not happen!')
@@ -133,24 +142,24 @@ except ImportError:
 
 def track_this():
     return 0
-""")
+"""
+        )
 
-    with open(os.path.join('this_should_really_not_be_here.py'), 'w') as f:
+    with open(os.path.join("this_should_really_not_be_here.py"), "w") as f:
         f.write("raise AssertionError('Should not be imported!')")
 
     d = {}
     d.update(ASV_CONF_JSON)
-    d['env_dir'] = "env"
-    d['benchmark_dir'] = 'benchmark'
-    d['repo'] = tools.generate_test_repo(tmpdir, [[0, 1]]).path
+    d["env_dir"] = "env"
+    d["benchmark_dir"] = "benchmark"
+    d["repo"] = tools.generate_test_repo(tmpdir, [[0, 1]]).path
     conf = config.Config.from_json(d)
 
     repo = get_repo(conf)
     envs = list(environment.get_environments(conf, None))
     commit_hash = repo.get_hash_from_name(repo.get_branch_name())
 
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex='track_this')
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex="track_this")
     assert len(b) == 1
 
 
@@ -160,9 +169,11 @@ def test_import_failure_retry(tmpdir):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
-    os.makedirs('benchmark')
-    with open(os.path.join('benchmark', '__init__.py'), 'w') as f:
-        f.write(textwrap.dedent("""
+    os.makedirs("benchmark")
+    with open(os.path.join("benchmark", "__init__.py"), "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
         import asv_test_repo
 
         def time_foo():
@@ -172,15 +183,17 @@ def test_import_failure_retry(tmpdir):
 
         if asv_test_repo.dummy_value == 0:
             raise RuntimeError("fail discovery")
-        """))
+        """
+            )
+        )
 
     dvcs = tools.generate_test_repo(tmpdir, [2, 1, 0])
 
     d = {}
     d.update(ASV_CONF_JSON)
-    d['env_dir'] = "env"
-    d['benchmark_dir'] = 'benchmark'
-    d['repo'] = dvcs.path
+    d["env_dir"] = "env"
+    d["benchmark_dir"] = "benchmark"
+    d["repo"] = dvcs.path
     conf = config.Config.from_json(d)
 
     repo = get_repo(conf)
@@ -189,28 +202,28 @@ def test_import_failure_retry(tmpdir):
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, commit_hashes)
     assert len(b) == 1
-    assert b['time_foo']['number'] == 1
+    assert b["time_foo"]["number"] == 1
 
 
 def test_conf_inside_benchmarks_dir(tmpdir):
     # Test that the configuration file can be inside the benchmark suite
 
     tmpdir = str(tmpdir)
-    benchmark_dir = os.path.join(tmpdir, 'benchmark')
+    benchmark_dir = os.path.join(tmpdir, "benchmark")
 
     os.makedirs(benchmark_dir)
-    with open(os.path.join(benchmark_dir, '__init__.py'), 'w') as f:
+    with open(os.path.join(benchmark_dir, "__init__.py"), "w") as f:
         # Test also benchmark in top-level __init__.py
         f.write("def track_this(): pass")
 
-    with open(os.path.join(benchmark_dir, 'bench.py'), 'w') as f:
+    with open(os.path.join(benchmark_dir, "bench.py"), "w") as f:
         f.write("def track_this(): pass")
 
     d = {}
     d.update(ASV_CONF_JSON)
-    d['env_dir'] = "env"
-    d['benchmark_dir'] = '.'
-    d['repo'] = tools.generate_test_repo(tmpdir, [[0, 1]]).path
+    d["env_dir"] = "env"
+    d["benchmark_dir"] = "."
+    d["repo"] = tools.generate_test_repo(tmpdir, [[0, 1]]).path
     conf = config.Config.from_json(d)
 
     # NB. conf_dir == getcwd()
@@ -220,32 +233,33 @@ def test_conf_inside_benchmarks_dir(tmpdir):
     envs = list(environment.get_environments(conf, None))
     commit_hash = repo.get_hash_from_name(repo.get_branch_name())
 
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex='track_this')
-    assert set(b.keys()) == {'track_this', 'bench.track_this'}
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex="track_this")
+    assert set(b.keys()) == {"track_this", "bench.track_this"}
 
 
 def test_code_extraction(tmpdir):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
-    shutil.copytree(BENCHMARK_DIR, 'benchmark')
+    shutil.copytree(BENCHMARK_DIR, "benchmark")
 
     d = {}
     d.update(ASV_CONF_JSON)
-    d['env_dir'] = "env"
-    d['benchmark_dir'] = 'benchmark'
-    d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
+    d["env_dir"] = "env"
+    d["benchmark_dir"] = "benchmark"
+    d["repo"] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
     repo = get_repo(conf)
     envs = list(environment.get_environments(conf, None))
     commit_hash = repo.get_hash_from_name(repo.get_branch_name())
 
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash],
-                                       regex=r'^code_extraction\.')
+    b = benchmarks.Benchmarks.discover(
+        conf, repo, envs, [commit_hash], regex=r"^code_extraction\."
+    )
 
-    expected_code = textwrap.dedent("""
+    expected_code = textwrap.dedent(
+        """
     def track_test():
         # module-level 難
         return 0
@@ -257,13 +271,15 @@ def test_code_extraction(tmpdir):
     def setup_cache():
         # module-level
         pass
-    """).strip()
+    """
+    ).strip()
 
-    bench = b['code_extraction.track_test']
-    assert bench['version'] == sha256(bench['code'].encode('utf-8')).hexdigest()
-    assert bench['code'] == expected_code
+    bench = b["code_extraction.track_test"]
+    assert bench["version"] == sha256(bench["code"].encode("utf-8")).hexdigest()
+    assert bench["code"] == expected_code
 
-    expected_code = textwrap.dedent("""
+    expected_code = textwrap.dedent(
+        """
     int track_pretty_source_test() {
         return 0;
     }
@@ -275,13 +291,15 @@ def test_code_extraction(tmpdir):
     def setup_cache():
         # module-level
         pass
-    """).strip()
+    """
+    ).strip()
 
-    bench = b['code_extraction.track_pretty_source_test']
-    assert bench['version'] == sha256(bench['code'].encode('utf-8')).hexdigest()
-    assert bench['code'] == expected_code
+    bench = b["code_extraction.track_pretty_source_test"]
+    assert bench["version"] == sha256(bench["code"].encode("utf-8")).hexdigest()
+    assert bench["code"] == expected_code
 
-    expected_code = textwrap.dedent("""
+    expected_code = textwrap.dedent(
+        """
     class MyClass:
         def track_test(self):
             # class-level 難
@@ -299,19 +317,20 @@ def test_code_extraction(tmpdir):
         def setup_cache(self):
             # class-level
             pass
-    """).strip()
+    """
+    ).strip()
 
-    bench = b['code_extraction.MyClass.track_test']
-    assert bench['version'] == sha256(bench['code'].encode('utf-8')).hexdigest()
+    bench = b["code_extraction.MyClass.track_test"]
+    assert bench["version"] == sha256(bench["code"].encode("utf-8")).hexdigest()
 
     if sys.version_info[:2] != (3, 2):
         # Python 3.2 doesn't have __qualname__
-        assert bench['code'] == expected_code
+        assert bench["code"] == expected_code
 
 
 def test_asv_benchmark_timings():
     # Check the benchmark runner runs
-    util.check_call([sys.executable, '-masv.benchmark', 'timing',
-                     '--setup=import time',
-                     'time.sleep(0)'],
-                    cwd=os.path.join(os.path.dirname(__file__), '..'))
+    util.check_call(
+        [sys.executable, "-masv.benchmark", "timing", "--setup=import time", "time.sleep(0)"],
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+    )

--- a/test/test_check.py
+++ b/test/test_check.py
@@ -14,10 +14,13 @@ def test_check(capsys, basic_conf):
 
     # Test check runs (with full benchmark suite)
     with pytest.raises(util.UserError, match="Benchmark suite check failed"):
-        tools.run_asv_with_conf(conf, 'check', "--python=same")
+        tools.run_asv_with_conf(conf, "check", "--python=same")
 
     text, err = capsys.readouterr()
 
-    assert re.search(r"params_examples\.track_wrong_number_of_args: call: "
-                     r"wrong number of arguments.*: expected 1, has 2", text)
+    assert re.search(
+        r"params_examples\.track_wrong_number_of_args: call: "
+        r"wrong number of arguments.*: expected 1, has 2",
+        text,
+    )
     assert text.count("wrong number of arguments") == 1

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -17,7 +17,7 @@ except ImportError:
     hglib = None
 
 
-MACHINE_FILE = abspath(join(dirname(__file__), 'asv-machine.json'))
+MACHINE_FILE = abspath(join(dirname(__file__), "asv-machine.json"))
 
 REFERENCE = """
 All benchmarks:
@@ -154,93 +154,148 @@ def test_compare(capsys, tmpdir, example_results):
     os.chdir(tmpdir)
 
     conf = config.Config.from_json(
-        {'results_dir': example_results,
-         'repo': tools.generate_test_repo(tmpdir).path,
-         'project': 'asv',
-         'environment_type': "shouldn't matter what"})
+        {
+            "results_dir": example_results,
+            "repo": tools.generate_test_repo(tmpdir).path,
+            "project": "asv",
+            "environment_type": "shouldn't matter what",
+        }
+    )
 
-    tools.run_asv_with_conf(conf, 'compare', '22b920c6', 'fcf8c079', '--machine=cheetah',
-                            '--factor=2', '--environment=py2.7-numpy1.8')
+    tools.run_asv_with_conf(
+        conf,
+        "compare",
+        "22b920c6",
+        "fcf8c079",
+        "--machine=cheetah",
+        "--factor=2",
+        "--environment=py2.7-numpy1.8",
+    )
 
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE.strip()
 
-    tools.run_asv_with_conf(conf, 'compare', '22b920c6', 'fcf8c079', '--machine=cheetah',
-                            '--factor=2', '--split', '--environment=py2.7-numpy1.8')
+    tools.run_asv_with_conf(
+        conf,
+        "compare",
+        "22b920c6",
+        "fcf8c079",
+        "--machine=cheetah",
+        "--factor=2",
+        "--split",
+        "--environment=py2.7-numpy1.8",
+    )
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE_SPLIT.strip()
 
     # Check print_table output as called from Continuous
-    status = Compare.print_table(conf, '22b920c6', 'fcf8c079', factor=2, machine='cheetah',
-                                 split=False, only_changed=True, sort='ratio',
-                                 env_names=["py2.7-numpy1.8"],
-                                 commit_names={'22b920c6': 'name1', 'fcf8c079': 'name2'})
+    status = Compare.print_table(
+        conf,
+        "22b920c6",
+        "fcf8c079",
+        factor=2,
+        machine="cheetah",
+        split=False,
+        only_changed=True,
+        sort="ratio",
+        env_names=["py2.7-numpy1.8"],
+        commit_names={"22b920c6": "name1", "fcf8c079": "name2"},
+    )
     worsened, improved = status
     assert worsened
     assert improved
     text, err = capsys.readouterr()
     # Removing tailing spaces, so they don't need to be in `REFERENCE_ONLY_CHANGED`
-    text = re.sub(r' *\n', r'\n', text)
+    text = re.sub(r" *\n", r"\n", text)
     assert text.strip() == REFERENCE_ONLY_CHANGED.strip()
 
     # Check table with multiple environments
-    status = Compare.print_table(conf, '22b920c6', 'fcf8c079', factor=2, machine='cheetah',
-                                 split=False, only_changed=True, sort='ratio')
+    status = Compare.print_table(
+        conf,
+        "22b920c6",
+        "fcf8c079",
+        factor=2,
+        machine="cheetah",
+        split=False,
+        only_changed=True,
+        sort="ratio",
+    )
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE_ONLY_CHANGED_MULTIENV.strip()
 
     # Check results with no stats
-    tools.run_asv_with_conf(conf, 'compare', '22b920c6', 'fcf8c079', '--machine=cheetah',
-                            '--factor=2', '--sort=ratio', '--environment=py2.7-numpy1.8',
-                            '--no-stats', '--only-changed')
+    tools.run_asv_with_conf(
+        conf,
+        "compare",
+        "22b920c6",
+        "fcf8c079",
+        "--machine=cheetah",
+        "--factor=2",
+        "--sort=ratio",
+        "--environment=py2.7-numpy1.8",
+        "--no-stats",
+        "--only-changed",
+    )
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE_ONLY_CHANGED_NOSTATS.strip()
     assert "time_ci_big" in text.strip()
 
 
-@pytest.mark.parametrize("dvcs_type", [
-    "git",
-    pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))
-])
+@pytest.mark.parametrize(
+    "dvcs_type",
+    ["git", pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))],
+)
 def test_compare_name_lookup(dvcs_type, capsys, tmpdir, example_results):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
     repo = tools.generate_test_repo(tmpdir, dvcs_type=dvcs_type)
 
-    branch_name = util.git_default_branch() if dvcs_type == 'git' else 'default'
+    branch_name = util.git_default_branch() if dvcs_type == "git" else "default"
     commit_hash = repo.get_branch_hashes(branch_name)[0]
 
-    result_dir = os.path.join(tmpdir, 'results')
+    result_dir = os.path.join(tmpdir, "results")
 
-    src = os.path.join(example_results, 'cheetah')
-    dst = os.path.join(result_dir, 'cheetah')
+    src = os.path.join(example_results, "cheetah")
+    dst = os.path.join(result_dir, "cheetah")
     os.makedirs(dst)
 
-    for fn in ['feea15ca-py2.7-Cython-numpy1.8.json', 'machine.json']:
+    for fn in ["feea15ca-py2.7-Cython-numpy1.8.json", "machine.json"]:
         shutil.copyfile(os.path.join(src, fn), os.path.join(dst, fn))
 
-    shutil.copyfile(os.path.join(example_results, 'benchmarks.json'),
-                    os.path.join(result_dir, 'benchmarks.json'))
+    shutil.copyfile(
+        os.path.join(example_results, "benchmarks.json"),
+        os.path.join(result_dir, "benchmarks.json"),
+    )
 
     # Copy to different commit
-    fn_1 = os.path.join(dst, 'feea15ca-py2.7-Cython-numpy1.8.json')
-    fn_2 = os.path.join(dst, commit_hash[:8] + '-py2.7-Cython-numpy1.8.json')
+    fn_1 = os.path.join(dst, "feea15ca-py2.7-Cython-numpy1.8.json")
+    fn_2 = os.path.join(dst, commit_hash[:8] + "-py2.7-Cython-numpy1.8.json")
     data = util.load_json(fn_1)
-    data['commit_hash'] = commit_hash
+    data["commit_hash"] = commit_hash
     util.write_json(fn_2, data)
 
     conf = config.Config.from_json(
-        {'results_dir': result_dir,
-         'repo': repo.path,
-         'project': 'asv',
-         'environment_type': "shouldn't matter what"})
+        {
+            "results_dir": result_dir,
+            "repo": repo.path,
+            "project": "asv",
+            "environment_type": "shouldn't matter what",
+        }
+    )
 
     # Lookup with symbolic name
-    tools.run_asv_with_conf(conf, 'compare', branch_name, 'feea15ca', '--machine=cheetah',
-                            '--factor=2', '--environment=py2.7-Cython-numpy1.8',
-                            '--only-changed')
+    tools.run_asv_with_conf(
+        conf,
+        "compare",
+        branch_name,
+        "feea15ca",
+        "--machine=cheetah",
+        "--factor=2",
+        "--environment=py2.7-Cython-numpy1.8",
+        "--only-changed",
+    )
 
     # Nothing should be printed since no results were changed
     text, err = capsys.readouterr()
-    assert text.strip() == ''
+    assert text.strip() == ""

--- a/test/test_conf.py
+++ b/test/test_conf.py
@@ -8,15 +8,15 @@ from asv.commands import Command
 
 
 def test_config():
-    conf = config.Config.load(join(dirname(__file__), 'asv.conf.json'))
+    conf = config.Config.load(join(dirname(__file__), "asv.conf.json"))
 
-    assert conf.project == 'astropy'
+    assert conf.project == "astropy"
     assert conf.matrix == {
         "numpy": ["1.8"],
         "Cython": [],
         "jinja2": [],
     }
-    assert conf.benchmark_dir == 'benchmark'
+    assert conf.benchmark_dir == "benchmark"
     assert conf.branches == [None]
     assert conf.install_timeout == 3142  # GH391
 
@@ -30,9 +30,7 @@ def test_config_default_install_timeout():
 class CustomCommand(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
-        parser = subparsers.add_parser(
-            "custom", help="Custom command",
-            description="Juts a test.")
+        parser = subparsers.add_parser("custom", help="Custom command", description="Juts a test.")
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -47,15 +45,15 @@ def test_load_plugin():
     os.chdir(dirname(__file__))
 
     parser, subparsers = commands.make_argparser()
-    args = parser.parse_args(['custom'])
+    args = parser.parse_args(["custom"])
 
-    assert hasattr(args, 'func')
+    assert hasattr(args, "func")
 
     args.func(args)
 
     for env in util.iter_subclasses(environment.Environment):
         print(env.__name__)
-        if env.__name__ == 'MyEnvironment':
+        if env.__name__ == "MyEnvironment":
             break
     else:
         assert False, "Custom plugin not loaded"

--- a/test/test_console.py
+++ b/test/test_console.py
@@ -38,10 +38,10 @@ def test_write_with_fallback(tmpdir, capfd):
                 _write_with_fallback(value, stream)
 
             # Check writing to a file
-            fn = os.path.join(tmpdir, 'tmp.txt')
-            with io.open(fn, 'w', encoding=stream_encoding) as stream:
+            fn = os.path.join(tmpdir, "tmp.txt")
+            with io.open(fn, "w", encoding=stream_encoding) as stream:
                 _write_with_fallback(value, stream)
-            with open(fn, 'rb') as stream:
+            with open(fn, "rb") as stream:
                 got = stream.read()
                 assert got == expected
         finally:
@@ -54,7 +54,7 @@ def test_write_with_fallback(tmpdir, capfd):
     # - Otherwise, map characters produced by asv to ascii equivalents, and
     #   - Try to print in latin1
     #   - Try to print in ascii, replacing all non-ascii characters
-    encodings = ['utf-8', 'latin1', 'ascii', 'euc-jp']
+    encodings = ["utf-8", "latin1", "ascii", "euc-jp"]
     strings = ["helloμ", "hello·", "hello難", "helloä", "hello±"]
     repmap = {"helloμ": "hellou", "hello·": "hello-", "hello±": "hello~"}
 
@@ -69,7 +69,7 @@ def test_write_with_fallback(tmpdir, capfd):
                 pass
         else:
             s2 = repmap.get(s, s)
-            expected = s2.encode(pref_enc, errors='replace')
+            expected = s2.encode(pref_enc, errors="replace")
 
         check_write(s, expected, stream_enc, pref_enc)
 
@@ -87,8 +87,8 @@ def test_color_print_nofail(capfd):
         color_print(b"really\xfe", "green", "not really")
 
     out, err = capfd.readouterr()
-    assert 'hello' in out
-    assert 'indeed' in out
+    assert "hello" in out
+    assert "indeed" in out
 
 
 def test_log_indent(capsys):
@@ -97,11 +97,11 @@ def test_log_indent(capsys):
 
     out, err = capsys.readouterr()
     lines = out.lstrip().splitlines()
-    assert lines[0].index('First') == lines[1].index('Second')
+    assert lines[0].index("First") == lines[1].index("Second")
 
     log.set_nitems(1)
     log.info("First\nSecond")
 
     out, err = capsys.readouterr()
     lines = out.lstrip().splitlines()
-    assert lines[0].index('First') == lines[1].index('Second')
+    assert lines[0].index("First") == lines[1].index("Second")

--- a/test/test_continuous.py
+++ b/test/test_continuous.py
@@ -18,14 +18,20 @@ def test_continuous(capfd, basic_conf_2):
     env_spec = ("-E", env_type + ":" + python)
 
     # Check that asv continuous runs
-    tools.run_asv_with_conf(conf, 'continuous',
-                            f"{util.git_default_branch()}^", '--show-stderr',
-                            '--bench=params_examples.track_find_test',
-                            '--bench=params_examples.track_param',
-                            '--bench=time_examples.TimeSuite.time_example_benchmark_1',
-                            '--attribute=repeat=1', '--attribute=number=1',
-                            '--attribute=warmup_time=0',
-                            *env_spec, _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "continuous",
+        f"{util.git_default_branch()}^",
+        "--show-stderr",
+        "--bench=params_examples.track_find_test",
+        "--bench=params_examples.track_param",
+        "--bench=time_examples.TimeSuite.time_example_benchmark_1",
+        "--attribute=repeat=1",
+        "--attribute=number=1",
+        "--attribute=warmup_time=0",
+        *env_spec,
+        _machine_file=machine_file,
+    )
 
     text, err = capfd.readouterr()
     assert "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY" in text
@@ -42,6 +48,6 @@ def test_continuous(capfd, basic_conf_2):
     result_found = False
     for results in iter_results_for_machine(conf.results_dir, "orangutan"):
         result_found = True
-        stats = results.get_result_stats('time_examples.TimeSuite.time_example_benchmark_1', [])
-        assert stats[0]['repeat'] == 2
+        stats = results.get_result_stats("time_examples.TimeSuite.time_example_benchmark_1", [])
+        assert stats[0]["repeat"] == 2
     assert result_found

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -11,8 +11,7 @@ def test_dev(capsys, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
 
     # Test Dev runs (with full benchmark suite)
-    ret = tools.run_asv_with_conf(conf, 'dev', '--quick', '-e',
-                                  _machine_file=machine_file)
+    ret = tools.run_asv_with_conf(conf, "dev", "--quick", "-e", _machine_file=machine_file)
     assert ret == 2
     text, err = capsys.readouterr()
 
@@ -32,9 +31,9 @@ def test_dev_with_repo_subdir(capsys, basic_conf_with_subdir):
     tmpdir, local, conf, machine_file = basic_conf_with_subdir
 
     # Test Dev runs
-    tools.run_asv_with_conf(conf, 'dev', '--quick',
-                            '--bench=time_secondary.track_value',
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf, "dev", "--quick", "--bench=time_secondary.track_value", _machine_file=machine_file
+    )
     text, err = capsys.readouterr()
 
     # Benchmarks were found and run
@@ -47,9 +46,9 @@ def test_dev_with_repo_subdir(capsys, basic_conf_with_subdir):
 
 def test_dev_strict(basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
-    ret = tools.run_asv_with_conf(conf, 'dev', '--quick',
-                                  '--bench=TimeSecondary',
-                                  _machine_file=machine_file)
+    ret = tools.run_asv_with_conf(
+        conf, "dev", "--quick", "--bench=TimeSecondary", _machine_file=machine_file
+    )
     assert ret == 2
 
 
@@ -57,10 +56,14 @@ def test_run_python_same(capsys, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
 
     # Test Run runs with python=same
-    tools.run_asv_with_conf(conf, 'run', '--python=same',
-                            '--bench=time_secondary.TimeSecondary.time_exception',
-                            '--bench=time_secondary.track_value',
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        "--python=same",
+        "--bench=time_secondary.TimeSecondary.time_exception",
+        "--bench=time_secondary.track_value",
+        _machine_file=machine_file,
+    )
     text, err = capsys.readouterr()
 
     assert re.search("time_exception.*failed", text, re.S)
@@ -75,8 +78,9 @@ def test_profile_python_same(capsys, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
 
     # Test Profile can run with python=same
-    tools.run_asv_with_conf(conf, 'profile', '--python=same', "time_secondary.track_value",
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf, "profile", "--python=same", "time_secondary.track_value", _machine_file=machine_file
+    )
     text, err = capsys.readouterr()
 
     # time_with_warnings failure case
@@ -90,41 +94,41 @@ def test_profile_python_same(capsys, basic_conf):
 def test_dev_python_arg():
     parser, subparsers = make_argparser()
 
-    argv = ['dev']
+    argv = ["dev"]
     args = parser.parse_args(argv)
     assert args.env_spec == []
     assert not args.verbose
 
-    argv = ['dev', '--python=foo']
+    argv = ["dev", "--python=foo"]
     args = parser.parse_args(argv)
-    assert args.env_spec == [':foo']
+    assert args.env_spec == [":foo"]
 
-    argv = ['dev', '-E', 'existing:foo']
+    argv = ["dev", "-E", "existing:foo"]
     args = parser.parse_args(argv)
-    assert args.env_spec == ['existing:foo']
+    assert args.env_spec == ["existing:foo"]
 
-    argv = ['run', 'ALL']
+    argv = ["run", "ALL"]
     args = parser.parse_args(argv)
     assert args.env_spec == []
 
-    argv = ['--verbose', '--config=foo', 'dev']
+    argv = ["--verbose", "--config=foo", "dev"]
     args = parser.parse_args(argv)
     assert args.verbose
-    assert args.config == 'foo'
+    assert args.config == "foo"
 
-    argv = ['dev', '--verbose', '--config=foo']
+    argv = ["dev", "--verbose", "--config=foo"]
     args = parser.parse_args(argv)
     assert args.verbose
-    assert args.config == 'foo'
+    assert args.config == "foo"
 
 
 def test_run_steps_arg():
     parser, subparsers = make_argparser()
 
-    argv = ['run', '--steps=20', 'ALL']
+    argv = ["run", "--steps=20", "ALL"]
     args = parser.parse_args(argv)
     assert args.steps == 20
 
 
-if __name__ == '__main__':
-    test_dev('/tmp')
+if __name__ == "__main__":
+    test_dev("/tmp")

--- a/test/test_feed.py
+++ b/test/test_feed.py
@@ -10,6 +10,7 @@ from asv import feed
 
 try:
     import feedparser
+
     HAVE_FEEDPARSER = True
 except ImportError:
     HAVE_FEEDPARSER = False
@@ -17,6 +18,7 @@ except ImportError:
 
 try:
     import feedvalidator
+
     HAVE_FEEDVALIDATOR = True
 except ImportError:
     HAVE_FEEDVALIDATOR = False
@@ -27,21 +29,25 @@ def prettify_xml(text):
 
 
 def dummy_feed_xml():
-    entry_1 = feed.FeedEntry(title='Some title', updated=datetime.datetime(1993, 1, 1))
-    entry_2 = feed.FeedEntry(title='Another title', updated=datetime.datetime(1990, 1, 1),
-                             link='http://foo', content='More text', id_context=['something'],
-                             id_date=datetime.datetime(2000, 1, 1))
+    entry_1 = feed.FeedEntry(title="Some title", updated=datetime.datetime(1993, 1, 1))
+    entry_2 = feed.FeedEntry(
+        title="Another title",
+        updated=datetime.datetime(1990, 1, 1),
+        link="http://foo",
+        content="More text",
+        id_context=["something"],
+        id_date=datetime.datetime(2000, 1, 1),
+    )
 
     stream = io.BytesIO()
-    feed.write_atom(stream, [entry_1, entry_2], author='Me', title='Feed title',
-                    address='baz.com')
+    feed.write_atom(stream, [entry_1, entry_2], author="Me", title="Feed title", address="baz.com")
 
     return stream.getvalue()
 
 
 def test_dummy_xml():
     xml = dummy_feed_xml()
-    text = xml.decode('utf-8').replace('>', '>\n')
+    text = xml.decode("utf-8").replace(">", ">\n")
 
     expected = """\
 <?xml version='1.0' encoding='utf-8'?>
@@ -90,12 +96,12 @@ def test_feedparser():
     xml = dummy_feed_xml()
     feed = feedparser.parse(xml)
 
-    assert feed['entries'][0]['title'] == 'Some title'
-    assert feed['entries'][1]['content'][0]['type'] == 'text/html'
-    assert feed['entries'][1]['content'][0]['value'] == 'More text'
-    assert feed['entries'][1]['links'] == [{'href': 'http://foo',
-                                            'type': 'text/html',
-                                            'rel': 'alternate'}]
+    assert feed["entries"][0]["title"] == "Some title"
+    assert feed["entries"][1]["content"][0]["type"] == "text/html"
+    assert feed["entries"][1]["content"][0]["value"] == "More text"
+    assert feed["entries"][1]["links"] == [
+        {"href": "http://foo", "type": "text/html", "rel": "alternate"}
+    ]
 
 
 @pytest.mark.skipif(not HAVE_FEEDVALIDATOR, reason="test requires feedvalidator module")
@@ -105,9 +111,9 @@ def test_feedvalidator():
 
     ok_messages = (feedvalidator.ValidValue, feedvalidator.MissingSelf)
 
-    assert result['feedType'] == feedvalidator.TYPE_ATOM
+    assert result["feedType"] == feedvalidator.TYPE_ATOM
 
-    for message in result['loggedEvents']:
+    for message in result["loggedEvents"]:
         if not isinstance(message, ok_messages):
             print(xml)
             print(message.params)

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -9,7 +9,7 @@ from asv.util import check_output, which, git_default_branch
 from . import tools
 from .conftest import generate_basic_conf
 
-WIN = (os.name == 'nt')
+WIN = os.name == "nt"
 
 
 def test_find(capfd, tmpdir):
@@ -26,48 +26,53 @@ def test_find(capfd, tmpdir):
         (6, 6),
     ]
 
-    tmpdir, local, conf, machine_file = generate_basic_conf(tmpdir,
-                                                            values=values,
-                                                            dummy_packages=False)
+    tmpdir, local, conf, machine_file = generate_basic_conf(
+        tmpdir, values=values, dummy_packages=False
+    )
 
     # Test find at least runs
-    tools.run_asv_with_conf(conf, 'find',
-                            f"{git_default_branch()}~5..{git_default_branch()}",
-                            "params_examples.track_find_test",
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "find",
+        f"{git_default_branch()}~5..{git_default_branch()}",
+        "params_examples.track_find_test",
+        _machine_file=machine_file,
+    )
 
     # Check it found the first commit after the initially tested one
     output, err = capfd.readouterr()
 
     regression_hash = check_output(
-        [which('git'), 'rev-parse', f'{git_default_branch()}^'], cwd=conf.repo)
+        [which("git"), "rev-parse", f"{git_default_branch()}^"], cwd=conf.repo
+    )
 
     assert f"Greatest regression found: {regression_hash[:8]}" in output
 
 
 @pytest.mark.flaky(reruns=1, reruns_delay=5)  # depends on a timeout
 def test_find_timeout(capfd, tmpdir):
-    values = [
-        (1, 0),
-        (1, 0),
-        (1, -1)
-    ]
+    values = [(1, 0), (1, 0), (1, -1)]
 
-    tmpdir, local, conf, machine_file = generate_basic_conf(tmpdir,
-                                                            values=values,
-                                                            dummy_packages=False)
+    tmpdir, local, conf, machine_file = generate_basic_conf(
+        tmpdir, values=values, dummy_packages=False
+    )
 
     # Test find at least runs
-    tools.run_asv_with_conf(conf, 'find', "-e",
-                            f"{git_default_branch()}",
-                            "params_examples.time_find_test_timeout",
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "find",
+        "-e",
+        f"{git_default_branch()}",
+        "params_examples.time_find_test_timeout",
+        _machine_file=machine_file,
+    )
 
     # Check it found the first commit after the initially tested one
     output, err = capfd.readouterr()
 
     regression_hash = check_output(
-        [which('git'), 'rev-parse', f'{git_default_branch()}'], cwd=conf.repo)
+        [which("git"), "rev-parse", f"{git_default_branch()}"], cwd=conf.repo
+    )
 
     assert f"Greatest regression found: {regression_hash[:8]}" in output
     assert "asv: benchmark timed out (timeout 1.0s)" in output
@@ -82,18 +87,25 @@ def test_find_inverted(capfd, tmpdir):
         (6, 1),
     ]
 
-    tmpdir, local, conf, machine_file = generate_basic_conf(tmpdir,
-                                                            values=values,
-                                                            dummy_packages=False)
-    tools.run_asv_with_conf(*[conf, 'find',
-                              "-i", f"{git_default_branch()}~4..{git_default_branch()}",
-                              "params_examples.track_find_test"],
-                            _machine_file=machine_file)
+    tmpdir, local, conf, machine_file = generate_basic_conf(
+        tmpdir, values=values, dummy_packages=False
+    )
+    tools.run_asv_with_conf(
+        *[
+            conf,
+            "find",
+            "-i",
+            f"{git_default_branch()}~4..{git_default_branch()}",
+            "params_examples.track_find_test",
+        ],
+        _machine_file=machine_file,
+    )
 
     output, err = capfd.readouterr()
 
     regression_hash = check_output(
-        [which('git'), 'rev-parse', f'{git_default_branch()}^'], cwd=conf.repo)
+        [which("git"), "rev-parse", f"{git_default_branch()}^"], cwd=conf.repo
+    )
 
     formatted = f"Greatest improvement found: {regression_hash[:8]}"
     assert formatted in output

--- a/test/test_gh_pages.py
+++ b/test/test_gh_pages.py
@@ -12,14 +12,14 @@ from . import tools
 def test_gh_pages(rewrite, tmpdir, generate_result_dir, monkeypatch):
     tmpdir = os.path.abspath(str(tmpdir))
 
-    monkeypatch.setenv(str('EMAIL'), str('test@asv'))
-    monkeypatch.setenv(str('GIT_COMMITTER_NAME'), str('asv test'))
-    monkeypatch.setenv(str('GIT_AUTHOR_NAME'), str('asv test'))
+    monkeypatch.setenv(str("EMAIL"), str("test@asv"))
+    monkeypatch.setenv(str("GIT_COMMITTER_NAME"), str("asv test"))
+    monkeypatch.setenv(str("GIT_AUTHOR_NAME"), str("asv test"))
 
     conf, repo, commits = generate_result_dir([1, 2, 3, 4])
 
-    dvcs_dir = os.path.join(tmpdir, 'repo1')
-    dvcs_dir2 = os.path.join(tmpdir, 'repo2')
+    dvcs_dir = os.path.join(tmpdir, "repo1")
+    dvcs_dir2 = os.path.join(tmpdir, "repo2")
 
     os.makedirs(dvcs_dir)
 
@@ -28,10 +28,10 @@ def test_gh_pages(rewrite, tmpdir, generate_result_dir, monkeypatch):
     dvcs = tools.Git(dvcs_dir)
     dvcs.init()
 
-    open(os.path.join(dvcs_dir, 'dummy'), 'wb').close()
+    open(os.path.join(dvcs_dir, "dummy"), "wb").close()
 
-    dvcs.add('dummy')
-    dvcs.commit('Initial commit')
+    dvcs.add("dummy")
+    dvcs.commit("Initial commit")
 
     if rewrite:
         rewrite_args = ("--rewrite",)
@@ -40,43 +40,43 @@ def test_gh_pages(rewrite, tmpdir, generate_result_dir, monkeypatch):
 
     # Check with no existing gh-pages branch, no push
     tools.run_asv_with_conf(conf, "gh-pages", "--no-push", *rewrite_args)
-    dvcs.checkout('gh-pages')
-    assert os.path.isfile(os.path.join(dvcs_dir, 'index.html'))
-    assert len(dvcs.run_git(['rev-list', 'gh-pages']).splitlines()) == 1
+    dvcs.checkout("gh-pages")
+    assert os.path.isfile(os.path.join(dvcs_dir, "index.html"))
+    assert len(dvcs.run_git(["rev-list", "gh-pages"]).splitlines()) == 1
     dvcs.checkout(f"{util.git_default_branch()}")
-    assert not os.path.isfile(os.path.join(dvcs_dir, 'index.html'))
+    assert not os.path.isfile(os.path.join(dvcs_dir, "index.html"))
 
     # Check with existing (and checked out) gh-pages branch, with no changes
     tools.run_asv_with_conf(conf, "gh-pages", "--no-push", *rewrite_args)
-    dvcs.checkout('gh-pages')
-    assert os.path.isfile(os.path.join(dvcs_dir, 'index.html'))
+    dvcs.checkout("gh-pages")
+    assert os.path.isfile(os.path.join(dvcs_dir, "index.html"))
     if rewrite:
-        assert len(dvcs.run_git(['rev-list', 'gh-pages']).splitlines()) == 1
+        assert len(dvcs.run_git(["rev-list", "gh-pages"]).splitlines()) == 1
     else:
         # Timestamp may have changed
-        assert len(dvcs.run_git(['rev-list', 'gh-pages']).splitlines()) <= 2
+        assert len(dvcs.run_git(["rev-list", "gh-pages"]).splitlines()) <= 2
     dvcs.checkout(f"{util.git_default_branch()}")
 
     # Check with existing (not checked out) gh-pages branch, with some changes
-    benchmarks_json = os.path.join(conf.results_dir, 'benchmarks.json')
+    benchmarks_json = os.path.join(conf.results_dir, "benchmarks.json")
     data = util.load_json(benchmarks_json)
-    data['time_func']['pretty_name'] = 'something changed'
+    data["time_func"]["pretty_name"] = "something changed"
     util.write_json(benchmarks_json, data)
 
-    prev_len = len(dvcs.run_git(['rev-list', 'gh-pages']).splitlines())
+    prev_len = len(dvcs.run_git(["rev-list", "gh-pages"]).splitlines())
     tools.run_asv_with_conf(conf, "gh-pages", "--no-push", *rewrite_args)
     if not rewrite:
-        assert len(dvcs.run_git(['rev-list', 'gh-pages']).splitlines()) == prev_len + 1
+        assert len(dvcs.run_git(["rev-list", "gh-pages"]).splitlines()) == prev_len + 1
     else:
-        assert len(dvcs.run_git(['rev-list', 'gh-pages']).splitlines()) == prev_len
+        assert len(dvcs.run_git(["rev-list", "gh-pages"]).splitlines()) == prev_len
 
     # Check that the push option works
-    dvcs.run_git(['branch', '-D', 'gh-pages'])
-    dvcs.run_git(['clone', dvcs_dir, dvcs_dir2])
+    dvcs.run_git(["branch", "-D", "gh-pages"])
+    dvcs.run_git(["clone", dvcs_dir, dvcs_dir2])
 
     os.chdir(dvcs_dir2)
     tools.run_asv_with_conf(conf, "gh-pages", *rewrite_args)
 
     os.chdir(dvcs_dir)
-    dvcs.checkout('gh-pages')
-    assert os.path.isfile(os.path.join(dvcs_dir, 'index.html'))
+    dvcs.checkout("gh-pages")
+    assert os.path.isfile(os.path.join(dvcs_dir, "index.html"))

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -2,8 +2,13 @@
 
 import os
 
-from asv.graph import (Graph, RESAMPLED_POINTS, make_summary_graph, _fill_missing_data,
-                       _combine_graph_data)
+from asv.graph import (
+    Graph,
+    RESAMPLED_POINTS,
+    make_summary_graph,
+    _fill_missing_data,
+    _combine_graph_data,
+)
 from asv import util
 
 
@@ -15,28 +20,28 @@ def test_graph_single():
         (4, 4, 7),
         (5, 5, None),
         (6, None, None),
-        (7, float('nan'), None),
+        (7, float("nan"), None),
     ]
 
     # Should give same data back, excluding missing values at edges
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     for k, v, dv in vals:
         g.add_data_point(k, v, dv)
     data = g.get_data()
     assert data == vals[:-2]
 
     # Should average duplicate values
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     g.add_data_point(4, 3)
     for k, v, dv in vals:
         g.add_data_point(k, v, dv)
     g.add_data_point(4, 5)
     data = g.get_data()
     assert data[3][0] == 4
-    assert abs(data[3][1] - (3 + 4 + 5) / 3.) < 1e-10
+    assert abs(data[3][1] - (3 + 4 + 5) / 3.0) < 1e-10
 
     # Summary graph should be the same as the main graph
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     for k, v, dv in vals:
         g.add_data_point(k, v, dv)
     g = make_summary_graph([g])
@@ -53,12 +58,12 @@ def test_graph_single():
 def test_graph_multi():
     vals = [
         (0, [None, None, None], [None] * 3),
-        (1, [1, None, float('nan')], [None] * 3),
+        (1, [1, None, float("nan")], [None] * 3),
         (2, [2, 5, 4], [1] * 3),
         (3, [3, 4, -60], [None] * 3),
         (4, [4, 3, 2], [None] * 3),
         (5, [None, 2, None], [None] * 3),
-        (6, [6, 1, None], [None] * 3)
+        (6, [6, 1, None], [None] * 3),
     ]
 
     filled_vals = [
@@ -67,11 +72,11 @@ def test_graph_multi():
         (3, [3, 4, -60]),
         (4, [4, 3, 2]),
         (5, [5, 2, None]),
-        (6, [6, 1, None])
+        (6, [6, 1, None]),
     ]
 
     # Should give same data back, with missing data at edges removed
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     for k, v, dv in vals:
         g.add_data_point(k, v, dv)
     data = g.get_data()
@@ -79,19 +84,19 @@ def test_graph_multi():
     assert data[1:] == vals[2:]
 
     # Should average duplicate values
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     g.add_data_point(4, [1, 2, 3])
     for k, v, dv in vals:
         g.add_data_point(k, v, dv)
     g.add_data_point(4, [3, 2, 1])
     data = g.get_data()
     assert data[3][0] == 4
-    assert abs(data[3][1][0] - (1 + 4 + 3) / 3.) < 1e-10
-    assert abs(data[3][1][1] - (2 + 3 + 2) / 3.) < 1e-10
-    assert abs(data[3][1][2] - (3 + 2 + 1) / 3.) < 1e-10
+    assert abs(data[3][1][0] - (1 + 4 + 3) / 3.0) < 1e-10
+    assert abs(data[3][1][1] - (2 + 3 + 2) / 3.0) < 1e-10
+    assert abs(data[3][1][2] - (3 + 2 + 1) / 3.0) < 1e-10
 
     # The summary graph is obtained by geometric mean of filled data
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     for k, v, dv in vals:
         g.add_data_point(k, v, dv)
     g = make_summary_graph([g])
@@ -108,9 +113,9 @@ def test_graph_multi():
 
     # Test summary over separate graphs -- should behave as if the
     # data was in a single graph
-    g0 = Graph('foo', {})
-    g1 = Graph('foo', {})
-    g2 = Graph('foo', {})
+    g0 = Graph("foo", {})
+    g1 = Graph("foo", {})
+    g2 = Graph("foo", {})
     for k, v, dv in vals:
         g0.add_data_point(k, v, dv)
         g1.add_data_point(k, v[0], dv[0])
@@ -133,14 +138,14 @@ def test_graph_multi():
 
 
 def test_empty_graph():
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     g.add_data_point(1, None)
     g.add_data_point(2, None)
     g.add_data_point(3, None)
     data = g.get_data()
     assert data == []
 
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     g.add_data_point(1, None)
     g.add_data_point(1, [None, None])
     g.add_data_point(2, [None, None])
@@ -151,28 +156,28 @@ def test_empty_graph():
 
 
 def test_nan():
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     g.add_data_point(1, 1)
     g.add_data_point(2, 2)
-    g.add_data_point(2, float('nan'))
+    g.add_data_point(2, float("nan"))
     g.add_data_point(3, 3)
-    g.add_data_point(4, float('nan'))
+    g.add_data_point(4, float("nan"))
     data = g.get_data()
     assert data == [(1, 1, None), (2, 2, None), (3, 3, None)]
 
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     g.add_data_point(1, None)
-    g.add_data_point(1, [1, float('nan')])
+    g.add_data_point(1, [1, float("nan")])
     g.add_data_point(2, [2, 2])
-    g.add_data_point(3, [float('nan'), float('nan')])
-    g.add_data_point(4, [None, float('nan')])
+    g.add_data_point(3, [float("nan"), float("nan")])
+    g.add_data_point(4, [None, float("nan")])
     data = g.get_data()
     assert data == [(1, [1, None], [None, None]), (2, [2, 2], [None, None])]
 
 
 def test_summary_graph():
     n = 2 * int(RESAMPLED_POINTS)
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     for i in range(n):
         g.add_data_point(i, 0.1)
         g.add_data_point(n + i, 0.2)
@@ -188,7 +193,7 @@ def test_summary_graph_loop():
     n = int(RESAMPLED_POINTS)
 
     # Resampling shouldn't get stuck in an infinite loop
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     for j in range(n):
         g.add_data_point(j, 0.1)
     g = make_summary_graph([g])
@@ -208,9 +213,9 @@ def test__fill_missing_data():
 
 
 def test__combine_graph_data():
-    g1 = Graph('1', {})
-    g2 = Graph('2', {})
-    g3 = Graph('3', {})
+    g1 = Graph("1", {})
+    g2 = Graph("2", {})
+    g3 = Graph("3", {})
     for i in range(5):
         if i >= 3:
             g1.add_data_point(i, None)
@@ -220,17 +225,29 @@ def test__combine_graph_data():
 
     x, ys = _combine_graph_data([g1, g2, g3])
     assert x == [0, 1, 2, 3, 4]
-    assert ys == [[None, None, None, None, None],
-                  [0, 1, 2, 3, 4],
-                  [0, -1, -2, None, None],
-                  [0, -2, -4, None, None]]
+    assert ys == [
+        [None, None, None, None, None],
+        [0, 1, 2, 3, 4],
+        [0, -1, -2, None, None],
+        [0, -2, -4, None, None],
+    ]
 
 
 def test_graph_steps():
-    vals = [(1, 1), (5, 1), (6, 1), (7, 1), (8, 1),
-            (11, 2), (15, 2), (16, 2 + 1e-5), (17, 2), (18, 2)]
+    vals = [
+        (1, 1),
+        (5, 1),
+        (6, 1),
+        (7, 1),
+        (8, 1),
+        (11, 2),
+        (15, 2),
+        (16, 2 + 1e-5),
+        (17, 2),
+        (18, 2),
+    ]
 
-    g = Graph('foo', {})
+    g = Graph("foo", {})
     for x, y in vals:
         g.add_data_point(x, y)
 
@@ -239,7 +256,7 @@ def test_graph_steps():
     assert abs(lastval - 1e-5 / 5.0) < 1e-10
     assert steps == [(1, 8 + 1, 1.0, 1.0, 0), (11, 18 + 1, 2.0, 2.0, lastval)]
 
-    multi_g = Graph('foo', {})
+    multi_g = Graph("foo", {})
     for x, y in vals:
         multi_g.add_data_point(x, [y, y, y])
 
@@ -248,8 +265,8 @@ def test_graph_steps():
 
 
 def test_graph_filename_sanitization():
-    g = Graph('hello:world', {'a/a': 'b>b', 'c*c': 'd\0\0d'})
-    assert g.path == os.path.join('graphs', 'a_a-b_b', 'c_c-d__d', 'hello_world')
+    g = Graph("hello:world", {"a/a": "b>b", "c*c": "d\0\0d"})
+    assert g.path == os.path.join("graphs", "a_a-b_b", "c_c-d__d", "hello_world")
 
 
 def _sgn(x):

--- a/test/test_machine.py
+++ b/test/test_machine.py
@@ -14,24 +14,23 @@ def test_machine(tmpdir):
         arch="MIPS",
         cpu="10 MHz",
         ram="640k",
-        _path=join(tmpdir, 'asv-machine.json'))
+        _path=join(tmpdir, "asv-machine.json"),
+    )
 
-    m = machine.Machine.load(
-        _path=join(tmpdir, 'asv-machine.json'), interactive=False)
+    m = machine.Machine.load(_path=join(tmpdir, "asv-machine.json"), interactive=False)
 
-    assert m.machine == 'orangutan'
-    assert m.os == 'BeOS'
-    assert m.arch == 'MIPS'
-    assert m.cpu == '10 MHz'
-    assert m.ram == '640k'
+    assert m.machine == "orangutan"
+    assert m.os == "BeOS"
+    assert m.arch == "MIPS"
+    assert m.cpu == "10 MHz"
+    assert m.ram == "640k"
 
 
 def test_machine_defaults(tmpdir):
     tmpdir = str(tmpdir)
 
     m = machine.Machine.load(
-        interactive=True,
-        use_defaults=True,
-        _path=join(tmpdir, 'asv-machine.json'))
+        interactive=True, use_defaults=True, _path=join(tmpdir, "asv-machine.json")
+    )
 
     assert m.__dict__ == m.get_defaults()

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -18,84 +18,104 @@ from asv.repo import get_repo
 
 from . import tools
 
-BENCHMARK_DIR = abspath(join(dirname(__file__), 'benchmark'))
+BENCHMARK_DIR = abspath(join(dirname(__file__), "benchmark"))
 
 
 def test_publish(tmpdir, example_results):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
-    result_dir = join(tmpdir, 'sample_results')
+    result_dir = join(tmpdir, "sample_results")
     os.makedirs(result_dir)
-    os.makedirs(join(result_dir, 'cheetah'))
+    os.makedirs(join(result_dir, "cheetah"))
 
     # Synthesize history with two branches that both have commits
-    result_files = [fn for fn in os.listdir(join(example_results, 'cheetah'))
-                    if fn.endswith('.json') and fn != 'machine.json']
+    result_files = [
+        fn
+        for fn in os.listdir(join(example_results, "cheetah"))
+        if fn.endswith(".json") and fn != "machine.json"
+    ]
     result_files.sort()
     master_values = list(range(len(result_files) * 2 // 3))
     branch_values = list(range(len(master_values), len(result_files)))
-    dvcs = tools.generate_test_repo(tmpdir, master_values, 'git',
-                                    [(f'{util.git_default_branch()}~6',
-                                      'some-branch', branch_values)])
+    dvcs = tools.generate_test_repo(
+        tmpdir,
+        master_values,
+        "git",
+        [(f"{util.git_default_branch()}~6", "some-branch", branch_values)],
+    )
 
     # Copy and modify result files, fixing commit hashes and setting result
     # dates to distinguish the two branches
-    master_commits = dvcs.get_branch_hashes(f'{util.git_default_branch()}')
-    only_branch = [x for x in dvcs.get_branch_hashes('some-branch')
-                   if x not in master_commits]
+    master_commits = dvcs.get_branch_hashes(f"{util.git_default_branch()}")
+    only_branch = [x for x in dvcs.get_branch_hashes("some-branch") if x not in master_commits]
     commits = master_commits + only_branch
     for k, item in enumerate(zip(result_files, commits)):
         fn, commit = item
-        src = join(example_results, 'cheetah', fn)
-        dst = join(result_dir, 'cheetah', commit[:8] + fn[8:])
+        src = join(example_results, "cheetah", fn)
+        dst = join(result_dir, "cheetah", commit[:8] + fn[8:])
         try:
             data = util.load_json(src)
         except util.UserError:
             # intentionally malformed file, ship it as is
             shutil.copyfile(src, dst)
             continue
-        data['commit_hash'] = commit
+        data["commit_hash"] = commit
         util.write_json(dst, data)
 
-    shutil.copyfile(join(example_results, 'benchmarks.json'),
-                    join(result_dir, 'benchmarks.json'))
-    shutil.copyfile(join(example_results, 'cheetah', 'machine.json'),
-                    join(result_dir, 'cheetah', 'machine.json'))
+    shutil.copyfile(join(example_results, "benchmarks.json"), join(result_dir, "benchmarks.json"))
+    shutil.copyfile(
+        join(example_results, "cheetah", "machine.json"),
+        join(result_dir, "cheetah", "machine.json"),
+    )
 
     # Publish the synthesized data
     conf = config.Config.from_json(
-        {'benchmark_dir': BENCHMARK_DIR,
-         'results_dir': result_dir,
-         'html_dir': join(tmpdir, 'html'),
-         'repo': dvcs.path,
-         'project': 'asv'})
+        {
+            "benchmark_dir": BENCHMARK_DIR,
+            "results_dir": result_dir,
+            "html_dir": join(tmpdir, "html"),
+            "repo": dvcs.path,
+            "project": "asv",
+        }
+    )
 
-    tools.run_asv_with_conf(conf, 'publish')
+    tools.run_asv_with_conf(conf, "publish")
 
     # Check output
-    assert isfile(join(tmpdir, 'html', 'index.html'))
-    assert isfile(join(tmpdir, 'html', 'index.json'))
-    assert isfile(join(tmpdir, 'html', 'asv.js'))
-    assert isfile(join(tmpdir, 'html', 'asv.css'))
-    assert not isdir(join(tmpdir, 'html', 'graphs', 'Cython', 'arch-x86_64',
-                          'branch-some-branch'))
-    assert not isdir(join(tmpdir, 'html', 'graphs', 'Cython-null', 'arch-x86_64',
-                          'branch-some-branch'))
-    index = util.load_json(join(tmpdir, 'html', 'index.json'))
-    assert index['params']['branch'] == [f'{util.git_default_branch()}']
+    assert isfile(join(tmpdir, "html", "index.html"))
+    assert isfile(join(tmpdir, "html", "index.json"))
+    assert isfile(join(tmpdir, "html", "asv.js"))
+    assert isfile(join(tmpdir, "html", "asv.css"))
+    assert not isdir(join(tmpdir, "html", "graphs", "Cython", "arch-x86_64", "branch-some-branch"))
+    assert not isdir(
+        join(tmpdir, "html", "graphs", "Cython-null", "arch-x86_64", "branch-some-branch")
+    )
+    index = util.load_json(join(tmpdir, "html", "index.json"))
+    assert index["params"]["branch"] == [f"{util.git_default_branch()}"]
 
     repo = get_repo(conf)
     revision_to_hash = dict((r, h) for h, r in repo.get_revisions(commits).items())
 
     def check_file(branch, cython):
-        fn = join(tmpdir, 'html', 'graphs', cython, 'arch-x86_64', 'branch-' + branch,
-                  'cpu-Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)',
-                  'machine-cheetah', 'numpy-1.8', 'os-Linux (Fedora 20)', 'python-2.7', 'ram-8.2G',
-                  'time_coordinates.time_latitude.json')
+        fn = join(
+            tmpdir,
+            "html",
+            "graphs",
+            cython,
+            "arch-x86_64",
+            "branch-" + branch,
+            "cpu-Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)",
+            "machine-cheetah",
+            "numpy-1.8",
+            "os-Linux (Fedora 20)",
+            "python-2.7",
+            "ram-8.2G",
+            "time_coordinates.time_latitude.json",
+        )
         data = util.load_json(fn)
         data_commits = [revision_to_hash[x[0]] for x in data]
-        if branch == f'{util.git_default_branch()}':
+        if branch == f"{util.git_default_branch()}":
             assert all(c in master_commits for c in data_commits)
         else:
             # Must contains commits from some-branch
@@ -110,8 +130,8 @@ def test_publish(tmpdir, example_results):
     check_file(f"{util.git_default_branch()}", "Cython-null")
 
     # Publish with branches set in the config
-    conf.branches = [f'{util.git_default_branch()}', 'some-branch']
-    tools.run_asv_with_conf(conf, 'publish')
+    conf.branches = [f"{util.git_default_branch()}", "some-branch"]
+    tools.run_asv_with_conf(conf, "publish")
 
     # Check output
     check_file(f"{util.git_default_branch()}", "Cython")
@@ -119,29 +139,33 @@ def test_publish(tmpdir, example_results):
     check_file("some-branch", "Cython")
     check_file("some-branch", "Cython-null")
 
-    index = util.load_json(join(tmpdir, 'html', 'index.json'))
-    assert index['params']['branch'] == [f'{util.git_default_branch()}', 'some-branch']
-    assert index['params']['Cython'] == ['', None]
-    assert index['params']['ram'] == ['8.2G', 8804682956.8]
+    index = util.load_json(join(tmpdir, "html", "index.json"))
+    assert index["params"]["branch"] == [f"{util.git_default_branch()}", "some-branch"]
+    assert index["params"]["Cython"] == ["", None]
+    assert index["params"]["ram"] == ["8.2G", 8804682956.8]
 
-    expected_graph_list = [{'Cython': cython, 'arch': 'x86_64',
-                            'branch': branch,
-                            'cpu': 'Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)',
-                            'machine': 'cheetah',
-                            'numpy': '1.8',
-                            'os': 'Linux (Fedora 20)',
-                            'python': '2.7',
-                            'ram': '8.2G'}
-                           for cython in ["",
-                                          None] for branch in [f"{util.git_default_branch()}",
-                                                               "some-branch"]]
+    expected_graph_list = [
+        {
+            "Cython": cython,
+            "arch": "x86_64",
+            "branch": branch,
+            "cpu": "Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)",
+            "machine": "cheetah",
+            "numpy": "1.8",
+            "os": "Linux (Fedora 20)",
+            "python": "2.7",
+            "ram": "8.2G",
+        }
+        for cython in ["", None]
+        for branch in [f"{util.git_default_branch()}", "some-branch"]
+    ]
     d = dict(expected_graph_list[0])
-    d['ram'] = 8804682956.8
+    d["ram"] = 8804682956.8
     expected_graph_list.append(d)
 
-    assert len(index['graph_param_list']) == len(expected_graph_list)
+    assert len(index["graph_param_list"]) == len(expected_graph_list)
     for item in expected_graph_list:
-        assert item in index['graph_param_list']
+        assert item in index["graph_param_list"]
 
 
 def _graph_path(dvcs_type):
@@ -156,21 +180,22 @@ def test_publish_range_spec(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1])
     for range_spec, expected in (
         ([commits[0], commits[-1]], set([commits[0], commits[-1]])),
-        ('HEAD~2..HEAD' if repo.dvcs == 'git' else '.~1:',
-            set(commits[-2:])),
+        ("HEAD~2..HEAD" if repo.dvcs == "git" else ".~1:", set(commits[-2:])),
     ):
         tools.run_asv_with_conf(conf, "publish", range_spec)
-        data = util.load_json(join(conf.html_dir, 'index.json'))
-        assert set(data['revision_to_hash'].values()) == expected
+        data = util.load_json(join(conf.html_dir, "index.json"))
+        assert set(data["revision_to_hash"].values()) == expected
 
 
 def test_regression_simple(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 5 * [10])
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, 10.0, 1.0,
-                [[None, 5, 1.0, 10.0]]
-    ]]}
+    expected = {
+        "regressions": [
+            ["time_func", _graph_path(repo.dvcs), {}, None, 10.0, 1.0, [[None, 5, 1.0, 10.0]]]
+        ]
+    }
     assert regressions == expected
 
 
@@ -178,9 +203,19 @@ def test_regression_range(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 6 * [10], commits_without_result=[5])
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, 10.0, 1.0,
-                                 [[4, 6, 1.0, 10.0]], ]]
-                }
+    expected = {
+        "regressions": [
+            [
+                "time_func",
+                _graph_path(repo.dvcs),
+                {},
+                None,
+                10.0,
+                1.0,
+                [[4, 6, 1.0, 10.0]],
+            ]
+        ]
+    }
     assert regressions == expected
 
 
@@ -196,9 +231,19 @@ def test_regression_double(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 5 * [10] + 5 * [15])
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, 15.0, 1.0,
+    expected = {
+        "regressions": [
+            [
+                "time_func",
+                _graph_path(repo.dvcs),
+                {},
+                None,
+                15.0,
+                1.0,
                 [[None, 5, 1.0, 10.0], [None, 10, 10.0, 15.0]],
-    ]]}
+            ]
+        ]
+    }
     assert regressions == expected
 
 
@@ -220,9 +265,11 @@ def test_regression_first_commits(generate_result_dir):
     conf.regressions_first_commits = {"^time_*": commits[2]}
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, 10.0, 1.0,
-                                 [[None, 5, 1.0, 10.0]]]]
-                }
+    expected = {
+        "regressions": [
+            ["time_func", _graph_path(repo.dvcs), {}, None, 10.0, 1.0, [[None, 5, 1.0, 10.0]]]
+        ]
+    }
     assert regressions == expected
 
 
@@ -232,26 +279,38 @@ def test_regression_parameterized(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [before] + 5 * [after])
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {'regressions': [[
-        'time_func(a)',
-        _graph_path(repo.dvcs),
-        {},
-        0,
-        6.0, 5.0, [[None, 5, 5.0, 6.0]],
-    ], [
-        'time_func(c)',
-        _graph_path(repo.dvcs),
-        {},
-        2,
-        10.0, 1.0, [[None, 5, 1.0, 10.0]],
-    ]]}
+    expected = {
+        "regressions": [
+            [
+                "time_func(a)",
+                _graph_path(repo.dvcs),
+                {},
+                0,
+                6.0,
+                5.0,
+                [[None, 5, 5.0, 6.0]],
+            ],
+            [
+                "time_func(c)",
+                _graph_path(repo.dvcs),
+                {},
+                2,
+                10.0,
+                1.0,
+                [[None, 5, 1.0, 10.0]],
+            ],
+        ]
+    }
     assert regressions == expected
 
 
-@pytest.mark.parametrize("dvcs_type", [
-    "git",
-    pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib")),
-])
+@pytest.mark.parametrize(
+    "dvcs_type",
+    [
+        "git",
+        pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib")),
+    ],
+)
 def test_regression_multiple_branches(dvcs_type, tmpdir):
     tmpdir = str(tmpdir)
     if dvcs_type == "git":
@@ -259,17 +318,23 @@ def test_regression_multiple_branches(dvcs_type, tmpdir):
     elif dvcs_type == "hg":
         master = "default"
     dvcs = tools.generate_repo_from_ops(
-        tmpdir, dvcs_type, [
+        tmpdir,
+        dvcs_type,
+        [
             ("commit", 1),
             ("checkout", "stable", master),
             ("commit", 1),
             ("checkout", master),
-        ] + 4 * [
+        ]
+        + 4
+        * [
             ("commit", 1),
             ("checkout", "stable"),
             ("commit", 1),
             ("checkout", master),
-        ] + 5 * [
+        ]
+        + 5
+        * [
             ("commit", 1),
             ("checkout", "stable"),
             ("commit", 2),
@@ -278,8 +343,7 @@ def test_regression_multiple_branches(dvcs_type, tmpdir):
     )
     commit_values = {}
     branches = dict(
-        (branch, list(reversed(dvcs.get_branch_hashes(branch))))
-        for branch in (master, "stable")
+        (branch, list(reversed(dvcs.get_branch_hashes(branch)))) for branch in (master, "stable")
     )
     for branch, values in (
         (master, 10 * [1]),
@@ -292,29 +356,42 @@ def test_regression_multiple_branches(dvcs_type, tmpdir):
     tools.run_asv_with_conf(conf, "publish")
     repo = get_repo(conf)
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    graph_path = join('graphs', 'branch-stable', 'machine-tarzan', 'time_func.json')
+    graph_path = join("graphs", "branch-stable", "machine-tarzan", "time_func.json")
     # Regression occur on 5th commit of stable branch
     revision = repo.get_revisions(commit_values.keys())[branches["stable"][5]]
-    expected = {'regressions': [['time_func', graph_path, {'branch': 'stable'}, None,
-                                 2.0, 1.0, [[None, revision, 1.0, 2.0]]]]}
+    expected = {
+        "regressions": [
+            [
+                "time_func",
+                graph_path,
+                {"branch": "stable"},
+                None,
+                2.0,
+                1.0,
+                [[None, revision, 1.0, 2.0]],
+            ]
+        ]
+    }
     assert regressions == expected
 
 
-@pytest.mark.parametrize("dvcs_type", [
-    "git",
-    pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))
-])
+@pytest.mark.parametrize(
+    "dvcs_type",
+    ["git", pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))],
+)
 def test_regression_non_monotonic(dvcs_type, tmpdir):
     tmpdir = str(tmpdir)
     now = datetime.datetime.now()
 
-    dates = [now + datetime.timedelta(days=i)
-             for i in range(5)] + [now - datetime.timedelta(days=i) for i in range(5)]
+    dates = [now + datetime.timedelta(days=i) for i in range(5)] + [
+        now - datetime.timedelta(days=i) for i in range(5)
+    ]
     # last commit in the past
     dates[-1] = now - datetime.timedelta(days=1)
 
-    dvcs = tools.generate_repo_from_ops(tmpdir, dvcs_type,
-                                        [("commit", i, d) for i, d in enumerate(dates)])
+    dvcs = tools.generate_repo_from_ops(
+        tmpdir, dvcs_type, [("commit", i, d) for i, d in enumerate(dates)]
+    )
     commits = list(reversed(dvcs.get_branch_hashes()))
     commit_values = {}
     for commit, value in zip(commits, 5 * [1] + 5 * [2]):
@@ -322,27 +399,44 @@ def test_regression_non_monotonic(dvcs_type, tmpdir):
     conf = tools.generate_result_dir(tmpdir, dvcs, commit_values)
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {'regressions': [['time_func', _graph_path(dvcs_type), {}, None,
-                                 2.0, 1.0, [[None, 5, 1.0, 2.0]]]]}
+    expected = {
+        "regressions": [
+            ["time_func", _graph_path(dvcs_type), {}, None, 2.0, 1.0, [[None, 5, 1.0, 2.0]]]
+        ]
+    }
     assert regressions == expected
 
 
 def test_regression_threshold(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1.0] + 5 * [1.1] + 5 * [2.0])
 
-    conf.regressions_thresholds = {'.*': 0}
+    conf.regressions_thresholds = {".*": 0}
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None,
-                                 2.0, 1.0, [[None, 5, 1.0, 1.1], [None, 10, 1.1, 2.0]]]]}
+    expected = {
+        "regressions": [
+            [
+                "time_func",
+                _graph_path(repo.dvcs),
+                {},
+                None,
+                2.0,
+                1.0,
+                [[None, 5, 1.0, 1.1], [None, 10, 1.1, 2.0]],
+            ]
+        ]
+    }
 
     assert regressions == expected
 
-    conf.regressions_thresholds = {'.*': 0, 'time_func.*': 0.2}
+    conf.regressions_thresholds = {".*": 0, "time_func.*": 0.2}
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, 2.0, 1.0,
-                                 [[None, 10, 1.1, 2.0]]]]}
+    expected = {
+        "regressions": [
+            ["time_func", _graph_path(repo.dvcs), {}, None, 2.0, 1.0, [[None, 10, 1.1, 2.0]]]
+        ]
+    }
 
     assert regressions == expected
 
@@ -356,47 +450,49 @@ def test_regression_atom_feed(generate_result_dir):
     tree = etree.parse(join(conf.html_dir, "regressions.xml"))
     root = tree.getroot()
 
-    assert root.tag == '{http://www.w3.org/2005/Atom}feed'
-    entries = root.findall('{http://www.w3.org/2005/Atom}entry')
+    assert root.tag == "{http://www.w3.org/2005/Atom}feed"
+    entries = root.findall("{http://www.w3.org/2005/Atom}entry")
 
     # Check entry titles
     assert len(entries) == 2
-    title = entries[0].find('{http://www.w3.org/2005/Atom}title')
-    assert title.text == '900.00% time_func'
-    title = entries[1].find('{http://www.w3.org/2005/Atom}title')
-    assert title.text == '50.00% time_func'
+    title = entries[0].find("{http://www.w3.org/2005/Atom}title")
+    assert title.text == "900.00% time_func"
+    title = entries[1].find("{http://www.w3.org/2005/Atom}title")
+    assert title.text == "50.00% time_func"
 
     # Check there's a link of some sort to the website in the content
-    content = entries[0].find('{http://www.w3.org/2005/Atom}content')
+    content = entries[0].find("{http://www.w3.org/2005/Atom}content")
     assert ('<a href="index.html#time_func?commits=' + commits[5]) in content.text
-    content = entries[1].find('{http://www.w3.org/2005/Atom}content')
+    content = entries[1].find("{http://www.w3.org/2005/Atom}content")
     assert ('<a href="index.html#time_func?commits=' + commits[10]) in content.text
 
     # Smoke check ids
-    id_1 = entries[0].find('{http://www.w3.org/2005/Atom}id')
-    id_2 = entries[1].find('{http://www.w3.org/2005/Atom}id')
+    id_1 = entries[0].find("{http://www.w3.org/2005/Atom}id")
+    id_2 = entries[1].find("{http://www.w3.org/2005/Atom}id")
     assert id_1.text != id_2.text
 
 
-@pytest.mark.parametrize("dvcs_type", [
-    "git",
-    pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))
-])
+@pytest.mark.parametrize(
+    "dvcs_type",
+    ["git", pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))],
+)
 def test_regression_atom_feed_update(dvcs_type, tmpdir):
     # Check that adding new commits which only change values preserves
     # feed entry ids
     tmpdir = str(tmpdir)
     values = 5 * [1] + 5 * [10] + 5 * [15.70, 15.31]
     dvcs = tools.generate_repo_from_ops(
-        tmpdir, dvcs_type, [("commit", i) for i in range(len(values))])
+        tmpdir, dvcs_type, [("commit", i) for i in range(len(values))]
+    )
     commits = list(reversed(dvcs.get_branch_hashes()))
 
     # Old results (drop last 6)
     commit_values = {}
     for commit, value in zip(commits, values[:-5]):
         commit_values[commit] = value
-    conf = tools.generate_result_dir(tmpdir, dvcs, commit_values,
-                                     updated=datetime.datetime(1970, 1, 1))
+    conf = tools.generate_result_dir(
+        tmpdir, dvcs, commit_values, updated=datetime.datetime(1970, 1, 1)
+    )
 
     tools.run_asv_with_conf(conf, "publish")
 
@@ -408,8 +504,9 @@ def test_regression_atom_feed_update(dvcs_type, tmpdir):
 
     shutil.rmtree(conf.results_dir)
     shutil.rmtree(conf.html_dir)
-    conf = tools.generate_result_dir(tmpdir, dvcs, commit_values,
-                                     updated=datetime.datetime(1990, 1, 1))
+    conf = tools.generate_result_dir(
+        tmpdir, dvcs, commit_values, updated=datetime.datetime(1990, 1, 1)
+    )
 
     tools.run_asv_with_conf(conf, "publish")
 
@@ -419,16 +516,16 @@ def test_regression_atom_feed_update(dvcs_type, tmpdir):
     old_root = old_tree.getroot()
     new_root = new_tree.getroot()
 
-    old_entries = old_root.findall('{http://www.w3.org/2005/Atom}entry')
-    new_entries = new_root.findall('{http://www.w3.org/2005/Atom}entry')
+    old_entries = old_root.findall("{http://www.w3.org/2005/Atom}entry")
+    new_entries = new_root.findall("{http://www.w3.org/2005/Atom}entry")
 
     assert len(new_entries) == len(old_entries) == 2
 
     for j, (a, b) in enumerate(zip(new_entries, old_entries)):
-        a_id = a.find('{http://www.w3.org/2005/Atom}id')
-        b_id = b.find('{http://www.w3.org/2005/Atom}id')
+        a_id = a.find("{http://www.w3.org/2005/Atom}id")
+        b_id = b.find("{http://www.w3.org/2005/Atom}id")
         assert a_id.text == b_id.text
 
-        a_content = a.find('{http://www.w3.org/2005/Atom}content')
-        b_content = b.find('{http://www.w3.org/2005/Atom}content')
+        a_content = a.find("{http://www.w3.org/2005/Atom}content")
+        b_content = b.find("{http://www.w3.org/2005/Atom}content")
         assert a_content.text != b_content.text

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -26,7 +26,7 @@ def _test_generic_repo(conf, tmpdir, hash_range, master, branch, is_remote=False
     if is_remote:
         if os.path.isdir(conf.project):
             shutil.rmtree(conf.project)
-        os.makedirs(join(conf.project, 'hello'))
+        os.makedirs(join(conf.project, "hello"))
         with pytest.raises(util.UserError):
             r = repo.get_repo(conf)
         shutil.rmtree(conf.project)
@@ -52,7 +52,7 @@ def _test_generic_repo(conf, tmpdir, hash_range, master, branch, is_remote=False
     r.checkout(workcopy_dir, master)
 
     # check recovering from corruption
-    for pth in ['.hg', '.git']:
+    for pth in [".hg", ".git"]:
         pth = os.path.join(workcopy_dir, pth)
         if os.path.isdir(pth):
             shutil.rmtree(pth)
@@ -91,10 +91,12 @@ def _test_branches(conf, branch_commits, require_describe=False):
 def test_repo_git(tmpdir):
     tmpdir = str(tmpdir)
 
-    dvcs = tools.generate_test_repo(tmpdir, list(range(10)),
-                                    dvcs_type='git',
-                                    extra_branches=[(f'{util.git_default_branch()}~4',
-                                                     'some-branch', [11, 12, 13])])
+    dvcs = tools.generate_test_repo(
+        tmpdir,
+        list(range(10)),
+        dvcs_type="git",
+        extra_branches=[(f"{util.git_default_branch()}~4", "some-branch", [11, 12, 13])],
+    )
 
     mirror_dir = join(tmpdir, "repo")
 
@@ -103,18 +105,22 @@ def test_repo_git(tmpdir):
 
         conf.project = mirror_dir
         conf.repo = dvcs.path
-        _test_generic_repo(conf, tmpdir,
-                           f'{util.git_default_branch()}~4..{util.git_default_branch()}',
-                           f'{util.git_default_branch()}', 'tag5',
-                           is_remote=is_remote)
+        _test_generic_repo(
+            conf,
+            tmpdir,
+            f"{util.git_default_branch()}~4..{util.git_default_branch()}",
+            f"{util.git_default_branch()}",
+            "tag5",
+            is_remote=is_remote,
+        )
 
-        conf.branches = [f'{util.git_default_branch()}', 'some-branch']
+        conf.branches = [f"{util.git_default_branch()}", "some-branch"]
         branch_commits = {
-            f'{util.git_default_branch()}':
-            [dvcs.get_hash(f'{util.git_default_branch()}'),
-             dvcs.get_hash(f'{util.git_default_branch()}~6')],
-            'some-branch': [dvcs.get_hash('some-branch'),
-                            dvcs.get_hash('some-branch~6')]
+            f"{util.git_default_branch()}": [
+                dvcs.get_hash(f"{util.git_default_branch()}"),
+                dvcs.get_hash(f"{util.git_default_branch()}~6"),
+            ],
+            "some-branch": [dvcs.get_hash("some-branch"), dvcs.get_hash("some-branch~6")],
         }
         _test_branches(conf, branch_commits, require_describe=True)
 
@@ -125,12 +131,13 @@ def test_repo_git(tmpdir):
 
     # try again, pretending the repo is not local
     from asv.plugins.git import Git
+
     old_local_method = Git.is_local_repo
     old_url_match = Git.url_match
     try:
-        Git.is_local_repo = classmethod(lambda cls, path:
-                                        path != dvcs.path and
-                                        old_local_method(path))
+        Git.is_local_repo = classmethod(
+            lambda cls, path: path != dvcs.path and old_local_method(path)
+        )
         Git.url_match = classmethod(lambda cls, url: os.path.isdir(url))
         test_it(is_remote=True)
         assert os.path.isdir(mirror_dir)
@@ -142,41 +149,49 @@ def test_repo_git(tmpdir):
 def test_repo_git_annotated_tag_date(tmpdir):
     tmpdir = str(tmpdir)
 
-    dvcs = tools.generate_test_repo(tmpdir, list(range(5)), dvcs_type='git')
+    dvcs = tools.generate_test_repo(tmpdir, list(range(5)), dvcs_type="git")
 
     conf = config.Config()
-    conf.project = 'sometest'
+    conf.project = "sometest"
     conf.repo = dvcs.path
 
     r = repo.get_repo(conf)
-    d1 = r.get_date('tag1')
-    d2 = r.get_date(r.get_hash_from_name('tag1'))
+    d1 = r.get_date("tag1")
+    d2 = r.get_date(r.get_hash_from_name("tag1"))
     assert d1 == d2
 
 
-@pytest.mark.skipif(hglib is None,
-                    reason="needs hglib")
+@pytest.mark.skipif(hglib is None, reason="needs hglib")
 def test_repo_hg(tmpdir):
     tmpdir = str(tmpdir)
 
     conf = config.Config()
 
-    dvcs = tools.generate_test_repo(tmpdir, list(range(10)), dvcs_type='hg',
-                                    extra_branches=[('default~4', 'somebranch', [11, 12, 13])])
+    dvcs = tools.generate_test_repo(
+        tmpdir,
+        list(range(10)),
+        dvcs_type="hg",
+        extra_branches=[("default~4", "somebranch", [11, 12, 13])],
+    )
 
     mirror_dir = join(tmpdir, "repo")
 
     def test_it(is_remote=False):
         conf.project = mirror_dir
         conf.repo = dvcs.path
-        _test_generic_repo(conf, tmpdir, hash_range="reverse(default~3::default)",
-                           master="default", branch="tag5",
-                           is_remote=is_remote)
+        _test_generic_repo(
+            conf,
+            tmpdir,
+            hash_range="reverse(default~3::default)",
+            master="default",
+            branch="tag5",
+            is_remote=is_remote,
+        )
 
-        conf.branches = ['default', 'somebranch']
+        conf.branches = ["default", "somebranch"]
         branch_commits = {
-            'default': [dvcs.get_hash('default'), dvcs.get_hash('default~6')],
-            'somebranch': [dvcs.get_hash('somebranch'), dvcs.get_hash('somebranch~6')]
+            "default": [dvcs.get_hash("default"), dvcs.get_hash("default~6")],
+            "somebranch": [dvcs.get_hash("somebranch"), dvcs.get_hash("somebranch~6")],
         }
         _test_branches(conf, branch_commits)
 
@@ -187,12 +202,13 @@ def test_repo_hg(tmpdir):
 
     # try again, pretending the repo is not local
     from asv.plugins.mercurial import Hg
+
     old_local_method = Hg.is_local_repo
     old_url_match = Hg.url_match
     try:
-        Hg.is_local_repo = classmethod(lambda cls, path:
-                                       path != dvcs.path and
-                                       old_local_method(path))
+        Hg.is_local_repo = classmethod(
+            lambda cls, path: path != dvcs.path and old_local_method(path)
+        )
         Hg.url_match = classmethod(lambda cls, url: os.path.isdir(url))
         test_it(is_remote=True)
         assert os.path.isdir(mirror_dir)
@@ -222,27 +238,38 @@ def test_get_branch_commits(two_branch_repo_case):
     }
     for branch in conf.branches:
         commits = [
-            dvcs.get_commit_message(commit_hash)
-            for commit_hash in r.get_branch_commits(branch)
+            dvcs.get_commit_message(commit_hash) for commit_hash in r.get_branch_commits(branch)
         ]
         assert commits == expected[branch]
 
 
-@pytest.mark.parametrize("existing, expected", [
-    # No existing commit, we expect all commits in commit order,
-    # master branch first
-    ([], ["Revision 6", "Revision 4", "Merge stable", "Revision 3",
-          "Revision 1", "Revision 5", "Merge master", "Revision 2"]),
-
-    # New commits on each branch
-    (["Revision 4", "Merge master"], ["Revision 6", "Revision 5"]),
-
-    # No new commits
-    (["Revision 6", "Revision 5"], []),
-
-    # Missing all commits on one branch (case of new branch added in config)
-    (["Revision 6"], ["Revision 5", "Merge master", "Revision 2", "Revision 1"]),
-], ids=["all", "new", "no-new", "new-branch-added-in-config"])
+@pytest.mark.parametrize(
+    "existing, expected",
+    [
+        # No existing commit, we expect all commits in commit order,
+        # master branch first
+        (
+            [],
+            [
+                "Revision 6",
+                "Revision 4",
+                "Merge stable",
+                "Revision 3",
+                "Revision 1",
+                "Revision 5",
+                "Merge master",
+                "Revision 2",
+            ],
+        ),
+        # New commits on each branch
+        (["Revision 4", "Merge master"], ["Revision 6", "Revision 5"]),
+        # No new commits
+        (["Revision 6", "Revision 5"], []),
+        # Missing all commits on one branch (case of new branch added in config)
+        (["Revision 6"], ["Revision 5", "Merge master", "Revision 2", "Revision 1"]),
+    ],
+    ids=["all", "new", "no-new", "new-branch-added-in-config"],
+)
 def test_get_new_branch_commits(two_branch_repo_case, existing, expected):
     dvcs, master, r, conf = two_branch_repo_case
 
@@ -264,47 +291,46 @@ def test_git_submodule(tmpdir):
     tmpdir = str(tmpdir)
 
     # State 0 (no submodule)
-    dvcs = tools.generate_test_repo(tmpdir, values=[0], dvcs_type='git')
-    sub_dvcs = tools.generate_test_repo(tmpdir, values=[0], dvcs_type='git')
-    ssub_dvcs = tools.generate_test_repo(tmpdir, values=[0], dvcs_type='git')
+    dvcs = tools.generate_test_repo(tmpdir, values=[0], dvcs_type="git")
+    sub_dvcs = tools.generate_test_repo(tmpdir, values=[0], dvcs_type="git")
+    ssub_dvcs = tools.generate_test_repo(tmpdir, values=[0], dvcs_type="git")
     commit_hash_0 = dvcs.get_hash(f"{util.git_default_branch()}")
 
     # State 1 (one submodule)
-    dvcs.run_git(['-c', 'protocol.file.allow=always',
-                  'submodule', 'add', sub_dvcs.path, 'sub1'])
-    dvcs.commit('Add sub1')
+    dvcs.run_git(["-c", "protocol.file.allow=always", "submodule", "add", sub_dvcs.path, "sub1"])
+    dvcs.commit("Add sub1")
     commit_hash_1 = dvcs.get_hash(f"{util.git_default_branch()}")
 
     # State 2 (one submodule with sub-submodule)
-    dvcs.run_git(['-c', 'protocol.file.allow=always',
-                  'submodule', 'update', '--init'])
-    sub1_dvcs = tools.Git(join(dvcs.path, 'sub1'))
-    sub_dvcs.run_git(['-c', 'protocol.file.allow=always',
-                      'submodule', 'add', ssub_dvcs.path, 'ssub1'])
-    sub_dvcs.commit('Add sub1')
-    sub1_dvcs.run_git(['pull'])
-    dvcs.run_git(['add', 'sub1'])
-    dvcs.commit('Update sub1')
+    dvcs.run_git(["-c", "protocol.file.allow=always", "submodule", "update", "--init"])
+    sub1_dvcs = tools.Git(join(dvcs.path, "sub1"))
+    sub_dvcs.run_git(
+        ["-c", "protocol.file.allow=always", "submodule", "add", ssub_dvcs.path, "ssub1"]
+    )
+    sub_dvcs.commit("Add sub1")
+    sub1_dvcs.run_git(["pull"])
+    dvcs.run_git(["add", "sub1"])
+    dvcs.commit("Update sub1")
     sub1_hash_2 = sub1_dvcs.get_hash(f"{util.git_default_branch()}")
     commit_hash_2 = dvcs.get_hash(f"{util.git_default_branch()}")
 
     # State 3 (one submodule; sub-submodule removed)
-    sub_dvcs.run_git(['rm', '-f', 'ssub1'])
-    sub_dvcs.commit('Remove ssub1')
-    sub1_dvcs.run_git(['pull'])
-    dvcs.run_git(['add', 'sub1'])
-    dvcs.commit('Update sub1 again')
+    sub_dvcs.run_git(["rm", "-f", "ssub1"])
+    sub_dvcs.commit("Remove ssub1")
+    sub1_dvcs.run_git(["pull"])
+    dvcs.run_git(["add", "sub1"])
+    dvcs.commit("Update sub1 again")
     commit_hash_3 = dvcs.get_hash(f"{util.git_default_branch()}")
 
     # State 4 (back to one submodule with sub-submodule)
-    sub1_dvcs.run_git(['checkout', sub1_hash_2])
-    dvcs.run_git(['add', 'sub1'])
-    dvcs.commit('Update sub1 3rd time')
+    sub1_dvcs.run_git(["checkout", sub1_hash_2])
+    dvcs.run_git(["add", "sub1"])
+    dvcs.commit("Update sub1 3rd time")
     commit_hash_4 = dvcs.get_hash(f"{util.git_default_branch()}")
 
     # State 5 (remove final submodule)
-    dvcs.run_git(['rm', '-f', 'sub1'])
-    dvcs.commit('Remove sub1')
+    dvcs.run_git(["rm", "-f", "sub1"])
+    dvcs.commit("Remove sub1")
     commit_hash_5 = dvcs.get_hash(f"{util.git_default_branch()}")
     # Verify clean operation
     conf = config.Config()
@@ -317,29 +343,29 @@ def test_git_submodule(tmpdir):
 
     # State 0
     r.checkout(checkout_dir, commit_hash_0)
-    assert os.path.isfile(join(checkout_dir, 'README'))
-    assert not os.path.exists(join(checkout_dir, 'sub1'))
+    assert os.path.isfile(join(checkout_dir, "README"))
+    assert not os.path.exists(join(checkout_dir, "sub1"))
 
     # State 1
     r.checkout(checkout_dir, commit_hash_1)
-    assert os.path.isfile(join(checkout_dir, 'sub1', 'README'))
-    assert not os.path.exists(join(checkout_dir, 'sub1', 'ssub1'))
+    assert os.path.isfile(join(checkout_dir, "sub1", "README"))
+    assert not os.path.exists(join(checkout_dir, "sub1", "ssub1"))
 
     # State 2
     r.checkout(checkout_dir, commit_hash_2)
-    assert os.path.isfile(join(checkout_dir, 'sub1', 'ssub1', 'README'))
+    assert os.path.isfile(join(checkout_dir, "sub1", "ssub1", "README"))
 
     # State 3
     r.checkout(checkout_dir, commit_hash_3)
-    assert os.path.isfile(join(checkout_dir, 'sub1', 'README'))
-    assert not os.path.exists(join(checkout_dir, 'sub1', 'ssub1'))
+    assert os.path.isfile(join(checkout_dir, "sub1", "README"))
+    assert not os.path.exists(join(checkout_dir, "sub1", "ssub1"))
 
     # State 4
     r.checkout(checkout_dir, commit_hash_4)
-    assert os.path.isfile(join(checkout_dir, 'sub1', 'ssub1', 'README'))
+    assert os.path.isfile(join(checkout_dir, "sub1", "ssub1", "README"))
 
     # State 4 (check clean -fdx runs in sub-sub modules)
-    garbage_filename = join(checkout_dir, 'sub1', 'ssub1', '.garbage')
+    garbage_filename = join(checkout_dir, "sub1", "ssub1", ".garbage")
     util.write_json(garbage_filename, {})
     assert os.path.isfile(garbage_filename)
     r.checkout(checkout_dir, commit_hash_4)
@@ -347,14 +373,14 @@ def test_git_submodule(tmpdir):
 
     # State 5
     r.checkout(checkout_dir, commit_hash_5)
-    assert os.path.isfile(join(checkout_dir, 'README'))
-    assert not os.path.isdir(join(checkout_dir, 'sub1'))
+    assert os.path.isfile(join(checkout_dir, "README"))
+    assert not os.path.isdir(join(checkout_dir, "sub1"))
 
 
-@pytest.mark.parametrize('dvcs_type', [
-    "git",
-    pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))
-])
+@pytest.mark.parametrize(
+    "dvcs_type",
+    ["git", pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))],
+)
 def test_root_ceiling(dvcs_type, tmpdir):
     # Check that git/hg does not try to look for repository in parent
     # directories.
@@ -377,7 +403,7 @@ def test_root_ceiling(dvcs_type, tmpdir):
     r.checkout(workcopy_dir, commit1)
 
     # Corrupt the checkout
-    for pth in ['.hg', '.git']:
+    for pth in [".hg", ".git"]:
         pth = os.path.join(workcopy_dir, pth)
         if os.path.isdir(pth):
             shutil.rmtree(pth)
@@ -388,10 +414,10 @@ def test_root_ceiling(dvcs_type, tmpdir):
         r.checkout(workcopy_dir, commit2)
 
 
-@pytest.mark.parametrize('dvcs_type', [
-    "git",
-    pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))
-])
+@pytest.mark.parametrize(
+    "dvcs_type",
+    ["git", pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))],
+)
 def test_no_such_name_error(dvcs_type, tmpdir):
     tmpdir = str(tmpdir)
     dvcs = tools.generate_test_repo(tmpdir, values=[0], dvcs_type=dvcs_type)
@@ -420,22 +446,22 @@ def test_no_such_name_error(dvcs_type, tmpdir):
         pass
 
 
-@pytest.mark.parametrize('dvcs_type', [
-    "git",
-    pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))
-])
+@pytest.mark.parametrize(
+    "dvcs_type",
+    ["git", pytest.param("hg", marks=pytest.mark.skipif(hglib is None, reason="needs hglib"))],
+)
 def test_filter_date_period(tmpdir, dvcs_type):
     tmpdir = str(tmpdir)
 
     dates = [
         datetime.datetime(2001, 1, 1),
         datetime.datetime(2001, 1, 2),
-        datetime.datetime(2001, 1, 8)
+        datetime.datetime(2001, 1, 8),
     ]
 
     dvcs = tools.generate_repo_from_ops(
-        tmpdir, dvcs_type,
-        [("commit", j, dates[j]) for j in range(len(dates))])
+        tmpdir, dvcs_type, [("commit", j, dates[j]) for j in range(len(dates))]
+    )
     commits = dvcs.get_branch_hashes()[::-1]
     assert len(commits) == len(dates)
 

--- a/test/test_repo_template/setup.py
+++ b/test/test_repo_template/setup.py
@@ -5,15 +5,15 @@ from setuptools import setup
 # This file is a template, and will be rendered before executed.
 # So the double curly brackets will become single after rendering, and
 # when executed, this will work as expected
-content = 'env = {{}}\n'.format(repr(dict(os.environ)))  # noqa W291 see above comment
-with open('asv_test_repo/build_time_env.py', 'w') as f:
+content = "env = {{}}\n".format(repr(dict(os.environ)))  # noqa W291 see above comment
+with open("asv_test_repo/build_time_env.py", "w") as f:
     f.write(content)
 
-setup(name='asv_test_repo',
-      version="{version}",
-      packages=['asv_test_repo'],
-
-      # The following forces setuptools to generate .egg-info directory,
-      # which causes problems in test_environment.py:test_install_success
-      include_package_data=True,
-      )
+setup(
+    name="asv_test_repo",
+    version="{version}",
+    packages=["asv_test_repo"],
+    # The following forces setuptools to generate .egg-info directory,
+    # which causes problems in test_environment.py:test_install_success
+    include_package_data=True,
+)

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -12,7 +12,7 @@ from asv import results, runner, util
 
 def _truncate_floats(item, digits=5):
     if isinstance(item, float):
-        fmt = f'{{:.{digits - 1}e}}'
+        fmt = f"{{:.{digits - 1}e}}"
         return float(fmt.format(item))
     elif isinstance(item, list):
         return [_truncate_floats(x, digits) for x in item]
@@ -31,45 +31,67 @@ def test_results(tmpdir):
     resultsdir = join(tmpdir, "results")
     for i in range(10):
         r = results.Results(
-            {'machine': 'foo',
-             'arch': 'x86_64'},
+            {"machine": "foo", "arch": "x86_64"},
             {},
             hex(i),
             i * 1000000,
-            '2.7',
-            'some-environment-name',
-            {})
+            "2.7",
+            "some-environment-name",
+            {},
+        )
 
         x1 = float(i * 0.001)
         x2 = float(i * 0.001)
         x3 = float((i + 1) ** -1)
 
         values = {
-            'suite1.benchmark1': {'result': [x1], 'number': [1],
-                                  'samples': [[x1, x1]], 'params': [['a']],
-                                  'version': "1", 'profile': b'\x00\xff'},
-            'suite1.benchmark2': {'result': [x2], 'number': [1],
-                                  'samples': [[x2, x2, x2]], 'params': [],
-                                  'version': "1", 'profile': b'\x00\xff'},
-            'suite2.benchmark1': {'result': [x3], 'number': [None],
-                                  'samples': [None], 'params': [['c']],
-                                  'version': None, 'profile': b'\x00\xff'},
-            'suite3.benchmark1': {'result': [x1, x2], 'number': [1, 1],
-                                  'samples': [[x1, x1], [x2, x2, x3]],
-                                  'params': [['c', 'd']],
-                                  'version': None, 'profile': b'\x00\xff'}
+            "suite1.benchmark1": {
+                "result": [x1],
+                "number": [1],
+                "samples": [[x1, x1]],
+                "params": [["a"]],
+                "version": "1",
+                "profile": b"\x00\xff",
+            },
+            "suite1.benchmark2": {
+                "result": [x2],
+                "number": [1],
+                "samples": [[x2, x2, x2]],
+                "params": [],
+                "version": "1",
+                "profile": b"\x00\xff",
+            },
+            "suite2.benchmark1": {
+                "result": [x3],
+                "number": [None],
+                "samples": [None],
+                "params": [["c"]],
+                "version": None,
+                "profile": b"\x00\xff",
+            },
+            "suite3.benchmark1": {
+                "result": [x1, x2],
+                "number": [1, 1],
+                "samples": [[x1, x1], [x2, x2, x3]],
+                "params": [["c", "d"]],
+                "version": None,
+                "profile": b"\x00\xff",
+            },
         }
 
         for key, val in values.items():
-            v = runner.BenchmarkResult(result=val['result'],
-                                       samples=val['samples'],
-                                       number=val['number'],
-                                       profile=val['profile'],
-                                       errcode=0,
-                                       stderr='')
-            benchmark = {'name': key, 'version': val['version'], 'params': val['params']}
-            r.add_result(benchmark, v, record_samples=True,
-                         started_at=timestamp1, duration=duration)
+            v = runner.BenchmarkResult(
+                result=val["result"],
+                samples=val["samples"],
+                number=val["number"],
+                profile=val["profile"],
+                errcode=0,
+                stderr="",
+            )
+            benchmark = {"name": key, "version": val["version"], "params": val["params"]}
+            r.add_result(
+                benchmark, v, record_samples=True, started_at=timestamp1, duration=duration
+            )
 
         # Save / add_existing_results roundtrip
         r.save(resultsdir)
@@ -79,13 +101,9 @@ def test_results(tmpdir):
         assert r2.commit_hash == r.commit_hash
         assert r2._filename == r._filename
 
-        r3 = results.Results(r.params,
-                             r._requirements,
-                             r.commit_hash,
-                             r.date,
-                             r._python,
-                             r.env_name,
-                             {})
+        r3 = results.Results(
+            r.params, r._requirements, r.commit_hash, r.date, r._python, r.env_name, {}
+        )
         r3.load_data(resultsdir)
 
         for rr in [r2, r3]:
@@ -102,66 +120,70 @@ def test_results(tmpdir):
         for bench in r2.get_all_result_keys():
             # Get with same parameters as stored
             params = r2.get_result_params(bench)
-            assert params == values[bench]['params']
-            assert r2.get_result_value(bench, params) == values[bench]['result']
-            assert r2.get_result_samples(bench, params) == values[bench]['samples']
+            assert params == values[bench]["params"]
+            assert r2.get_result_value(bench, params) == values[bench]["result"]
+            assert r2.get_result_samples(bench, params) == values[bench]["samples"]
             stats = r2.get_result_stats(bench, params)
-            if values[bench]['number'][0] is None:
+            if values[bench]["number"][0] is None:
                 assert stats == [None]
             else:
-                assert stats[0]['number'] == values[bench]['number'][0]
+                assert stats[0]["number"] == values[bench]["number"][0]
 
             # Get with different parameters than stored (should return n/a)
-            bad_params = [['foo', 'bar']]
+            bad_params = [["foo", "bar"]]
             assert r2.get_result_value(bench, bad_params) == [None, None]
             assert r2.get_result_stats(bench, bad_params) == [None, None]
             assert r2.get_result_samples(bench, bad_params) == [None, None]
 
             # Get profile
-            assert r2.get_profile(bench) == b'\x00\xff'
+            assert r2.get_profile(bench) == b"\x00\xff"
 
         # Check get_result_keys
         mock_benchmarks = {
-            'suite1.benchmark1': {'version': '1'},
-            'suite1.benchmark2': {'version': '2'},
-            'suite2.benchmark1': {'version': '2'},
+            "suite1.benchmark1": {"version": "1"},
+            "suite1.benchmark2": {"version": "2"},
+            "suite2.benchmark1": {"version": "2"},
         }
-        assert sorted(r2.get_result_keys(mock_benchmarks)) == ['suite1.benchmark1',
-                                                               'suite2.benchmark1']
+        assert sorted(r2.get_result_keys(mock_benchmarks)) == [
+            "suite1.benchmark1",
+            "suite2.benchmark1",
+        ]
 
 
 def test_get_result_hash_from_prefix(tmpdir):
-    results_dir = tmpdir.mkdir('results')
-    machine_dir = results_dir.mkdir('cheetah')
+    results_dir = tmpdir.mkdir("results")
+    machine_dir = results_dir.mkdir("cheetah")
 
-    machine_json = join(os.path.dirname(__file__), 'example_results', 'cheetah', 'machine.json')
-    shutil.copyfile(machine_json, join(str(machine_dir), 'machine.json'))
+    machine_json = join(os.path.dirname(__file__), "example_results", "cheetah", "machine.json")
+    shutil.copyfile(machine_json, join(str(machine_dir), "machine.json"))
 
-    for f in ['e5b6cdbc', 'e5bfoo12']:
-        open(join(str(machine_dir), f'{f}-py2.7-Cython-numpy1.8.json'), 'a').close()
+    for f in ["e5b6cdbc", "e5bfoo12"]:
+        open(join(str(machine_dir), f"{f}-py2.7-Cython-numpy1.8.json"), "a").close()
 
     # check unique, valid case
-    full_commit = results.get_result_hash_from_prefix(str(results_dir), 'cheetah', 'e5b6')
-    assert full_commit == 'e5b6cdbc'
+    full_commit = results.get_result_hash_from_prefix(str(results_dir), "cheetah", "e5b6")
+    assert full_commit == "e5b6cdbc"
 
     # check invalid hash case
-    bad_commit = results.get_result_hash_from_prefix(str(results_dir), 'cheetah', 'foobar')
+    bad_commit = results.get_result_hash_from_prefix(str(results_dir), "cheetah", "foobar")
     assert bad_commit is None
 
     # check non-unique case
     with pytest.raises(util.UserError) as excinfo:
-        results.get_result_hash_from_prefix(str(results_dir), 'cheetah', 'e')
+        results.get_result_hash_from_prefix(str(results_dir), "cheetah", "e")
 
-    assert 'one of multiple commits' in str(excinfo.value)
+    assert "one of multiple commits" in str(excinfo.value)
 
 
-def test_backward_compat_load(example_results): # noqa F811 redefinition of the imported fixture,it can be removed when the fixture is moved to conftest.py file and the import deleted
+def test_backward_compat_load(
+    example_results,
+):  # noqa F811 redefinition of the imported fixture,it can be removed when the fixture is moved to conftest.py file and the import deleted
     resultsdir = example_results
-    filename = join('cheetah', '624da0aa-py2.7-Cython-numpy1.8.json')
+    filename = join("cheetah", "624da0aa-py2.7-Cython-numpy1.8.json")
 
     r = results.Results.load(join(resultsdir, filename))
     assert r._filename == filename
-    assert r._env_name == 'py2.7-Cython-numpy1.8'
+    assert r._env_name == "py2.7-Cython-numpy1.8"
 
 
 def test_json_timestamp(tmpdir):
@@ -172,46 +194,39 @@ def test_json_timestamp(tmpdir):
     stamp1 = datetime.datetime(1971, 1, 1)
     duration = 1.5
 
-    r = results.Results({'machine': 'mach'},
-                        {},
-                        'aaaa',
-                        util.datetime_to_timestamp(stamp0),
-                        'py',
-                        'env',
-                        {})
-    value = runner.BenchmarkResult(
-        result=[42],
-        samples=[None],
-        number=[None],
-        profile=None,
-        errcode=0,
-        stderr=''
+    r = results.Results(
+        {"machine": "mach"}, {}, "aaaa", util.datetime_to_timestamp(stamp0), "py", "env", {}
     )
-    benchmark = {'name': 'some_benchmark', 'version': 'some version', 'params': []}
+    value = runner.BenchmarkResult(
+        result=[42], samples=[None], number=[None], profile=None, errcode=0, stderr=""
+    )
+    benchmark = {"name": "some_benchmark", "version": "some version", "params": []}
     r.add_result(benchmark, value, started_at=stamp1, duration=duration)
     r.save(tmpdir)
 
-    r = util.load_json(join(tmpdir, 'mach', 'aaaa-env.json'))
-    keys = r['result_columns']
-    values = dict(zip(keys, r['results']['some_benchmark']))
-    assert values['started_at'] == util.datetime_to_js_timestamp(stamp1)
-    assert values['duration'] == duration
+    r = util.load_json(join(tmpdir, "mach", "aaaa-env.json"))
+    keys = r["result_columns"]
+    values = dict(zip(keys, r["results"]["some_benchmark"]))
+    assert values["started_at"] == util.datetime_to_js_timestamp(stamp1)
+    assert values["duration"] == duration
 
 
-def test_iter_results(capsys, tmpdir, example_results): # noqa F811 noqa F811 redefinition of the imported fixture,it can be removed when the fixture is moved to conftest.py file and the import deleted
-    dst = os.path.join(str(tmpdir), 'example_results')
+def test_iter_results(
+    capsys, tmpdir, example_results
+):  # noqa F811 noqa F811 redefinition of the imported fixture,it can be removed when the fixture is moved to conftest.py file and the import deleted
+    dst = os.path.join(str(tmpdir), "example_results")
     shutil.copytree(example_results, dst)
 
-    path = os.path.join(dst, 'cheetah')
+    path = os.path.join(dst, "cheetah")
 
     skip_list = [
-        'machine.json',
-        'aaaaaaaa-py2.7-Cython-numpy1.8.json',  # malformed file
-        'bbbbbbbb-py2.7-Cython-numpy1.8.json',  # malformed file
-        'cccccccc-py2.7-Cython-numpy1.8.json',  # malformed file
+        "machine.json",
+        "aaaaaaaa-py2.7-Cython-numpy1.8.json",  # malformed file
+        "bbbbbbbb-py2.7-Cython-numpy1.8.json",  # malformed file
+        "cccccccc-py2.7-Cython-numpy1.8.json",  # malformed file
     ]
 
-    files = [f for f in os.listdir(path) if f.endswith('.json') and f not in skip_list]
+    files = [f for f in os.listdir(path) if f.endswith(".json") and f not in skip_list]
     res = list(results.iter_results(path))
     assert len(res) == len(files)
     out, err = capsys.readouterr()
@@ -221,7 +236,7 @@ def test_iter_results(capsys, tmpdir, example_results): # noqa F811 noqa F811 re
     assert skip_list[0] not in out
 
     # The directory should be ignored without machine.json
-    os.unlink(os.path.join(path, 'machine.json'))
+    os.unlink(os.path.join(path, "machine.json"))
     res = list(results.iter_results(path))
     assert len(res) == 0
     out, err = capsys.readouterr()
@@ -229,82 +244,98 @@ def test_iter_results(capsys, tmpdir, example_results): # noqa F811 noqa F811 re
 
 
 def test_filename_format():
-    r = results.Results({'machine': 'foo'}, [], "commit", 0, "", "env", {})
+    r = results.Results({"machine": "foo"}, [], "commit", 0, "", "env", {})
     assert r._filename == join("foo", "commit-env.json")
 
-    r = results.Results({'machine': 'foo'}, [], "hash", 0, "", "a" * 128, {})
+    r = results.Results({"machine": "foo"}, [], "hash", 0, "", "a" * 128, {})
     assert r._filename == join("foo", "hash-env-e510683b3f5ffe4093d021808bc6ff70.json")
 
 
 def test_remove_samples():
-    benchmark1 = {'name': 'a', 'version': '1', 'params': []}
-    benchmark2 = {'name': 'b', 'version': '1', 'params': [['1', '2', '3']]}
+    benchmark1 = {"name": "a", "version": "1", "params": []}
+    benchmark2 = {"name": "b", "version": "1", "params": [["1", "2", "3"]]}
 
     r = results.Results.unnamed()
 
-    v1 = runner.BenchmarkResult(result=[True], samples=[[1]], number=[1],
-                                profile=None, errcode=0, stderr='')
-    v2 = runner.BenchmarkResult(result=[True] * 3, samples=[[1], [2], [3]], number=[1, 1, 1],
-                                profile=None, errcode=0, stderr='')
+    v1 = runner.BenchmarkResult(
+        result=[True], samples=[[1]], number=[1], profile=None, errcode=0, stderr=""
+    )
+    v2 = runner.BenchmarkResult(
+        result=[True] * 3,
+        samples=[[1], [2], [3]],
+        number=[1, 1, 1],
+        profile=None,
+        errcode=0,
+        stderr="",
+    )
 
     r.add_result(benchmark1, v1, record_samples=True)
     r.add_result(benchmark2, v2, record_samples=True)
 
-    assert r.get_result_samples(benchmark1['name'], benchmark1['params']) == v1.samples
-    assert r.get_result_samples(benchmark2['name'], benchmark2['params']) == v2.samples
+    assert r.get_result_samples(benchmark1["name"], benchmark1["params"]) == v1.samples
+    assert r.get_result_samples(benchmark2["name"], benchmark2["params"]) == v2.samples
 
-    r.remove_samples(benchmark1['name'])
-    assert r.get_result_samples(benchmark1['name'], benchmark1['params']) == [None]
+    r.remove_samples(benchmark1["name"])
+    assert r.get_result_samples(benchmark1["name"], benchmark1["params"]) == [None]
 
-    r.remove_samples(benchmark2['name'], selected_idx=[1])
-    assert r.get_result_samples(benchmark2['name'], benchmark2['params']) == [[1], None, [3]]
+    r.remove_samples(benchmark2["name"], selected_idx=[1])
+    assert r.get_result_samples(benchmark2["name"], benchmark2["params"]) == [[1], None, [3]]
 
-    r.remove_samples(benchmark2['name'])
-    assert r.get_result_samples(benchmark2['name'], benchmark2['params']) == [None, None, None]
+    r.remove_samples(benchmark2["name"])
+    assert r.get_result_samples(benchmark2["name"], benchmark2["params"]) == [None, None, None]
 
 
 def test_table_formatting():
-    benchmark = {'params': [], 'param_names': [], 'unit': 's'}
+    benchmark = {"params": [], "param_names": [], "unit": "s"}
     result = []
     expected = ["[]"]
     assert results._format_benchmark_result(result, benchmark) == expected
 
-    benchmark = {'params': [['a', 'b', 'c']], 'param_names': ['param1'], "unit": "seconds"}
+    benchmark = {"params": [["a", "b", "c"]], "param_names": ["param1"], "unit": "seconds"}
     result = list(zip([1e-6, 2e-6, 3e-6], [3e-6, 2e-6, 1e-6]))
-    expected = ("======== ==========\n"
-                " param1            \n"
-                "-------- ----------\n"
-                "   a      1.00\u00b13\u03bcs \n"
-                "   b      2.00\u00b12\u03bcs \n"
-                "   c      3.00\u00b11\u03bcs \n"
-                "======== ==========")
+    expected = (
+        "======== ==========\n"
+        " param1            \n"
+        "-------- ----------\n"
+        "   a      1.00\u00b13\u03bcs \n"
+        "   b      2.00\u00b12\u03bcs \n"
+        "   c      3.00\u00b11\u03bcs \n"
+        "======== =========="
+    )
     table = "\n".join(results._format_benchmark_result(result, benchmark, max_width=80))
     assert table == expected
 
-    benchmark = {'params': [["'a'", "'b'", "'c'"], ["[1]", "[2]"]],
-                 'param_names': ['param1', 'param2'], "unit": "seconds"}
-    result = list(zip([1, 2, None, 4, 5, float('nan')], [None] * 6))
-    expected = ("======== ======== =======\n"
-                "--            param2     \n"
-                "-------- ----------------\n"
-                " param1    [1]      [2]  \n"
-                "======== ======== =======\n"
-                "   a      1.00s    2.00s \n"
-                "   b      failed   4.00s \n"
-                "   c      5.00s     n/a  \n"
-                "======== ======== =======")
+    benchmark = {
+        "params": [["'a'", "'b'", "'c'"], ["[1]", "[2]"]],
+        "param_names": ["param1", "param2"],
+        "unit": "seconds",
+    }
+    result = list(zip([1, 2, None, 4, 5, float("nan")], [None] * 6))
+    expected = (
+        "======== ======== =======\n"
+        "--            param2     \n"
+        "-------- ----------------\n"
+        " param1    [1]      [2]  \n"
+        "======== ======== =======\n"
+        "   a      1.00s    2.00s \n"
+        "   b      failed   4.00s \n"
+        "   c      5.00s     n/a  \n"
+        "======== ======== ======="
+    )
     table = "\n".join(results._format_benchmark_result(result, benchmark, max_width=80))
     assert table == expected
 
-    expected = ("======== ======== ========\n"
-                " param1   param2          \n"
-                "-------- -------- --------\n"
-                "   a       [1]     1.00s  \n"
-                "   a       [2]     2.00s  \n"
-                "   b       [1]     failed \n"
-                "   b       [2]     4.00s  \n"
-                "   c       [1]     5.00s  \n"
-                "   c       [2]      n/a   \n"
-                "======== ======== ========")
+    expected = (
+        "======== ======== ========\n"
+        " param1   param2          \n"
+        "-------- -------- --------\n"
+        "   a       [1]     1.00s  \n"
+        "   a       [2]     2.00s  \n"
+        "   b       [1]     failed \n"
+        "   b       [2]     4.00s  \n"
+        "   c       [1]     5.00s  \n"
+        "   c       [2]      n/a   \n"
+        "======== ======== ========"
+    )
     table = "\n".join(results._format_benchmark_result(result, benchmark, max_width=0))
     assert table == expected

--- a/test/test_rm.py
+++ b/test/test_rm.py
@@ -10,27 +10,24 @@ from . import tools
 def test_rm(tmpdir, example_results):
     tmpdir = str(tmpdir)
 
-    shutil.copytree(
-        example_results,
-        join(tmpdir, 'example_results'))
+    shutil.copytree(example_results, join(tmpdir, "example_results"))
 
-    conf = config.Config.from_json({
-        'results_dir': join(tmpdir, 'example_results'),
-        'repo': "### IGNORED, BUT REQUIRED ###"
-    })
+    conf = config.Config.from_json(
+        {"results_dir": join(tmpdir, "example_results"), "repo": "### IGNORED, BUT REQUIRED ###"}
+    )
 
-    tools.run_asv_with_conf(conf, 'rm', '-y', 'benchmark=time_quantity*')
+    tools.run_asv_with_conf(conf, "rm", "-y", "benchmark=time_quantity*")
 
     results_a = list(results.iter_results(tmpdir))
     for result in results_a:
         for key in result.get_all_result_keys():
-            assert not key.startswith('time_quantity')
+            assert not key.startswith("time_quantity")
         for key in result.started_at.keys():
-            assert not key.startswith('time_quantity')
+            assert not key.startswith("time_quantity")
         for key in result.duration.keys():
-            assert not key.startswith('time_quantity')
+            assert not key.startswith("time_quantity")
 
-    tools.run_asv_with_conf(conf, 'rm', '-y', 'commit_hash=05d283b9')
+    tools.run_asv_with_conf(conf, "rm", "-y", "commit_hash=05d283b9")
 
     results_b = list(results.iter_results(tmpdir))
     assert len(results_b) == len(results_a) - 1

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -24,14 +24,18 @@ def test_set_commit_hash(capsys, existing_env_conf):
     r = repo.get_repo(conf)
     commit_hash = r.get_hash_from_name(r.get_branch_name())
 
-    tools.run_asv_with_conf(conf, 'run', '--set-commit-hash=' + r.get_branch_name(),
-                            _machine_file=join(tmpdir, 'asv-machine.json'))
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        "--set-commit-hash=" + r.get_branch_name(),
+        _machine_file=join(tmpdir, "asv-machine.json"),
+    )
 
     env_name = list(environment.get_environments(conf, None))[0].name
-    result_filename = commit_hash[:conf.hash_length] + '-' + env_name + '.json'
-    assert result_filename in os.listdir(join('results_workflow', 'orangutan'))
+    result_filename = commit_hash[: conf.hash_length] + "-" + env_name + ".json"
+    assert result_filename in os.listdir(join("results_workflow", "orangutan"))
 
-    result_path = join('results_workflow', 'orangutan', result_filename)
+    result_path = join("results_workflow", "orangutan", result_filename)
     times = results.Results.load(result_path)
     assert times.commit_hash == commit_hash
 
@@ -40,21 +44,24 @@ def test_run_spec(basic_conf_2):
     tmpdir, local, conf, machine_file = basic_conf_2
     conf.build_cache_size = 5
 
-    extra_branches = [(f'{util.git_default_branch()}~1', 'some-branch', [12])]
-    dvcs_path = os.path.join(tmpdir, 'test_repo2')
-    dvcs = tools.generate_test_repo(dvcs_path, [1, 2],
-                                    extra_branches=extra_branches)
+    extra_branches = [(f"{util.git_default_branch()}~1", "some-branch", [12])]
+    dvcs_path = os.path.join(tmpdir, "test_repo2")
+    dvcs = tools.generate_test_repo(dvcs_path, [1, 2], extra_branches=extra_branches)
     conf.repo = dvcs.path
 
     initial_commit = dvcs.get_hash(f"{util.git_default_branch()}~1")
     master_commit = dvcs.get_hash(f"{util.git_default_branch()}")
     branch_commit = dvcs.get_hash("some-branch")
     template_dir = os.path.join(tmpdir, "results_workflow_template")
-    results_dir = os.path.join(tmpdir, 'results_workflow')
-    tools.run_asv_with_conf(conf, 'run', initial_commit + "^!",
-                            '--bench=time_secondary.track_value',
-                            '--quick',
-                            _machine_file=join(tmpdir, 'asv-machine.json'))
+    results_dir = os.path.join(tmpdir, "results_workflow")
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        initial_commit + "^!",
+        "--bench=time_secondary.track_value",
+        "--quick",
+        _machine_file=join(tmpdir, "asv-machine.json"),
+    )
     shutil.copytree(results_dir, template_dir)
 
     def _test_run(range_spec, branches, expected_commits):
@@ -62,9 +69,14 @@ def test_run_spec(basic_conf_2):
         shutil.rmtree(results_dir)
         shutil.copytree(template_dir, results_dir)
 
-        args = ["run", "--quick", "--skip-existing-successful",
-                "--bench=time_secondary.track_value",
-                "-s", "1000"]  # large number of steps should be noop
+        args = [
+            "run",
+            "--quick",
+            "--skip-existing-successful",
+            "--bench=time_secondary.track_value",
+            "-s",
+            "1000",
+        ]  # large number of steps should be noop
         if range_spec is not None:
             args.append(range_spec)
         conf.branches = branches
@@ -75,42 +87,44 @@ def test_run_spec(basic_conf_2):
         tool_name = envs[0].tool_name
 
         pyver = conf.pythons[0]
-        if pyver.startswith('pypy'):
+        if pyver.startswith("pypy"):
             pyver = pyver[2:]
 
-        expected = set(['machine.json'])
+        expected = set(["machine.json"])
         for commit in expected_commits:
             for psver in tools.DUMMY2_VERSIONS:
-                expected.add(f'{commit[:8]}-{tool_name}-py{pyver}-asv_dummy_'
-                             f'test_package_1-asv_dummy_test_package_2{psver}.json')
+                expected.add(
+                    f"{commit[:8]}-{tool_name}-py{pyver}-asv_dummy_"
+                    f"test_package_1-asv_dummy_test_package_2{psver}.json"
+                )
 
-        result_files = os.listdir(join(tmpdir, 'results_workflow', 'orangutan'))
+        result_files = os.listdir(join(tmpdir, "results_workflow", "orangutan"))
 
         assert set(result_files) == expected
 
     for branches, expected_commits in (
         # Without branches in config, shoud just use master
         ([None], [initial_commit, master_commit]),
-
         # With one branch in config, should just use that branch
         (["some-branch"], [initial_commit, branch_commit]),
-
         # With two branch in config, should apply to specified branches
-        ([f"{util.git_default_branch()}", "some-branch"],
-         [initial_commit, master_commit, branch_commit]),
+        (
+            [f"{util.git_default_branch()}", "some-branch"],
+            [initial_commit, master_commit, branch_commit],
+        ),
     ):
         for range_spec in (None, "NEW", "ALL"):
             _test_run(range_spec, branches, expected_commits)
 
     # test the HASHFILE version of range_spec'ing
     expected_commits = (initial_commit, branch_commit)
-    with open(os.path.join(tmpdir, 'hashes_to_benchmark'), 'w') as f:
+    with open(os.path.join(tmpdir, "hashes_to_benchmark"), "w") as f:
         for commit in expected_commits:
             f.write(commit + "\n")
         f.write(f"{util.git_default_branch()}~1\n")
         f.write("some-bad-hash-that-will-be-ignored\n")
         expected_commits += (dvcs.get_hash(f"{util.git_default_branch()}~1"),)
-    _test_run('HASHFILE:hashes_to_benchmark', [None], expected_commits)
+    _test_run("HASHFILE:hashes_to_benchmark", [None], expected_commits)
 
 
 def test_run_build_failure(basic_conf):
@@ -120,56 +134,61 @@ def test_run_build_failure(basic_conf):
 
     # Add a commit that fails to build
     dvcs = tools.Git(conf.repo)
-    setup_py = join(dvcs.path, 'setup.py')
-    with open(setup_py, 'r') as f:
+    setup_py = join(dvcs.path, "setup.py")
+    with open(setup_py, "r") as f:
         setup_py_content = f.read()
-    with open(setup_py, 'w') as f:
+    with open(setup_py, "w") as f:
         f.write("assert False")
-    dvcs.add(join(dvcs.path, 'setup.py'))
+    dvcs.add(join(dvcs.path, "setup.py"))
     dvcs.commit("Break setup.py")
-    with open(setup_py, 'w') as f:
+    with open(setup_py, "w") as f:
         f.write(setup_py_content)
-    dvcs.add(join(dvcs.path, 'setup.py'))
+    dvcs.add(join(dvcs.path, "setup.py"))
     dvcs.commit("Fix setup.py")
 
     # Test running it
     timestamp = util.datetime_to_js_timestamp(datetime.datetime.utcnow())
 
-    bench_name = 'time_secondary.track_value'
-    for commit in [f'{util.git_default_branch()}^!',
-                   f'{util.git_default_branch()}~1^!']:
-        tools.run_asv_with_conf(conf, 'run', commit,
-                                '--quick', '--show-stderr',
-                                '--bench', bench_name,
-                                _machine_file=machine_file)
+    bench_name = "time_secondary.track_value"
+    for commit in [f"{util.git_default_branch()}^!", f"{util.git_default_branch()}~1^!"]:
+        tools.run_asv_with_conf(
+            conf,
+            "run",
+            commit,
+            "--quick",
+            "--show-stderr",
+            "--bench",
+            bench_name,
+            _machine_file=machine_file,
+        )
 
     # Check results
     hashes = dvcs.get_branch_hashes()
-    fn_broken, = glob.glob(join(tmpdir, 'results_workflow', 'orangutan',
-                                hashes[1][:8] + '-*.json'))
-    fn_ok, = glob.glob(join(tmpdir, 'results_workflow', 'orangutan',
-                            hashes[0][:8] + '-*.json'))
+    (fn_broken,) = glob.glob(
+        join(tmpdir, "results_workflow", "orangutan", hashes[1][:8] + "-*.json")
+    )
+    (fn_ok,) = glob.glob(join(tmpdir, "results_workflow", "orangutan", hashes[0][:8] + "-*.json"))
 
     data_broken = util.load_json(fn_broken)
     data_ok = util.load_json(fn_ok)
 
     for data in (data_broken, data_ok):
-        value = dict(zip(data['result_columns'], data['results'][bench_name]))
-        assert value['started_at'] >= timestamp
+        value = dict(zip(data["result_columns"], data["results"][bench_name]))
+        assert value["started_at"] >= timestamp
         if data is data_broken:
-            assert 'duration' not in value
+            assert "duration" not in value
         else:
-            assert value['duration'] >= 0
+            assert value["duration"] >= 0
 
-    assert len(data_broken['results']) == 1
-    assert len(data_ok['results']) == 1
-    assert data_broken['result_columns'][0] == 'result'
-    assert data_ok['result_columns'][0] == 'result'
-    assert data_broken['results'][bench_name][0] is None
-    assert data_ok['results'][bench_name][0] == [42.0]
+    assert len(data_broken["results"]) == 1
+    assert len(data_ok["results"]) == 1
+    assert data_broken["result_columns"][0] == "result"
+    assert data_ok["result_columns"][0] == "result"
+    assert data_broken["results"][bench_name][0] is None
+    assert data_ok["results"][bench_name][0] == [42.0]
 
     # Check that parameters were also saved
-    assert data_broken['params'] == data_ok['params']
+    assert data_broken["params"] == data_ok["params"]
 
 
 def test_run_with_repo_subdir(basic_conf_with_subdir):
@@ -181,84 +200,124 @@ def test_run_with_repo_subdir(basic_conf_with_subdir):
     conf.matrix = {}
 
     # This benchmark imports the project under test (asv_test_repo)
-    bench_name = 'params_examples.track_find_test'
+    bench_name = "params_examples.track_find_test"
     # Test with a single changeset
-    tools.run_asv_with_conf(conf, 'run', f'{util.git_default_branch()}^!',
-                            '--quick', '--show-stderr',
-                            '--bench', bench_name,
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        f"{util.git_default_branch()}^!",
+        "--quick",
+        "--show-stderr",
+        "--bench",
+        bench_name,
+        _machine_file=machine_file,
+    )
 
     # Check it ran ok
-    fn_results, = glob.glob(join(tmpdir, 'results_workflow', 'orangutan',
-                                 '*-*.json'))  # avoid machine.json
+    (fn_results,) = glob.glob(
+        join(tmpdir, "results_workflow", "orangutan", "*-*.json")
+    )  # avoid machine.json
     data = util.load_json(fn_results)
 
-    value = dict(zip(data['result_columns'], data['results'][bench_name]))
-    assert value['params'] == [['1', '2']]
-    assert value['result'] == [6, 6]
+    value = dict(zip(data["result_columns"], data["results"][bench_name]))
+    assert value["params"] == [["1", "2"]]
+    assert value["result"] == [6, 6]
 
 
 def test_benchmark_param_selection(basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
     conf.matrix = {}
     tools.generate_test_repo(tmpdir, values=[(1, 2, 3)])
-    tools.run_asv_with_conf(conf, 'run', f'{util.git_default_branch()}^!',
-                            '--quick', '--show-stderr',
-                            '--bench', r'track_param_selection\(.*, 3\)',
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        f"{util.git_default_branch()}^!",
+        "--quick",
+        "--show-stderr",
+        "--bench",
+        r"track_param_selection\(.*, 3\)",
+        _machine_file=machine_file,
+    )
 
     def get_results():
-        results = util.load_json(glob.glob(join(
-            tmpdir, 'results_workflow', 'orangutan', '*-*.json'))[0])
+        results = util.load_json(
+            glob.glob(join(tmpdir, "results_workflow", "orangutan", "*-*.json"))[0]
+        )
         # replacing NaN by 'n/a' make assertions easier
-        keys = results['result_columns']
-        value = dict(zip(keys, results['results']['params_examples.track_param_selection']))
-        return ['n/a' if util.is_nan(item) else item
-                for item in value['result']]
+        keys = results["result_columns"]
+        value = dict(zip(keys, results["results"]["params_examples.track_param_selection"]))
+        return ["n/a" if util.is_nan(item) else item for item in value["result"]]
 
-    assert get_results() == [4, 'n/a', 5, 'n/a']
-    tools.run_asv_with_conf(conf, 'run', '--show-stderr',
-                            '--bench', r'track_param_selection\(1, ',
-                            _machine_file=machine_file)
-    assert get_results() == [4, 6, 5, 'n/a']
-    tools.run_asv_with_conf(conf, 'run', '--show-stderr',
-                            '--bench', 'track_param_selection',
-                            _machine_file=machine_file)
+    assert get_results() == [4, "n/a", 5, "n/a"]
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        "--show-stderr",
+        "--bench",
+        r"track_param_selection\(1, ",
+        _machine_file=machine_file,
+    )
+    assert get_results() == [4, 6, 5, "n/a"]
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        "--show-stderr",
+        "--bench",
+        "track_param_selection",
+        _machine_file=machine_file,
+    )
 
 
 def test_run_append_samples(basic_conf_2):
     tmpdir, local, conf, machine_file = basic_conf_2
 
     # Only one environment
-    conf.matrix['asv_dummy_test_package_2'] = conf.matrix['asv_dummy_test_package_2'][:1]
+    conf.matrix["asv_dummy_test_package_2"] = conf.matrix["asv_dummy_test_package_2"][:1]
 
     # Tests multiple calls to "asv run --append-samples"
     def run_it():
-        tools.run_asv_with_conf(conf, 'run', f"{util.git_default_branch()}^!",
-                                '--bench', 'time_examples.TimeSuite.time_example_benchmark_1',
-                                '--append-samples', '-a', 'repeat=(1, 1, 10.0)', '-a', 'rounds=1',
-                                '-a', 'number=1', '-a', 'warmup_time=0',
-                                _machine_file=machine_file)
+        tools.run_asv_with_conf(
+            conf,
+            "run",
+            f"{util.git_default_branch()}^!",
+            "--bench",
+            "time_examples.TimeSuite.time_example_benchmark_1",
+            "--append-samples",
+            "-a",
+            "repeat=(1, 1, 10.0)",
+            "-a",
+            "rounds=1",
+            "-a",
+            "number=1",
+            "-a",
+            "warmup_time=0",
+            _machine_file=machine_file,
+        )
 
     run_it()
 
-    result_dir = join(tmpdir, 'results_workflow', 'orangutan')
-    result_fn, = [join(result_dir, fn) for fn in os.listdir(result_dir)
-                  if fn != 'machine.json']
+    result_dir = join(tmpdir, "results_workflow", "orangutan")
+    (result_fn,) = [join(result_dir, fn) for fn in os.listdir(result_dir) if fn != "machine.json"]
 
     data = util.load_json(result_fn)
-    value = dict(zip(
-        data['result_columns'],
-        data['results']['time_examples.TimeSuite.time_example_benchmark_1']))
-    assert value['stats_q_25'][0] is not None
-    assert len(value['samples'][0]) == 1
+    value = dict(
+        zip(
+            data["result_columns"],
+            data["results"]["time_examples.TimeSuite.time_example_benchmark_1"],
+        )
+    )
+    assert value["stats_q_25"][0] is not None
+    assert len(value["samples"][0]) == 1
 
     run_it()
     data = util.load_json(result_fn)
-    value = dict(zip(
-        data['result_columns'],
-        data['results']['time_examples.TimeSuite.time_example_benchmark_1']))
-    assert len(value['samples'][0]) == 2
+    value = dict(
+        zip(
+            data["result_columns"],
+            data["results"]["time_examples.TimeSuite.time_example_benchmark_1"],
+        )
+    )
+    assert len(value["samples"][0]) == 2
 
 
 def test_cpu_affinity(basic_conf):
@@ -267,17 +326,28 @@ def test_cpu_affinity(basic_conf):
     # Only one environment
     conf.matrix = {}
 
-    tools.run_asv_with_conf(conf, 'run', f"{util.git_default_branch()}^!",
-                            '--bench', 'time_examples.TimeSuite.time_example_benchmark_1',
-                            '--cpu-affinity=0', '-a', 'repeat=(1, 1, 10.0)', '-a', 'rounds=1',
-                            '-a', 'number=1', '-a', 'warmup_time=0',
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        f"{util.git_default_branch()}^!",
+        "--bench",
+        "time_examples.TimeSuite.time_example_benchmark_1",
+        "--cpu-affinity=0",
+        "-a",
+        "repeat=(1, 1, 10.0)",
+        "-a",
+        "rounds=1",
+        "-a",
+        "number=1",
+        "-a",
+        "warmup_time=0",
+        _machine_file=machine_file,
+    )
     # Check run produced a result
-    result_dir = join(tmpdir, 'results_workflow', 'orangutan')
-    result_fn, = [join(result_dir, fn) for fn in os.listdir(result_dir)
-                  if fn != 'machine.json']
+    result_dir = join(tmpdir, "results_workflow", "orangutan")
+    (result_fn,) = [join(result_dir, fn) for fn in os.listdir(result_dir) if fn != "machine.json"]
     data = util.load_json(result_fn)
-    assert data['results']['time_examples.TimeSuite.time_example_benchmark_1']
+    assert data["results"]["time_examples.TimeSuite.time_example_benchmark_1"]
 
 
 def test_env_matrix_value(basic_conf):
@@ -288,45 +358,57 @@ def test_env_matrix_value(basic_conf):
     def check_env_matrix(env_build, env_nobuild):
         conf.matrix = {"env": env_build, "env_nobuild": env_nobuild}
 
-        tools.run_asv_with_conf(conf, 'run', f"{util.git_default_branch()}^!",
-                                '--bench', 'time_secondary.track_environment_value',
-                                _machine_file=machine_file)
+        tools.run_asv_with_conf(
+            conf,
+            "run",
+            f"{util.git_default_branch()}^!",
+            "--bench",
+            "time_secondary.track_environment_value",
+            _machine_file=machine_file,
+        )
 
         # Check run produced a result
-        result_dir = join(tmpdir, 'results_workflow', 'orangutan')
+        result_dir = join(tmpdir, "results_workflow", "orangutan")
 
-        result_fn1, = glob.glob(result_dir + '/*-SOME_TEST_VAR1.json')
-        result_fn2, = glob.glob(result_dir + '/*-SOME_TEST_VAR2.json')
+        (result_fn1,) = glob.glob(result_dir + "/*-SOME_TEST_VAR1.json")
+        (result_fn2,) = glob.glob(result_dir + "/*-SOME_TEST_VAR2.json")
 
         data = util.load_json(result_fn1)
-        assert data['result_columns'][0] == 'result'
-        assert data['results']['time_secondary.track_environment_value'][0] == [1]
+        assert data["result_columns"][0] == "result"
+        assert data["results"]["time_secondary.track_environment_value"][0] == [1]
 
         data = util.load_json(result_fn2)
-        assert data['results']['time_secondary.track_environment_value'][0] == [2]
+        assert data["results"]["time_secondary.track_environment_value"][0] == [2]
 
-    check_env_matrix({}, {'SOME_TEST_VAR': ['1', '2']})
-    check_env_matrix({'SOME_TEST_VAR': ['1', '2']}, {})
+    check_env_matrix({}, {"SOME_TEST_VAR": ["1", "2"]})
+    check_env_matrix({"SOME_TEST_VAR": ["1", "2"]}, {})
 
 
 def test_parallel(basic_conf_2, dummy_packages):
     tmpdir, local, conf, machine_file = basic_conf_2
 
-    if WIN and os.path.basename(sys.argv[0]).lower().startswith('py.test'):
+    if WIN and os.path.basename(sys.argv[0]).lower().startswith("py.test"):
         # Multiprocessing in spawn mode can result to problems with py.test
         # Find.run calls Setup.run in parallel mode by default
-        pytest.skip("Multiprocessing spawn mode on Windows not safe to run "
-                    "from py.test runner.")
+        pytest.skip(
+            "Multiprocessing spawn mode on Windows not safe to run " "from py.test runner."
+        )
 
     conf.matrix = {
         "req": dict(conf.matrix),
         "env": {"SOME_TEST_VAR": ["1", "2"]},
-        "env_nobuild": {"SOME_OTHER_TEST_VAR": ["1", "2"]}
+        "env_nobuild": {"SOME_OTHER_TEST_VAR": ["1", "2"]},
     }
 
-    tools.run_asv_with_conf(conf, 'run', f"{util.git_default_branch()}^!",
-                            '--bench', 'time_secondary.track_environment_value',
-                            '--parallel=2', _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        f"{util.git_default_branch()}^!",
+        "--bench",
+        "time_secondary.track_environment_value",
+        "--parallel=2",
+        _machine_file=machine_file,
+    )
 
 
 def test_filter_date_period(tmpdir, basic_conf):
@@ -335,26 +417,31 @@ def test_filter_date_period(tmpdir, basic_conf):
     dates = [
         datetime.datetime(2001, 1, 1),
         datetime.datetime(2001, 1, 2),
-        datetime.datetime(2001, 1, 8)
+        datetime.datetime(2001, 1, 8),
     ]
 
     dvcs = tools.generate_repo_from_ops(
-        tmpdir, 'git',
-        [("commit", j, dates[j]) for j in range(len(dates))])
+        tmpdir, "git", [("commit", j, dates[j]) for j in range(len(dates))]
+    )
     commits = dvcs.get_branch_hashes()[::-1]
 
     conf.repo = dvcs.path
     conf.matrix = {}
 
-    tools.run_asv_with_conf(conf, 'run', f'{util.git_default_branch()}',
-                            '--date-period=1w',
-                            '--quick', '--show-stderr',
-                            '--bench=time_secondary.track_value',
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        f"{util.git_default_branch()}",
+        "--date-period=1w",
+        "--quick",
+        "--show-stderr",
+        "--bench=time_secondary.track_value",
+        _machine_file=machine_file,
+    )
 
     expected_commits = [commits[0], commits[2]]
 
-    fns = glob.glob(join(tmpdir, 'results_workflow', 'orangutan', '*-*.json'))
+    fns = glob.glob(join(tmpdir, "results_workflow", "orangutan", "*-*.json"))
 
     for commit in expected_commits:
         assert any(os.path.basename(c).startswith(commit[:8]) for c in fns)
@@ -363,12 +450,13 @@ def test_filter_date_period(tmpdir, basic_conf):
 
 
 def test_format_durations():
-    durations = {'foo': 1, 'bar': 2, 'quux': 3}
+    durations = {"foo": 1, "bar": 2, "quux": 3}
 
     msg = Run.format_durations(durations, 2)
     # Removing tailing spaces, so they don't need to be in `expected`
-    msg = re.sub(r' *\n', r'\n', msg)
-    expected = textwrap.dedent("""\
+    msg = re.sub(r" *\n", r"\n", msg)
+    expected = textwrap.dedent(
+        """\
     =========== ================
      benchmark   total duration
     ----------- ----------------
@@ -376,14 +464,21 @@ def test_format_durations():
         bar          2.00s
         ...           ...
        total         6.00s
-    =========== ================""")
+    =========== ================"""
+    )
     assert msg == expected
 
 
 def test_return_code(tmpdir, basic_conf_2):
     tmpdir, local, conf, machine_file = basic_conf_2
 
-    res = tools.run_asv_with_conf(conf, 'run', f'{util.git_default_branch()}^!', '--quick',
-                                  '--bench', 'TimeSecondary',
-                                  _machine_file=machine_file)
+    res = tools.run_asv_with_conf(
+        conf,
+        "run",
+        f"{util.git_default_branch()}^!",
+        "--quick",
+        "--bench",
+        "TimeSecondary",
+        _machine_file=machine_file,
+    )
     assert res == 2

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -17,13 +17,24 @@ from asv.results import Results
 
 from .test_benchmarks import ASV_CONF_JSON, BENCHMARK_DIR
 
-ON_PYPY = hasattr(sys, 'pypy_version_info')
+ON_PYPY = hasattr(sys, "pypy_version_info")
 
 
 class ResultsWrapper:
-    tuple_type = collections.namedtuple('tuple_type', ['result', 'stats', 'samples',
-                                                       'params', 'stderr', 'errcode',
-                                                       'profile', 'started_at', 'duration'])
+    tuple_type = collections.namedtuple(
+        "tuple_type",
+        [
+            "result",
+            "stats",
+            "samples",
+            "params",
+            "stderr",
+            "errcode",
+            "profile",
+            "started_at",
+            "duration",
+        ],
+    )
 
     def __init__(self, results, benchmarks):
         self.results = results
@@ -37,17 +48,18 @@ class ResultsWrapper:
             yield key, self[key]
 
     def __getitem__(self, key):
-        params = self.benchmarks[key]['params']
-        return self.tuple_type(result=self.results.get_result_value(key, params),
-                               stats=self.results.get_result_stats(key, params),
-                               samples=self.results.get_result_samples(key, params),
-                               stderr=self.results.stderr.get(key),
-                               errcode=self.results.errcode.get(key),
-                               params=params,
-                               profile=(self.results.get_profile(key)
-                                        if self.results.has_profile(key) else None),
-                               started_at=self.results.started_at[key],
-                               duration=self.results.duration.get(key))
+        params = self.benchmarks[key]["params"]
+        return self.tuple_type(
+            result=self.results.get_result_value(key, params),
+            stats=self.results.get_result_stats(key, params),
+            samples=self.results.get_result_samples(key, params),
+            stderr=self.results.stderr.get(key),
+            errcode=self.results.errcode.get(key),
+            params=params,
+            profile=(self.results.get_profile(key) if self.results.has_profile(key) else None),
+            started_at=self.results.started_at[key],
+            duration=self.results.duration.get(key),
+        )
 
 
 @pytest.mark.flaky(reruns=1, reruns_delay=5)
@@ -60,107 +72,109 @@ def test_run_benchmarks(benchmarks_fixture, tmpdir):
 
     # Old results to append to
     results = Results.unnamed()
-    name = 'time_examples.TimeSuite.time_example_benchmark_1'
-    results.add_result(b[name],
-                       runner.BenchmarkResult(result=[1],
-                                              samples=[[42.0, 24.0]],
-                                              number=[1],
-                                              errcode=0, stderr='', profile=None),
-                       record_samples=True)
+    name = "time_examples.TimeSuite.time_example_benchmark_1"
+    results.add_result(
+        b[name],
+        runner.BenchmarkResult(
+            result=[1], samples=[[42.0, 24.0]], number=[1], errcode=0, stderr="", profile=None
+        ),
+        record_samples=True,
+    )
 
     # Run
     runner.run_benchmarks(
-        b, envs[0], results=results, profile=True, show_stderr=True,
-        append_samples=True, record_samples=True)
+        b,
+        envs[0],
+        results=results,
+        profile=True,
+        show_stderr=True,
+        append_samples=True,
+        record_samples=True,
+    )
     times = ResultsWrapper(results, b)
 
     assert len(times) == len(b)
-    assert times[
-        'time_examples.TimeSuite.time_example_benchmark_1'].result != [None]
-    stats = results.get_result_stats(name, b[name]['params'])
-    assert isinstance(stats[0]['q_25'], float)
+    assert times["time_examples.TimeSuite.time_example_benchmark_1"].result != [None]
+    stats = results.get_result_stats(name, b[name]["params"])
+    assert isinstance(stats[0]["q_25"], float)
     # The exact number of samples may vary if the calibration is not fully accurate
-    samples = results.get_result_samples(name, b[name]['params'])
+    samples = results.get_result_samples(name, b[name]["params"])
     assert len(samples[0]) >= 4
     # Explicitly provided 'prev_samples` should come first
     assert samples[0][:2] == [42.0, 24.0]
     # Benchmarks that raise exceptions should have a time of "None"
-    assert times[
-        'time_secondary.TimeSecondary.time_exception'].result == [None]
-    assert times[
-        'subdir.time_subdir.time_foo'].result != [None]
+    assert times["time_secondary.TimeSecondary.time_exception"].result == [None]
+    assert times["subdir.time_subdir.time_foo"].result != [None]
     if not ON_PYPY:
         # XXX: the memory benchmarks don't work on Pypy, since asizeof
         # is CPython-only
-        assert times[
-            'mem_examples.mem_list'].result[0] > 1000
-    assert times[
-        'time_secondary.track_value'].result == [42.0]
-    assert times['time_secondary.track_value'].profile is not None
-    assert isinstance(times['time_examples.time_with_warnings'].stderr, type(''))
-    assert times['time_examples.time_with_warnings'].errcode != 0
-    assert times['time_secondary.track_fail_errcode_123'].errcode == 123
-    if hasattr(os, 'kill') and hasattr(os, 'getpid'):
+        assert times["mem_examples.mem_list"].result[0] > 1000
+    assert times["time_secondary.track_value"].result == [42.0]
+    assert times["time_secondary.track_value"].profile is not None
+    assert isinstance(times["time_examples.time_with_warnings"].stderr, type(""))
+    assert times["time_examples.time_with_warnings"].errcode != 0
+    assert times["time_secondary.track_fail_errcode_123"].errcode == 123
+    if hasattr(os, "kill") and hasattr(os, "getpid"):
         expected = -9 if os.name != "nt" else 9
-        assert times['time_secondary.track_fail_signal_9'].errcode == expected
+        assert times["time_secondary.track_fail_signal_9"].errcode == expected
 
-    assert times['time_examples.TimeWithBadTimer.time_it'].result == [0.0]
+    assert times["time_examples.TimeWithBadTimer.time_it"].result == [0.0]
 
-    assert times['params_examples.track_param'].params == [
+    assert times["params_examples.track_param"].params == [
         [
             "<class 'benchmark.params_examples.ClassOne'>",
-            "<class 'benchmark.params_examples.ClassTwo'>"
+            "<class 'benchmark.params_examples.ClassTwo'>",
         ]
     ]
-    assert times['params_examples.track_param'].result == [42, 42]
+    assert times["params_examples.track_param"].result == [42, 42]
 
-    assert times['params_examples.mem_param'].params == [['10', '20'], ['2', '3']]
-    assert len(times['params_examples.mem_param'].result) == 2 * 2
+    assert times["params_examples.mem_param"].params == [["10", "20"], ["2", "3"]]
+    assert len(times["params_examples.mem_param"].result) == 2 * 2
 
-    assert times['params_examples.ParamSuite.track_value'].params == [["'a'", "'b'", "'c'"]]
-    assert times['params_examples.ParamSuite.track_value'].result == [1 + 0, 2 + 0, 3 + 0]
+    assert times["params_examples.ParamSuite.track_value"].params == [["'a'", "'b'", "'c'"]]
+    assert times["params_examples.ParamSuite.track_value"].result == [1 + 0, 2 + 0, 3 + 0]
 
-    assert isinstance(times['params_examples.TuningTest.time_it'].result[0], float)
-    assert isinstance(times['params_examples.TuningTest.time_it'].result[1], float)
+    assert isinstance(times["params_examples.TuningTest.time_it"].result[0], float)
+    assert isinstance(times["params_examples.TuningTest.time_it"].result[1], float)
 
-    assert isinstance(times['params_examples.time_skip'].result[0], float)
-    assert isinstance(times['params_examples.time_skip'].result[1], float)
-    assert util.is_nan(times['params_examples.time_skip'].result[2])
+    assert isinstance(times["params_examples.time_skip"].result[0], float)
+    assert isinstance(times["params_examples.time_skip"].result[1], float)
+    assert util.is_nan(times["params_examples.time_skip"].result[2])
 
-    assert times['peakmem_examples.peakmem_list'].result[0] >= 4 * 2**20
+    assert times["peakmem_examples.peakmem_list"].result[0] >= 4 * 2**20
 
-    assert times['cache_examples.ClassLevelSetup.track_example'].result == [500]
-    assert times['cache_examples.ClassLevelSetup.track_example2'].result == [500]
+    assert times["cache_examples.ClassLevelSetup.track_example"].result == [500]
+    assert times["cache_examples.ClassLevelSetup.track_example2"].result == [500]
 
-    assert times['cache_examples.track_cache_foo'].result == [42]
-    assert times['cache_examples.track_cache_bar'].result == [12]
-    assert times['cache_examples.track_my_cache_foo'].result == [0]
+    assert times["cache_examples.track_cache_foo"].result == [42]
+    assert times["cache_examples.track_cache_bar"].result == [12]
+    assert times["cache_examples.track_my_cache_foo"].result == [0]
 
-    assert times['cache_examples.ClassLevelSetupFail.track_fail'].result == [None]
-    assert 'raise RuntimeError()' in times['cache_examples.ClassLevelSetupFail.track_fail'].stderr
+    assert times["cache_examples.ClassLevelSetupFail.track_fail"].result == [None]
+    assert "raise RuntimeError()" in times["cache_examples.ClassLevelSetupFail.track_fail"].stderr
 
-    assert times['cache_examples.ClassLevelCacheTimeout.track_fail'].result == [None]
-    assert times['cache_examples.ClassLevelCacheTimeoutSuccess.track_success'].result == [0]
+    assert times["cache_examples.ClassLevelCacheTimeout.track_fail"].result == [None]
+    assert times["cache_examples.ClassLevelCacheTimeoutSuccess.track_success"].result == [0]
 
-    assert times['cache_examples.time_fail_second_run'].result == [None]
-    assert times['cache_examples.time_fail_second_run'].samples == [None]
+    assert times["cache_examples.time_fail_second_run"].result == [None]
+    assert times["cache_examples.time_fail_second_run"].samples == [None]
 
-    profile_path = join(str(tmpdir), 'test.profile')
-    with open(profile_path, 'wb') as fd:
-        fd.write(times['time_secondary.track_value'].profile)
+    profile_path = join(str(tmpdir), "test.profile")
+    with open(profile_path, "wb") as fd:
+        fd.write(times["time_secondary.track_value"].profile)
     pstats.Stats(profile_path)
 
     # Check for running setup on each repeat (one extra run from profile)
     # The output would contain error messages if the asserts in the benchmark fail.
     expected = ["<%d>" % j for j in range(1, 12)]
-    assert times['time_examples.TimeWithRepeat.time_it'].stderr.split() == expected
+    assert times["time_examples.TimeWithRepeat.time_it"].stderr.split() == expected
 
     # Calibration of iterations should not rerun setup
-    expected = (['setup'] * 2, ['setup'] * 3)
-    assert times['time_examples.TimeWithRepeatCalibrate.time_it'].stderr.split() in expected
+    expected = (["setup"] * 2, ["setup"] * 3)
+    assert times["time_examples.TimeWithRepeatCalibrate.time_it"].stderr.split() in expected
 
     # Check tuple-form repeat attribute produced results
-    assert 2 <= len(times['time_examples.time_auto_repeat'].samples[0]) <= 4
+    assert 2 <= len(times["time_examples.time_auto_repeat"].samples[0]) <= 4
 
     # Check run time timestamps
     for name, result in times.items():
@@ -176,7 +190,7 @@ def test_quick(benchmarks_fixture):
     conf, repo, envs, commit_hash = benchmarks_fixture
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
-    skip_names = [name for name in b.keys() if name != 'time_examples.TimeWithRepeat.time_it']
+    skip_names = [name for name in b.keys() if name != "time_examples.TimeWithRepeat.time_it"]
     b2 = b.filter_out(skip_names)
 
     results = runner.run_benchmarks(b2, envs[0], quick=True, show_stderr=True)
@@ -187,92 +201,90 @@ def test_quick(benchmarks_fixture):
     # Check that the benchmark was run only once. The result for quick==False
     # is tested above in test_find_benchmarks
     expected = ["<1>"]
-    assert times['time_examples.TimeWithRepeat.time_it'].stderr.split() == expected
+    assert times["time_examples.TimeWithRepeat.time_it"].stderr.split() == expected
 
 
 def test_skip_param_selection():
-    d = {'repo': 'foo'}
+    d = {"repo": "foo"}
     d.update(ASV_CONF_JSON)
     conf = config.Config.from_json(d)
 
     class DummyEnv:
-        name = 'env'
+        name = "env"
 
     d = [
-        {'name': 'test_nonparam', 'params': [], 'version': '1'},
-        {'name': 'test_param',
-         'params': [['1', '2', '3']],
-         'param_names': ['n'],
-         'version': '1'}
+        {"name": "test_nonparam", "params": [], "version": "1"},
+        {"name": "test_param", "params": [["1", "2", "3"]], "param_names": ["n"], "version": "1"},
     ]
 
     results = Results.unnamed()
-    b = benchmarks.Benchmarks(conf, d, [r'test_nonparam', r'test_param\([23]\)'])
+    b = benchmarks.Benchmarks(conf, d, [r"test_nonparam", r"test_param\([23]\)"])
 
     results.add_result(
-        b['test_param'],
+        b["test_param"],
         runner.BenchmarkResult(
             result=[1, 2, 3],
             samples=[None] * 3,
             number=[None] * 3,
             errcode=0,
-            stderr='',
-            profile=None
-        )
+            stderr="",
+            profile=None,
+        ),
     )
 
     runner.skip_benchmarks(b, DummyEnv(), results)
 
-    assert results._results.get('test_nonparam') is None
-    assert results._results['test_param'] == [1, None, None]
+    assert results._results.get("test_nonparam") is None
+    assert results._results["test_param"] == [1, None, None]
 
 
-@pytest.mark.skipif(not (hasattr(os, 'fork') and hasattr(socket, 'AF_UNIX')),
-                    reason="test requires fork and unix sockets")
+@pytest.mark.skipif(
+    not (hasattr(os, "fork") and hasattr(socket, "AF_UNIX")),
+    reason="test requires fork and unix sockets",
+)
 def test_forkserver(tmpdir):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
-    shutil.copytree(BENCHMARK_DIR, 'benchmark')
+    shutil.copytree(BENCHMARK_DIR, "benchmark")
 
     d = {}
     d.update(ASV_CONF_JSON)
-    d['env_dir'] = "env"
-    d['benchmark_dir'] = 'benchmark'
-    d['repo'] = 'None'
+    d["env_dir"] = "env"
+    d["benchmark_dir"] = "benchmark"
+    d["repo"] = "None"
     conf = config.Config.from_json(d)
 
-    with open(os.path.join('benchmark', '__init__.py'), 'w') as f:
+    with open(os.path.join("benchmark", "__init__.py"), "w") as f:
         f.write("import sys; sys.stdout.write('import-time print')")
 
-    with open(os.path.join('benchmark', 'unimportable.py'), 'w') as f:
+    with open(os.path.join("benchmark", "unimportable.py"), "w") as f:
         f.write("raise RuntimeError('not importable')")
 
     env = environment.ExistingEnvironment(conf, sys.executable, {}, {})
-    spawner = runner.ForkServer(env, os.path.abspath('benchmark'))
+    spawner = runner.ForkServer(env, os.path.abspath("benchmark"))
 
-    result_file = os.path.join(tmpdir, 'run-result')
+    result_file = os.path.join(tmpdir, "run-result")
 
     try:
-        out, errcode = spawner.run('time_examples.TimeWithRepeat.time_it', '{}',
-                                   None,
-                                   result_file,
-                                   60,
-                                   os.getcwd())
+        out, errcode = spawner.run(
+            "time_examples.TimeWithRepeat.time_it", "{}", None, result_file, 60, os.getcwd()
+        )
     finally:
         spawner.close()
 
     assert out.startswith("import-time print<1>")
     assert errcode == 0
 
-    with open(result_file, 'r') as f:
+    with open(result_file, "r") as f:
         data = json.load(f)
-    assert len(data['samples']) >= 1
+    assert len(data["samples"]) >= 1
 
 
 needs_unix_socket_mark = pytest.mark.skipif(
-    not (hasattr(os, 'fork') and hasattr(socket, 'AF_UNIX')),
-    reason="test requires fork and unix sockets")
+    not (hasattr(os, "fork") and hasattr(socket, "AF_UNIX")),
+    reason="test requires fork and unix sockets",
+)
 
 
 def clear_pyc(path):
@@ -280,10 +292,10 @@ def clear_pyc(path):
         fn = join(path, fn)
         if not os.path.isfile(fn):
             continue
-        if fn.lower().endswith('.pyc'):
+        if fn.lower().endswith(".pyc"):
             os.unlink(fn)
 
-    dn = join(path, '__pycache__')
+    dn = join(path, "__pycache__")
     if os.path.isdir(dn):
         shutil.rmtree(dn)
 
@@ -293,13 +305,13 @@ def test_forkserver_preimport(tmpdir):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
-    os.makedirs('benchmark')
+    os.makedirs("benchmark")
 
     d = {}
     d.update(ASV_CONF_JSON)
-    d['env_dir'] = "env"
-    d['benchmark_dir'] = 'benchmark'
-    d['repo'] = 'None'
+    d["env_dir"] = "env"
+    d["benchmark_dir"] = "benchmark"
+    d["repo"] = "None"
     conf = config.Config.from_json(d)
 
     env = environment.ExistingEnvironment(conf, sys.executable, {}, {})
@@ -308,10 +320,10 @@ def test_forkserver_preimport(tmpdir):
     # Normal benchmark suite
     #
 
-    with open(os.path.join('benchmark', '__init__.py'), 'w') as f:
+    with open(os.path.join("benchmark", "__init__.py"), "w") as f:
         f.write("print('message')")
 
-    spawner = runner.ForkServer(env, os.path.abspath('benchmark'))
+    spawner = runner.ForkServer(env, os.path.abspath("benchmark"))
     try:
         success, out = spawner.preimport()
     finally:
@@ -326,94 +338,96 @@ def test_forkserver_preimport(tmpdir):
 
     # NOTE: the .pyc files need to be removed, as Python 2 pyc caching
     # has problems with overwriting files rapidly
-    clear_pyc('benchmark')
+    clear_pyc("benchmark")
 
-    with open(os.path.join('benchmark', '__init__.py'), 'w') as f:
+    with open(os.path.join("benchmark", "__init__.py"), "w") as f:
         f.write("import os, sys; print('egassem'); sys.stdout.flush(); os._exit(0)")
 
-    spawner = runner.ForkServer(env, os.path.abspath('benchmark'))
+    spawner = runner.ForkServer(env, os.path.abspath("benchmark"))
     try:
         success, out = spawner.preimport()
     finally:
         spawner.close()
 
     assert success is False
-    assert out.startswith('asv: benchmark runner crashed')
+    assert out.startswith("asv: benchmark runner crashed")
 
     #
     # Benchmark suite that has an unimportable file
     #
 
-    clear_pyc('benchmark')
+    clear_pyc("benchmark")
 
-    with open(os.path.join('benchmark', '__init__.py'), 'w') as f:
+    with open(os.path.join("benchmark", "__init__.py"), "w") as f:
         pass
 
-    with open(os.path.join('benchmark', 'bad.py'), 'w') as f:
+    with open(os.path.join("benchmark", "bad.py"), "w") as f:
         f.write("raise RuntimeError()")
 
-    spawner = runner.ForkServer(env, os.path.abspath('benchmark'))
+    spawner = runner.ForkServer(env, os.path.abspath("benchmark"))
     try:
         success, out = spawner.preimport()
     finally:
         spawner.close()
 
     assert success is True
-    assert out.startswith('Traceback')
+    assert out.startswith("Traceback")
 
 
-@pytest.mark.parametrize('launch_method', [
-    'spawn',
-    pytest.param('forkserver', marks=needs_unix_socket_mark)
-])
+@pytest.mark.parametrize(
+    "launch_method", ["spawn", pytest.param("forkserver", marks=needs_unix_socket_mark)]
+)
 def test_run_import_failure(capsys, benchmarks_fixture, launch_method):
     conf, repo, envs, commit_hash = benchmarks_fixture
 
-    with open(os.path.join('benchmark', 'unimportable.py'), 'w') as f:
-        f.write('def track_unimportable(): pass')
+    with open(os.path.join("benchmark", "unimportable.py"), "w") as f:
+        f.write("def track_unimportable(): pass")
 
     b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
 
-    skip_names = [name for name in b.keys()
-                  if name not in ('time_secondary.track_value', 'unimportable.track_unimportable')]
+    skip_names = [
+        name
+        for name in b.keys()
+        if name not in ("time_secondary.track_value", "unimportable.track_unimportable")
+    ]
     b2 = b.filter_out(skip_names)
 
     #
     # Module with import raising an exception
     #
 
-    with open(os.path.join('benchmark', 'unimportable.py'), 'w') as f:
+    with open(os.path.join("benchmark", "unimportable.py"), "w") as f:
         f.write('import sys; sys.stderr.write("hello import"); sys.stderr.flush()\n')
-        f.write('raise SystemExit(0)')
+        f.write("raise SystemExit(0)")
 
     results = runner.run_benchmarks(b2, envs[0], show_stderr=False, launch_method=launch_method)
     times = ResultsWrapper(results, b2)
 
-    assert times['time_secondary.track_value'].errcode == 0
-    assert times['time_secondary.track_value'].result == [42]
+    assert times["time_secondary.track_value"].errcode == 0
+    assert times["time_secondary.track_value"].result == [42]
 
-    assert times['unimportable.track_unimportable'].errcode != 0
-    err = times['unimportable.track_unimportable'].stderr
-    assert 'hello import' in err
+    assert times["unimportable.track_unimportable"].errcode != 0
+    err = times["unimportable.track_unimportable"].stderr
+    assert "hello import" in err
 
     text, err = capsys.readouterr()
-    assert 'hello import' not in text
+    assert "hello import" not in text
 
     #
     # Module with import crashing the process
     #
 
-    clear_pyc('benchmark')
+    clear_pyc("benchmark")
 
-    with open(os.path.join('benchmark', 'unimportable.py'), 'w') as f:
+    with open(os.path.join("benchmark", "unimportable.py"), "w") as f:
         f.write('import sys; sys.stderr.write("hello import"); sys.stderr.flush()\n')
-        f.write('import os; os._exit(0)')
+        f.write("import os; os._exit(0)")
 
     results = runner.run_benchmarks(b2, envs[0], show_stderr=True, launch_method=launch_method)
     times = ResultsWrapper(results, b2)
 
-    assert times['unimportable.track_unimportable'].errcode != 0
-    assert times['unimportable.track_unimportable'].stderr
+    assert times["unimportable.track_unimportable"].errcode != 0
+    assert times["unimportable.track_unimportable"].stderr
 
     # track_value may run (spawn) or not (forkserver), so don't check for it
 
@@ -423,29 +437,29 @@ def test_run_import_failure(capsys, benchmarks_fixture, launch_method):
     # Module with import printing output
     #
 
-    clear_pyc('benchmark')
+    clear_pyc("benchmark")
 
-    with open(os.path.join('benchmark', 'unimportable.py'), 'w') as f:
+    with open(os.path.join("benchmark", "unimportable.py"), "w") as f:
         f.write('import sys; sys.stderr.write("hello import"); sys.stderr.flush()\n')
 
     results = runner.run_benchmarks(b2, envs[0], show_stderr=True, launch_method=launch_method)
     times = ResultsWrapper(results, b2)
 
-    assert times['time_secondary.track_value'].errcode == 0
-    assert times['unimportable.track_unimportable'].errcode != 0
+    assert times["time_secondary.track_value"].errcode == 0
+    assert times["unimportable.track_unimportable"].errcode != 0
 
     text, err = capsys.readouterr()
-    assert 'hello import' in text
+    assert "hello import" in text
 
 
 def test_timeraw_benchmark(benchmarks_fixture):
     conf, repo, envs, commit_hash = benchmarks_fixture
 
-    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex='TimerawSuite')
+    b = benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash], regex="TimerawSuite")
     results = runner.run_benchmarks(b, envs[0], show_stderr=True)
     times = ResultsWrapper(results, b)
 
-    assert times['timeraw_examples.TimerawSuite.timeraw_fresh'].result is not None
-    assert times['timeraw_examples.TimerawSuite.timeraw_setup'].result is not None
-    assert 'timed out' in times['timeraw_examples.TimerawSuite.timeraw_timeout'].stderr
-    assert '0' * 7 * 3 in times['timeraw_examples.TimerawSuite.timeraw_count'].stderr
+    assert times["timeraw_examples.TimerawSuite.timeraw_fresh"].result is not None
+    assert times["timeraw_examples.TimerawSuite.timeraw_setup"].result is not None
+    assert "timed out" in times["timeraw_examples.TimerawSuite.timeraw_timeout"].stderr
+    assert "0" * 7 * 3 in times["timeraw_examples.TimerawSuite.timeraw_count"].stderr

--- a/test/test_show.py
+++ b/test/test_show.py
@@ -4,28 +4,30 @@ from os.path import abspath, dirname, join
 
 from . import tools
 
-BENCHMARK_DIR = abspath(join(dirname(__file__), 'example_results'))
-MACHINE_FILE = abspath(join(dirname(__file__), 'asv-machine.json'))
+BENCHMARK_DIR = abspath(join(dirname(__file__), "example_results"))
+MACHINE_FILE = abspath(join(dirname(__file__), "asv-machine.json"))
 
 
 def test_show(capsys, show_fixture):
     conf = show_fixture
 
-    tools.run_asv_with_conf(conf, 'show')
+    tools.run_asv_with_conf(conf, "show")
     text, err = capsys.readouterr()
-    assert 'py2.7-Cython-numpy1.8' in text
-    assert 'py2.7-numpy1.8' in text
-    assert 'py2.7-foo-numpy1.8' in text
-    assert 'fcf8c079' in text
+    assert "py2.7-Cython-numpy1.8" in text
+    assert "py2.7-numpy1.8" in text
+    assert "py2.7-foo-numpy1.8" in text
+    assert "fcf8c079" in text
 
-    tools.run_asv_with_conf(conf, 'show', 'fcf8c079')
+    tools.run_asv_with_conf(conf, "show", "fcf8c079")
     text, err = capsys.readouterr()
     assert "time_ci_small [cheetah/py2.7-numpy1.8]\n  3.00±0s\n\n" in text
 
-    tools.run_asv_with_conf(conf, 'show', 'fcf8c079', '--machine=cheetah',
-                            '--bench=time_ci', '--details')
+    tools.run_asv_with_conf(
+        conf, "show", "fcf8c079", "--machine=cheetah", "--bench=time_ci", "--details"
+    )
     text, err = capsys.readouterr()
-    expected = textwrap.dedent("""
+    expected = textwrap.dedent(
+        """
     Commit: fcf8c079
 
     time_ci_big [cheetah/py2.7-numpy1.8]
@@ -35,21 +37,22 @@ def test_show(capsys, show_fixture):
     time_ci_small [cheetah/py2.7-numpy1.8]
       3.00±0s
       ci_99: (3.10s, 3.90s)
-    """)
+    """
+    )
     assert text.strip() == expected.strip()
 
 
 def test_show_durations(capsys, show_fixture):
     conf = show_fixture
 
-    tools.run_asv_with_conf(conf, 'show', '--machine=cheetah', '--durations')
+    tools.run_asv_with_conf(conf, "show", "--machine=cheetah", "--durations")
     text, err = capsys.readouterr()
-    assert '13dd6571547f8dd87b24c4e29536d33cc4f335c9  6.00s' in text.strip()
+    assert "13dd6571547f8dd87b24c4e29536d33cc4f335c9  6.00s" in text.strip()
 
-    tools.run_asv_with_conf(conf, 'show', '13dd6571', '--machine=cheetah',
-                            '--durations')
+    tools.run_asv_with_conf(conf, "show", "13dd6571", "--machine=cheetah", "--durations")
     text, err = capsys.readouterr()
-    expected = textwrap.dedent("""
+    expected = textwrap.dedent(
+        """
     Commit: 13dd6571
 
     Machine    : cheetah
@@ -60,5 +63,6 @@ def test_show_durations(capsys, show_fixture):
         time_quantity.time_quantity_array_conversion  1.00s
 
         total duration: 6.00s
-    """)
+    """
+    )
     assert text.strip() == expected.strip()

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -16,20 +16,28 @@ def test_compute_stats():
 
     assert statistics.compute_stats([], 1) == (None, None)
     assert statistics.compute_stats([15.0], 1) == (
-        15.0, {'ci_99_a': -math.inf, 'ci_99_b': math.inf,
-               'number': 1, 'q_25': 15.0, 'q_75': 15.0, 'repeat': 1})
+        15.0,
+        {
+            "ci_99_a": -math.inf,
+            "ci_99_b": math.inf,
+            "number": 1,
+            "q_25": 15.0,
+            "q_75": 15.0,
+            "repeat": 1,
+        },
+    )
 
     for nsamples, true_mean in product([10, 50, 250], [0, 0.3, 0.6]):
         samples = np.random.randn(nsamples) + true_mean
         result, stats = statistics.compute_stats(samples, 42)
 
-        assert stats['repeat'] == len(samples)
-        assert stats['number'] == 42
-        assert np.allclose(stats['q_25'], np.percentile(samples, 25))
-        assert np.allclose(stats['q_75'], np.percentile(samples, 75))
+        assert stats["repeat"] == len(samples)
+        assert stats["number"] == 42
+        assert np.allclose(stats["q_25"], np.percentile(samples, 25))
+        assert np.allclose(stats["q_75"], np.percentile(samples, 75))
         assert np.allclose(result, np.median(samples))
 
-        ci = stats['ci_99_a'], stats['ci_99_b']
+        ci = stats["ci_99_a"], stats["ci_99_b"]
         assert ci[0] <= true_mean <= ci[1]
         w = 12.0 * np.std(samples) / np.sqrt(len(samples))
         assert ci[1] - ci[0] < w
@@ -109,8 +117,9 @@ def test_quantile_ci():
     np.random.seed(1)
 
     for sampler in [sample_exp, sample_normal]:
-        cis = _check_ci(lambda z, alpha: statistics.quantile_ci(z, 0.5, alpha),
-                        sampler, nsamples=300)
+        cis = _check_ci(
+            lambda z, alpha: statistics.quantile_ci(z, 0.5, alpha), sampler, nsamples=300
+        )
         atol = 5 / 300
         for size, alpha, alpha_got in cis:
             if size < 20:
@@ -130,8 +139,20 @@ def test_quantile_ci_small():
 
 def test_quantile_ci_r():
     # Compare to R
-    x = [-2.47946614, -1.49595963, -1.02812482, -0.76592323, -0.09452743, 0.10732743,
-         0.27798342, 0.50173779, 0.57829823, 0.60474948, 0.94695675, 1.20159789]
+    x = [
+        -2.47946614,
+        -1.49595963,
+        -1.02812482,
+        -0.76592323,
+        -0.09452743,
+        0.10732743,
+        0.27798342,
+        0.50173779,
+        0.57829823,
+        0.60474948,
+        0.94695675,
+        1.20159789,
+    ]
 
     # quantile(x, type=7, prob=p)
     q_20_e = -0.9756845
@@ -248,8 +269,8 @@ def test_laplace_posterior_basic():
     assert abs(c.cdf(249.5) - 0.5) < 1e-8
 
     # check cdf sanity
-    assert c.cdf(float('inf')) == 1.0
-    assert c.cdf(-float('inf')) == 0.0
+    assert c.cdf(float("inf")) == 1.0
+    assert c.cdf(-float("inf")) == 0.0
     assert abs(c.cdf(-1e9) - 0) < 1e-6
     assert abs(c.cdf(1e9) - 1) < 1e-6
 
@@ -317,39 +338,45 @@ def test_mann_whitney_u_cdf():
                 assert p2 == pytest.approx(p, abs=1e-3, rel=0), (m, n, u, p2, p)
 
     # Tables from Mann & Whitney, Ann. Math. Statist. 18, 50 (1947).
-    tbl = [[.250, .100, .050],
-           [.500, .200, .100],
-           [.750, .400, .200],
-           [None, .600, .350],
-           [None, None, .500],
-           [None, None, .650]]
+    tbl = [
+        [0.250, 0.100, 0.050],
+        [0.500, 0.200, 0.100],
+        [0.750, 0.400, 0.200],
+        [None, 0.600, 0.350],
+        [None, None, 0.500],
+        [None, None, 0.650],
+    ]
     check_table(3, tbl)
 
-    tbl = [[.200, .067, .028, .014],
-           [.400, .133, .057, .029],
-           [.600, .267, .114, .057],
-           [None, .400, .200, .100],
-           [None, .600, .314, .171],
-           [None, None, .429, .243],
-           [None, None, .571, .343],
-           [None, None, None, .443],
-           [None, None, None, .557]]
+    tbl = [
+        [0.200, 0.067, 0.028, 0.014],
+        [0.400, 0.133, 0.057, 0.029],
+        [0.600, 0.267, 0.114, 0.057],
+        [None, 0.400, 0.200, 0.100],
+        [None, 0.600, 0.314, 0.171],
+        [None, None, 0.429, 0.243],
+        [None, None, 0.571, 0.343],
+        [None, None, None, 0.443],
+        [None, None, None, 0.557],
+    ]
     check_table(4, tbl)
 
-    tbl = [[.167, .047, .018, .008, .004],
-           [.333, .095, .036, .016, .008],
-           [.500, .190, .071, .032, .016],
-           [.667, .286, .125, .056, .028],
-           [None, .429, .196, .095, .048],
-           [None, .571, .286, .143, .075],
-           [None, None, .393, .206, .111],
-           [None, None, .500, .278, .155],
-           [None, None, .607, .365, .210],
-           [None, None, None, .452, .274],
-           [None, None, None, .548, .345],
-           [None, None, None, None, .421],
-           [None, None, None, None, .500],
-           [None, None, None, None, .579]]
+    tbl = [
+        [0.167, 0.047, 0.018, 0.008, 0.004],
+        [0.333, 0.095, 0.036, 0.016, 0.008],
+        [0.500, 0.190, 0.071, 0.032, 0.016],
+        [0.667, 0.286, 0.125, 0.056, 0.028],
+        [None, 0.429, 0.196, 0.095, 0.048],
+        [None, 0.571, 0.286, 0.143, 0.075],
+        [None, None, 0.393, 0.206, 0.111],
+        [None, None, 0.500, 0.278, 0.155],
+        [None, None, 0.607, 0.365, 0.210],
+        [None, None, None, 0.452, 0.274],
+        [None, None, None, 0.548, 0.345],
+        [None, None, None, None, 0.421],
+        [None, None, None, None, 0.500],
+        [None, None, None, None, 0.579],
+    ]
     check_table(5, tbl)
 
 
@@ -359,13 +386,13 @@ def test_mann_whitney_u_scipy():
     stats = pytest.importorskip("scipy.stats")
 
     def check(x, y):
-        u0, p0 = stats.mannwhitneyu(x, y, alternative='two-sided', use_continuity=False)
+        u0, p0 = stats.mannwhitneyu(x, y, alternative="two-sided", use_continuity=False)
 
-        u, p = statistics.mann_whitney_u(x.tolist(), y.tolist(), method='normal')
+        u, p = statistics.mann_whitney_u(x.tolist(), y.tolist(), method="normal")
         assert u == u0
         assert p == pytest.approx(p0, rel=1e-9, abs=0)
 
-        u, p = statistics.mann_whitney_u(x.tolist(), y.tolist(), method='exact')
+        u, p = statistics.mann_whitney_u(x.tolist(), y.tolist(), method="exact")
         assert u == u0
         assert p == pytest.approx(p0, rel=5e-2, abs=5e-3)
 
@@ -386,19 +413,19 @@ def test_mann_whitney_u_basic():
     # wilcox.test(a, b, exact=TRUE)
     a = [1, 2, 3, 4]
     b = [0.9, 1.1, 0.7]
-    u, p = statistics.mann_whitney_u(a, b, method='exact')
+    u, p = statistics.mann_whitney_u(a, b, method="exact")
     assert u == 11
     assert p == pytest.approx(0.11428571428571428, abs=0, rel=1e-10)
 
     a = [1, 2]
     b = [1.5]
-    u, p = statistics.mann_whitney_u(a, b, method='exact')
+    u, p = statistics.mann_whitney_u(a, b, method="exact")
     assert u == 1
     assert p == 1.0
 
     a = [1, 2]
     b = [2.5]
-    u, p = statistics.mann_whitney_u(a, b, method='exact')
+    u, p = statistics.mann_whitney_u(a, b, method="exact")
     assert u == 0
     assert p == pytest.approx(2 / 3, abs=0, rel=1e-10)
 
@@ -413,14 +440,13 @@ def test_mann_whitney_u_R():
     random.shuffle(a)
     random.shuffle(b)
 
-    wilcox_test = robjects.r('wilcox.test')
+    wilcox_test = robjects.r("wilcox.test")
 
     for m in range(1, len(a) + 1):
         for n in range(1, len(b) + 1):
             u, p = statistics.mann_whitney_u(a[:m], b[:n])
 
-            r = wilcox_test(robjects.FloatVector(a[:m]),
-                            robjects.FloatVector(b[:n]))
+            r = wilcox_test(robjects.FloatVector(a[:m]), robjects.FloatVector(b[:n]))
 
             if max(m, n) <= 20:
                 err = 1e-10  # exact method
@@ -433,8 +459,8 @@ def test_mann_whitney_u_R():
                 else:
                     err = 0.05
 
-            assert u == r.rx('statistic')[0][0]
-            assert p == pytest.approx(r.rx('p.value')[0][0], abs=0, rel=err)
+            assert u == r.rx("statistic")[0][0]
+            assert p == pytest.approx(r.rx("p.value")[0][0], abs=0, rel=err)
 
 
 def test_binom():

--- a/test/test_step_detect.py
+++ b/test/test_step_detect.py
@@ -4,12 +4,20 @@ import random
 import pytest
 
 from asv import step_detect
-from asv.step_detect import (detect_regressions, detect_steps, golden_search, median,
-                             rolling_median_dev, solve_potts, solve_potts_approx,
-                             solve_potts_autogamma)
+from asv.step_detect import (
+    detect_regressions,
+    detect_steps,
+    golden_search,
+    median,
+    rolling_median_dev,
+    solve_potts,
+    solve_potts_approx,
+    solve_potts_autogamma,
+)
 
 try:
     import numpy as np
+
     np.random.seed
     HAVE_NUMPY = True
 except (ImportError, NameError):
@@ -37,11 +45,7 @@ def test_solve_potts(use_rangemedian):
 
     # Bigger case, exact solver
     t = np.arange(100)
-    y0 = (+ 0.4 * (t >= 5) +
-          0.9 * (t >= 10) -
-          0.2 * (t >= 20) +
-          0.2 * (t >= 50) +
-          1.1 * (t >= 70))
+    y0 = +0.4 * (t >= 5) + 0.9 * (t >= 10) - 0.2 * (t >= 20) + 0.2 * (t >= 50) + 1.1 * (t >= 70)
     y = y0 + 0.05 * np.random.rand(y0.size)
     right, values, dists = solve_potts(y.tolist(), w=[1] * len(y), gamma=0.1)
     assert right == [5, 10, 20, 50, 70, 100]
@@ -52,12 +56,14 @@ def test_solve_potts(use_rangemedian):
 
     # Larger case
     t = np.arange(3000)
-    y0 = (+ 0.4 * (t >= 10) +
-          0.9 * (t >= 30) -
-          0.2 * (t >= 200) +
-          0.2 * (t >= 600) +
-          1.1 * (t >= 2500) -
-          0.5 * (t >= 2990))
+    y0 = (
+        +0.4 * (t >= 10)
+        + 0.9 * (t >= 30)
+        - 0.2 * (t >= 200)
+        + 0.2 * (t >= 600)
+        + 1.1 * (t >= 2500)
+        - 0.5 * (t >= 2990)
+    )
 
     # Small amount of noise shouldn't disturb step finding
     y = y0 + 0.05 * np.random.randn(y0.size)
@@ -74,8 +80,9 @@ def test_solve_potts(use_rangemedian):
     # steps in the former
     y = y0 + 0.025 * np.random.rand(y.size)
     ypad = 0.025 * np.random.randn(10000 - 3000)
-    right, values, dists, gamma = solve_potts_autogamma(y.tolist() + ypad.tolist(),
-                                                        w=[1] * (len(y) + len(ypad)))
+    right, values, dists, gamma = solve_potts_autogamma(
+        y.tolist() + ypad.tolist(), w=[1] * (len(y) + len(ypad))
+    )
     assert right == [10, 30, 200, 600, 2500, 2990, 3000, 10000]
 
 
@@ -101,11 +108,7 @@ def test_weighted():
     np.random.seed(1234)
 
     t = np.arange(100)
-    y0 = (+ 0.4 * (t >= 5) +
-          0.9 * (t >= 10) -
-          0.2 * (t >= 20) +
-          0.2 * (t >= 50) +
-          1.1 * (t >= 70))
+    y0 = +0.4 * (t >= 5) + 0.9 * (t >= 10) - 0.2 * (t >= 20) + 0.2 * (t >= 50) + 1.1 * (t >= 70)
     y = y0 + 0.05 * np.random.rand(y0.size)
 
     y = y.tolist()
@@ -158,13 +161,15 @@ def test_detect_regressions(use_rangemedian):
         steps_lr = [(l, r) for l, r, _, _, _ in steps]
         k = steps[0][1]
         assert 990 <= k <= 1010
-        assert steps_lr == [(0, k),
-                            (k, 3234 + (seed % 123)),
-                            (3234 + (seed % 123), 3264 + (seed % 53)),
-                            (3264 + (seed % 53), 3350),
-                            (3350, 3500 + (seed % 71)),
-                            (3500 + (seed % 71), 3700),
-                            (3700, 4000)]
+        assert steps_lr == [
+            (0, k),
+            (k, 3234 + (seed % 123)),
+            (3234 + (seed % 123), 3264 + (seed % 53)),
+            (3264 + (seed % 53), 3350),
+            (3350, 3500 + (seed % 71)),
+            (3500 + (seed % 71), 3700),
+            (3700, 4000),
+        ]
         steps_v = [x[2] for x in steps]
         assert np.allclose(steps_v, [0.35, 0.05, 2.05, 4.05, 1.15, 4.05, 2.05], rtol=0.3)
 
@@ -174,10 +179,10 @@ def test_detect_regressions(use_rangemedian):
 
         # Check detect_regressions
         new_value, best_value, regression_pos = detect_regressions(steps)
-        assert regression_pos == [(3233 + (seed % 123), (3233 + (seed % 123) + 1),
-                                   steps_v[1], min(steps_v[2:])),
-                                  (3499 + (seed % 71), 3499 + (seed % 71) + 1,
-                                   steps_v[4], min(steps_v[5:]))]
+        assert regression_pos == [
+            (3233 + (seed % 123), (3233 + (seed % 123) + 1), steps_v[1], min(steps_v[2:])),
+            (3499 + (seed % 71), 3499 + (seed % 71) + 1, steps_v[4], min(steps_v[5:])),
+        ]
         assert np.allclose(best_value, 0.7 / 2 - 0.3, rtol=0.3, atol=0)
         assert np.allclose(new_value, 0.7 / 2 - 0.3 + 2, rtol=0.3, atol=0)
 
@@ -185,6 +190,7 @@ def test_detect_regressions(use_rangemedian):
 def test_golden_search():
     def f(x):
         return 1 + x**3 + x**4
+
     x = golden_search(f, -1, -0.25, xatol=1e-5, ftol=0)
     assert abs(x - (-3 / 4)) < 1e-4
     x = golden_search(f, -0.25, 0.25, xatol=1e-5, ftol=0)
@@ -201,10 +207,7 @@ def rolling_median_dev_naive(items):
 def test_rolling_median():
     random.seed(1)
 
-    datasets = [
-        [1, 1, 10, 3, 5, 1, -16, -3, 4, 9],
-        [random.gauss(0, 1) for j in range(500)]
-    ]
+    datasets = [[1, 1, 10, 3, 5, 1, -16, -3, 4, 9], [random.gauss(0, 1) for j in range(500)]]
 
     for x in datasets:
         got = list(rolling_median_dev(x))
@@ -221,7 +224,7 @@ def test_l1dist(use_rangemedian):
     datasets = [
         ([1, 1, 10, 3, 5, 1, -16, -3, 4, 9], [1] * 10),
         ([random.gauss(0, 1) for j in range(50)], [1] * 50),
-        ([1, 2, 3, 4], [1, 2, 1, 2])
+        ([1, 2, 3, 4], [1, 2, 1, 2]),
     ]
 
     def median_iter(y, w):
@@ -249,9 +252,7 @@ def test_l1dist(use_rangemedian):
 
 
 def test_regression_threshold():
-    steps = [(0, 1, 1.0, 1.0, 0.0),
-             (1, 2, 1.1, 1.1, 0.0),
-             (2, 3, 2.0, 2.0, 0.0)]
+    steps = [(0, 1, 1.0, 1.0, 0.0), (1, 2, 1.1, 1.1, 0.0), (2, 3, 2.0, 2.0, 0.0)]
 
     latest, best, pos = detect_regressions(steps, threshold=0.05, min_size=1)
     assert latest == 2
@@ -273,9 +274,7 @@ def test_regression_threshold():
     assert best is None
     assert pos is None
 
-    steps = [(0, 1, 1.0, 1.0, 0.0),
-             (1, 2, 1.3, 1.3, 0.0),
-             (2, 3, 1.1, 1.1, 0.0)]
+    steps = [(0, 1, 1.0, 1.0, 0.0), (1, 2, 1.3, 1.3, 0.0), (2, 3, 1.1, 1.1, 0.0)]
 
     latest, best, pos = detect_regressions(steps, threshold=0.2, min_size=1)
     assert latest is None
@@ -284,9 +283,7 @@ def test_regression_threshold():
 
     # Gradual change should result to a regression detected somewhere,
     # even if the individual steps are smaller than the threshold
-    steps = [(0, 1, 1.0, 1.0, 0.0),
-             (1, 2, 1.04, 1.04, 0.0),
-             (2, 3, 1.08, 1.08, 0.0)]
+    steps = [(0, 1, 1.0, 1.0, 0.0), (1, 2, 1.04, 1.04, 0.0), (2, 3, 1.08, 1.08, 0.0)]
 
     latest, best, pos = detect_regressions(steps, threshold=0.05)
     assert pos == [(0, 1, 1.0, 1.04)]
@@ -310,9 +307,7 @@ def test_zero_weight():
 
 
 def test_regression_min_size():
-    steps = [(0, 2, 1.0, 1.0, 0.0),
-             (2, 3, 0.0, 0.0, 0.0),
-             (3, 5, 1.0, 1.0, 0.0)]
+    steps = [(0, 2, 1.0, 1.0, 0.0), (2, 3, 0.0, 0.0, 0.0), (3, 5, 1.0, 1.0, 0.0)]
 
     latest, best, pos = detect_regressions(steps)
     assert latest is None and best is None and pos is None
@@ -322,9 +317,7 @@ def test_regression_min_size():
     assert best == 0.0
     assert pos == [(2, 3, 0.0, 1.0)]
 
-    steps = [(0, 2, 1.0, 1.0, 0.0),
-             (2, 3, 0.0, 0.0, 0.0),
-             (3, 5, 2.0, 1.0, 0.0)]
+    steps = [(0, 2, 1.0, 1.0, 0.0), (2, 3, 0.0, 0.0, 0.0), (3, 5, 2.0, 1.0, 0.0)]
 
     latest, best, pos = detect_regressions(steps)
     assert latest == 2.0
@@ -333,14 +326,110 @@ def test_regression_min_size():
 
 
 def test_solve_potts_approx_bug():
-    y = [2.9, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1,
-         3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1,
-         3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.2, 3.1, 3.1, 3.1, 3.1,
-         3.1, 3.1, 3.1, 3.1, 2.9, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1, 3.1]
-    w = [86.1, 1.0, 1.0, 1.0, 0.8, 1.0, 0.8, 1.0, 1.0, 0.9, 0.9, 1.0,
-         0.8, 1.0, 1.0, 1.0, 1.0, 0.9, 0.6, 0.9, 0.5, 1.0, 1.0, 1.0, 1.0,
-         1.0, 1.0, 1.0, 1.0, 1.0, 0.9, 1.0, 1.0, 0.7, 1.0, 1.0, 1.0, 1.0,
-         1.0, 1.0, 0.8, 0.8, 50.0, 0.8, 1.0, 1.0, 0.6, 0.8, 1.0, 1.0]
+    y = [
+        2.9,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.2,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        2.9,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+        3.1,
+    ]
+    w = [
+        86.1,
+        1.0,
+        1.0,
+        1.0,
+        0.8,
+        1.0,
+        0.8,
+        1.0,
+        1.0,
+        0.9,
+        0.9,
+        1.0,
+        0.8,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        0.9,
+        0.6,
+        0.9,
+        0.5,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        0.9,
+        1.0,
+        1.0,
+        0.7,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        0.8,
+        0.8,
+        50.0,
+        0.8,
+        1.0,
+        1.0,
+        0.6,
+        0.8,
+        1.0,
+        1.0,
+    ]
     gamma = 0.3
 
     r0, v0, d0 = solve_potts(y, w, gamma=gamma)

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -12,7 +12,8 @@ from asv import util
 @pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_timeout():
     timeout_codes = []
-    timeout_codes.append(r"""
+    timeout_codes.append(
+        r"""
 import sys
 import time
 
@@ -23,10 +24,12 @@ sys.stderr.flush()
 time.sleep(60)
 sys.stdout.write("Stdout after waiting\n")
 sys.stderr.write("Stderr after waiting\n")
-    """)
+    """
+    )
 
     # Another example, where timeout is due to a hanging sub-subprocess
-    timeout_codes.append(r"""
+    timeout_codes.append(
+        r"""
 import sys
 import subprocess
 
@@ -42,16 +45,16 @@ subprocess.call([
 ])
 sys.stdout.write("Stdout after waiting\n")
 sys.stderr.write("Stderr after waiting\n")
-    """)
+    """
+    )
 
     for timeout_code in timeout_codes:
         t = time.time()
         try:
-            util.check_output([
-                sys.executable, "-c", timeout_code], timeout=1)
+            util.check_output([sys.executable, "-c", timeout_code], timeout=1)
         except util.ProcessError as e:
-            assert len(e.stdout.strip().split('\n')) == 1
-            assert len(e.stderr.strip().split('\n')) == 1
+            assert len(e.stdout.strip().split("\n")) == 1
+            assert len(e.stderr.strip().split("\n")) == 1
             print(e.stdout)
             assert e.stdout.strip() == "Stdout before waiting"
             assert e.stderr.strip() == "Stderr before waiting"
@@ -71,12 +74,10 @@ sys.stderr.write("Stderr before error\n")
 sys.exit(1)
 """
     try:
-        util.check_output([
-            sys.executable, "-c", code])
+        util.check_output([sys.executable, "-c", code])
     except util.ProcessError as e:
-        assert len(e.stdout.strip().split('\n')) == 1
-        err = [x for x in e.stderr.strip().split('\n')
-               if not x.startswith('Coverage')]
+        assert len(e.stdout.strip().split("\n")) == 1
+        err = [x for x in e.stderr.strip().split("\n") if not x.startswith("Coverage")]
         assert len(err) == 1
         assert e.stdout.strip() == "Stdout before error"
         assert err[0] == "Stderr before error"
@@ -99,7 +100,7 @@ for j in range(3):
     time.sleep(1.0)
 """
     output = util.check_output([sys.executable, "-c", code], timeout=1.5)
-    assert output == '.' * 3
+    assert output == "." * 3
 
     try:
         util.check_output([sys.executable, "-c", code], timeout=0.5)
@@ -116,35 +117,39 @@ print(os.environ['TEST_ASV_FOO'])
 print(os.environ['TEST_ASV_BAR'])
 """
     env = os.environ.copy()
-    env['TEST_ASV_FOO'] = 'foo'
+    env["TEST_ASV_FOO"] = "foo"
     # Force unicode string on Python 2
-    env['TEST_ASV_BAR'] = u'bar'
+    env["TEST_ASV_BAR"] = "bar"
     output = util.check_output([sys.executable, "-c", code], env=env)
-    assert output.splitlines() == ['foo', 'bar']
+    assert output.splitlines() == ["foo", "bar"]
 
 
 def test_no_timeout():
     # Check that timeout=None is allowed.
     code = "import time; time.sleep(0.05)"
-    out, err, retcode = util.check_output([sys.executable, "-c", code], timeout=None,
-                                          return_stderr=True)
-    assert out == ''
-    assert err == ''
+    out, err, retcode = util.check_output(
+        [sys.executable, "-c", code], timeout=None, return_stderr=True
+    )
+    assert out == ""
+    assert err == ""
     assert retcode == 0
 
 
 def test_stderr_redirect():
     # Check redirecting stderr to stdout works
-    code = ("import sys;"
-            "sys.stdout.write('OUT\\n');"
-            "sys.stdout.flush();"
-            "sys.stderr.write('ERR\\n')")
+    code = (
+        "import sys;"
+        "sys.stdout.write('OUT\\n');"
+        "sys.stdout.flush();"
+        "sys.stderr.write('ERR\\n')"
+    )
     out = util.check_output([sys.executable, "-c", code], redirect_stderr=True)
-    assert out.splitlines() == ['OUT', 'ERR']
-    out, err, retcode = util.check_output([sys.executable, "-c", code],
-                                          return_stderr=True, redirect_stderr=True)
-    assert out.splitlines() == ['OUT', 'ERR']
-    assert err == ''
+    assert out.splitlines() == ["OUT", "ERR"]
+    out, err, retcode = util.check_output(
+        [sys.executable, "-c", code], return_stderr=True, redirect_stderr=True
+    )
+    assert out.splitlines() == ["OUT", "ERR"]
+    assert err == ""
     assert retcode == 0
 
 
@@ -161,9 +166,10 @@ def test_popen():
 
 def test_large_output():
     # More data than a pipe buffer can hold
-    data = util.check_output([sys.executable, "-c",
-                              "import sys; [sys.stdout.write('x'*1000) for j in range(5000)]"])
-    assert data == 'x' * 5000000
+    data = util.check_output(
+        [sys.executable, "-c", "import sys; [sys.stdout.write('x'*1000) for j in range(5000)]"]
+    )
+    assert data == "x" * 5000000
 
 
 # This *does* seem to work, only seems untestable somehow...

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -15,40 +15,39 @@ def test_update_simple(monkeypatch, generate_result_dir):
     basedir = os.path.abspath(os.path.dirname(conf.results_dir))
     local = os.path.abspath(os.path.dirname(__file__))
 
-    shutil.copyfile(os.path.join(local, 'asv-machine.json'),
-                    os.path.join(basedir, 'asv-machine.json'))
-    machine_file = 'asv-machine.json'
+    shutil.copyfile(
+        os.path.join(local, "asv-machine.json"), os.path.join(basedir, "asv-machine.json")
+    )
+    machine_file = "asv-machine.json"
 
     conf_values = {}
-    for key in ['results_dir', 'html_dir', 'repo', 'project', 'branches']:
+    for key in ["results_dir", "html_dir", "repo", "project", "branches"]:
         conf_values[key] = getattr(conf, key)
 
-    util.write_json(os.path.join(basedir, 'asv.conf.json'), conf_values,
-                    api_version=1)
+    util.write_json(os.path.join(basedir, "asv.conf.json"), conf_values, api_version=1)
 
     # Check renaming of long result files
-    machine_dir = os.path.join(basedir, 'results', 'tarzan')
+    machine_dir = os.path.join(basedir, "results", "tarzan")
 
-    result_fns = [fn for fn in sorted(os.listdir(machine_dir))
-                  if fn != 'machine.json']
-    long_result_fn = 'abbacaca-' + 'a' * 128 + '.json'
-    hash_result_fn = ('abbacaca-env-' + hashlib.md5(b'a' * 128).hexdigest() + '.json')
+    result_fns = [fn for fn in sorted(os.listdir(machine_dir)) if fn != "machine.json"]
+    long_result_fn = "abbacaca-" + "a" * 128 + ".json"
+    hash_result_fn = "abbacaca-env-" + hashlib.md5(b"a" * 128).hexdigest() + ".json"
 
-    shutil.copyfile(os.path.join(machine_dir, result_fns[0]),
-                    os.path.join(machine_dir, long_result_fn))
+    shutil.copyfile(
+        os.path.join(machine_dir, result_fns[0]), os.path.join(machine_dir, long_result_fn)
+    )
 
-    old_env_name = util.load_json(os.path.join(machine_dir, result_fns[0]))['env_name']
+    old_env_name = util.load_json(os.path.join(machine_dir, result_fns[0]))["env_name"]
 
     # Should succeed
     monkeypatch.chdir(basedir)
     tools.run_asv_with_conf(conf, "update", _machine_file=machine_file)
 
     # Check file rename
-    items = [fn for fn in sorted(os.listdir(machine_dir))
-             if fn != 'machine.json']
+    items = [fn for fn in sorted(os.listdir(machine_dir)) if fn != "machine.json"]
     assert long_result_fn.lower() not in [x.lower() for x in items]
     assert hash_result_fn.lower() in [x.lower() for x in items]
 
     # Check env name is preserved
-    new_env_name = util.load_json(os.path.join(machine_dir, items[0]))['env_name']
+    new_env_name = util.load_json(os.path.join(machine_dir, items[0]))["env_name"]
     assert old_env_name == new_env_name

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -12,7 +12,7 @@ import pytest
 
 from asv import util
 
-WIN = (os.name == 'nt')
+WIN = os.name == "nt"
 
 
 def _multiprocessing_raise_processerror(arg):
@@ -35,10 +35,11 @@ def _multiprocessing_raise_usererror(arg):
 def test_parallelfailure():
     # Check the workaround for https://bugs.python.org/issue9400 works
 
-    if WIN and os.path.basename(sys.argv[0]).lower().startswith('py.test'):
+    if WIN and os.path.basename(sys.argv[0]).lower().startswith("py.test"):
         # Multiprocessing in spawn mode can result to problems with py.test
-        pytest.skip("Multiprocessing spawn mode on Windows not safe to run "
-                    "from py.test runner.")
+        pytest.skip(
+            "Multiprocessing spawn mode on Windows not safe to run " "from py.test runner."
+        )
 
     # The exception class must be pickleable
     exc = util.ParallelFailure("test", Exception, "something")
@@ -75,50 +76,46 @@ def test_parallelfailure():
 
 
 def test_which_path(tmpdir):
-    dirname = os.path.abspath(os.path.join(str(tmpdir), 'name with spaces'))
-    fn = 'asv_test_exe_1234.exe'
-    fn2 = 'asv_test_exe_4321.bat'
+    dirname = os.path.abspath(os.path.join(str(tmpdir), "name with spaces"))
+    fn = "asv_test_exe_1234.exe"
+    fn2 = "asv_test_exe_4321.bat"
 
     os.makedirs(dirname)
     shutil.copyfile(sys.executable, os.path.join(dirname, fn))
     shutil.copyfile(sys.executable, os.path.join(dirname, fn2))
 
-    old_path = os.environ.get('PATH', '')
+    old_path = os.environ.get("PATH", "")
     try:
         if WIN:
-            os.environ['PATH'] = old_path + os.pathsep + '"' + dirname + '"'
-            util.which('asv_test_exe_1234')
-            util.which('asv_test_exe_1234.exe')
-            util.which('asv_test_exe_4321')
-            util.which('asv_test_exe_4321.bat')
+            os.environ["PATH"] = old_path + os.pathsep + '"' + dirname + '"'
+            util.which("asv_test_exe_1234")
+            util.which("asv_test_exe_1234.exe")
+            util.which("asv_test_exe_4321")
+            util.which("asv_test_exe_4321.bat")
 
-        os.environ['PATH'] = old_path + os.pathsep + dirname
-        util.which('asv_test_exe_1234.exe')
-        util.which('asv_test_exe_4321.bat')
+        os.environ["PATH"] = old_path + os.pathsep + dirname
+        util.which("asv_test_exe_1234.exe")
+        util.which("asv_test_exe_4321.bat")
         if WIN:
-            util.which('asv_test_exe_1234')
-            util.which('asv_test_exe_4321')
+            util.which("asv_test_exe_1234")
+            util.which("asv_test_exe_4321")
 
         # Check the paths= argument
-        util.which('asv_test_exe_1234.exe', paths=[dirname])
-        util.which('asv_test_exe_4321.bat', paths=[dirname])
+        util.which("asv_test_exe_1234.exe", paths=[dirname])
+        util.which("asv_test_exe_4321.bat", paths=[dirname])
 
         # Check non-existent files
         with pytest.raises(IOError):
-            util.which('nonexistent.exe', paths=[dirname])
+            util.which("nonexistent.exe", paths=[dirname])
     finally:
-        os.environ['PATH'] = old_path
+        os.environ["PATH"] = old_path
 
 
 def test_write_load_json(tmpdir):
-    data = {
-        'a': 1,
-        'b': 2,
-        'c': 3
-    }
+    data = {"a": 1, "b": 2, "c": 3}
     orig_data = dict(data)
 
-    filename = os.path.join(str(tmpdir), 'test.json')
+    filename = os.path.join(str(tmpdir), "test.json")
 
     util.write_json(filename, data)
     data2 = util.load_json(filename)
@@ -143,7 +140,6 @@ def test_write_load_json(tmpdir):
 def test_human_float():
     items = [
         # (expected, value, significant, truncate_small, significant_zeros, reference_value)
-
         # significant
         ("1", 1.2345, 1),
         ("1.2", 1.2345, 2),
@@ -154,7 +150,6 @@ def test_human_float():
         ("123.5", 123.45, 4),
         ("0.001", 0.0012346, 1),
         ("0.001235", 0.0012346, 4),
-
         # significant zeros
         ("0.001", 0.001, 1, None, True),
         ("0.0010", 0.001, 2, None, True),
@@ -162,17 +157,14 @@ def test_human_float():
         ("1", 1, 1, None, True),
         ("1.0", 1, 2, None, True),
         ("1.00", 1, 3, None, True),
-
         # truncate small
         ("0", 0.001, 2, 0),
         ("0", 0.001, 2, 1),
         ("0.001", 0.001, 2, 2),
-
         # non-finite
-        ("inf", float('inf'), 1),
-        ("-inf", -float('inf'), 1),
-        ("nan", float('nan'), 1),
-
+        ("inf", float("inf"), 1),
+        ("-inf", -float("inf"), 1),
+        ("nan", float("nan"), 1),
         # negative
         ("-1", -1.2345, 1),
         ("-0.00100", -0.001, 3, None, True),
@@ -189,7 +181,6 @@ def test_human_float():
 def test_human_time():
     items = [
         # (expected, value, err)
-
         # scales
         ("1.00ns", 1e-9),
         ("1.10μs", 1.1e-6),
@@ -200,7 +191,6 @@ def test_human_time():
         ("2.00h", 3600 * 2),
         ("0s", 0),
         ("n/a", float("nan")),
-
         # err
         ("1.00±1ns", 1e-9, 1e-9),
         ("1.00±0.1ns", 1e-9, 0.1e-9),
@@ -217,14 +207,13 @@ def test_human_time():
         expected = item[0]
         got = util.human_time(*item[1:])
         assert got == expected, item
-        got = util.human_value(item[1], 'seconds', *item[2:])
+        got = util.human_value(item[1], "seconds", *item[2:])
         assert got == expected, item
 
 
 def test_human_file_size():
     items = [
         # (expected, value, err)
-
         # scales
         ("1", 1),
         ("999", 999),
@@ -232,7 +221,6 @@ def test_human_file_size():
         ("1.1M", 1.1e6),
         ("1.12G", 1.12e9),
         ("1.12T", 1.123e12),
-
         # err
         ("1±2", 1, 2),
         ("1±0.1k", 1e3, 123),
@@ -243,7 +231,7 @@ def test_human_file_size():
         expected = item[0]
         got = util.human_file_size(*item[1:])
         assert got == expected, item
-        got = util.human_value(item[1], 'bytes', *item[2:])
+        got = util.human_value(item[1], "bytes", *item[2:])
         assert got == expected, item
 
 
@@ -273,7 +261,7 @@ def test_parse_human_time():
 def test_is_main_thread():
     if sys.version_info[0] >= 3:
         # NB: the test itself doesn't necessarily run in main thread...
-        is_main = (threading.current_thread() == threading.main_thread())
+        is_main = threading.current_thread() == threading.main_thread()
         assert util.is_main_thread() == is_main
 
     results = []
@@ -289,7 +277,7 @@ def test_is_main_thread():
 
 
 def test_json_non_ascii(tmpdir):
-    non_ascii_data = [{'😼': '難', 'ä': 3}]
+    non_ascii_data = [{"😼": "難", "ä": 3}]
 
     fn = os.path.join(str(tmpdir), "nonascii.json")
     util.write_json(fn, non_ascii_data)
@@ -300,40 +288,60 @@ def test_json_non_ascii(tmpdir):
 
 def test_interpolate_command():
     good_items = [
-        ('python {inputs}', dict(inputs='9'),
-         ['python', '9'], {}, {0}, None),
-
-        ('python "{inputs}"', dict(inputs='9'),
-         ['python', '9'], {}, {0}, None),
-
-        ('python {inputs}', dict(inputs=''),
-         ['python', ''], {}, {0}, None),
-
-        ('HELLO="asd" python "{inputs}"', dict(inputs='9'),
-         ['python', '9'], {'HELLO': 'asd'}, {0}, None),
-
-        ('HELLO="asd" return-code=any python "{inputs}"', dict(inputs='9'),
-         ['python', '9'], {'HELLO': 'asd'}, None, None),
-
-        ('HELLO="asd" return-code=255 python "{inputs}"', dict(inputs='9'),
-         ['python', '9'], {'HELLO': 'asd'}, {255}, None),
-
-        ('HELLO="asd" return-code=255 python "{inputs}"', dict(inputs='9'),
-         ['python', '9'], {'HELLO': 'asd'}, {255}, None),
-
-        ('HELLO="asd" in-dir="{somedir}" python', dict(somedir='dir'),
-         ['python'], {'HELLO': 'asd'}, {0}, 'dir'),
+        ("python {inputs}", dict(inputs="9"), ["python", "9"], {}, {0}, None),
+        ('python "{inputs}"', dict(inputs="9"), ["python", "9"], {}, {0}, None),
+        ("python {inputs}", dict(inputs=""), ["python", ""], {}, {0}, None),
+        (
+            'HELLO="asd" python "{inputs}"',
+            dict(inputs="9"),
+            ["python", "9"],
+            {"HELLO": "asd"},
+            {0},
+            None,
+        ),
+        (
+            'HELLO="asd" return-code=any python "{inputs}"',
+            dict(inputs="9"),
+            ["python", "9"],
+            {"HELLO": "asd"},
+            None,
+            None,
+        ),
+        (
+            'HELLO="asd" return-code=255 python "{inputs}"',
+            dict(inputs="9"),
+            ["python", "9"],
+            {"HELLO": "asd"},
+            {255},
+            None,
+        ),
+        (
+            'HELLO="asd" return-code=255 python "{inputs}"',
+            dict(inputs="9"),
+            ["python", "9"],
+            {"HELLO": "asd"},
+            {255},
+            None,
+        ),
+        (
+            'HELLO="asd" in-dir="{somedir}" python',
+            dict(somedir="dir"),
+            ["python"],
+            {"HELLO": "asd"},
+            {0},
+            "dir",
+        ),
     ]
 
     bad_items = [
-        ('python {foo}', {}),
-        ('HELLO={foo} python', {}),
-        ('return-code=none python', {}),
-        ('return-code= python', {}),
-        ('return-code=, python', {}),
-        ('return-code=1,,2 python', {}),
-        ('return-code=1 return-code=2 python', {}),
-        ('in-dir=a in-dir=b python', {}),
+        ("python {foo}", {}),
+        ("HELLO={foo} python", {}),
+        ("return-code=none python", {}),
+        ("return-code= python", {}),
+        ("return-code=, python", {}),
+        ("return-code=1,,2 python", {}),
+        ("return-code=1 return-code=2 python", {}),
+        ("in-dir=a in-dir=b python", {}),
     ]
 
     for value, variables, e_parts, e_env, e_codes, e_cwd in good_items:
@@ -349,8 +357,7 @@ def test_interpolate_command():
 
 
 def test_datetime_to_js_timestamp():
-    tss = [0, 0.5, -0.5, 12345.6789, -12345.6789,
-           1535910708.7767508]
+    tss = [0, 0.5, -0.5, 12345.6789, -12345.6789, 1535910708.7767508]
     for ts in tss:
         t = datetime.datetime.utcfromtimestamp(ts)
         ts2 = util.datetime_to_js_timestamp(t)
@@ -369,8 +376,7 @@ def test_datetime_to_js_timestamp():
 
 
 def test_datetime_to_timestamp():
-    tss = [0, 0.5, -0.5, 12345.6789, -12345.6789,
-           1535910708.7767508]
+    tss = [0, 0.5, -0.5, 12345.6789, -12345.6789, 1535910708.7767508]
     for ts in tss:
         t = datetime.datetime.utcfromtimestamp(ts)
         ts2 = util.datetime_to_timestamp(t)
@@ -385,12 +391,12 @@ def test_datetime_to_timestamp():
 
 def test_check_output_exit_code(capsys):
     with pytest.raises(util.ProcessError):
-        util.check_output([sys.executable, '-c', 'import sys; sys.exit(1)'])
+        util.check_output([sys.executable, "-c", "import sys; sys.exit(1)"])
     out, err = capsys.readouterr()
-    assert '(exit status 1)' in out
+    assert "(exit status 1)" in out
 
 
 def test_geom_mean_na():
     for x in [[1, 2, -3], [1, 2, 3], [3, 1, 3, None, None]]:
-        expected = abs(x[0] * x[1] * x[2])**(1 / 3)
+        expected = abs(x[0] * x[1] * x[2]) ** (1 / 3)
         assert abs(util.geom_mean_na(x) - expected) < 1e-10

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -28,42 +28,38 @@ def _rebuild_basic_html(basedir):
     cwd = os.getcwd()
 
     if os.path.isdir(basedir):
-        html_dir = join(basedir, 'html')
-        dvcs = tools.Git(join(basedir, 'repo'))
+        html_dir = join(basedir, "html")
+        dvcs = tools.Git(join(basedir, "repo"))
         return html_dir, dvcs
 
     os.makedirs(basedir)
     os.chdir(basedir)
     try:
-        machine_file = join(basedir, 'asv-machine.json')
+        machine_file = join(basedir, "asv-machine.json")
 
-        shutil.copyfile(join(local, 'asv-machine.json'),
-                        machine_file)
+        shutil.copyfile(join(local, "asv-machine.json"), machine_file)
 
-        values = [[x] * 2 for x in [0, 0, 0, 0, 0,
-                                    1, 1, 1, 1, 1,
-                                    3, 3, 3, 3, 3,
-                                    2, 2, 2, 2, 2]]
+        values = [[x] * 2 for x in [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2]]
         dvcs = tools.generate_test_repo(basedir, values)
-        first_tested_commit_hash = dvcs.get_hash(f'{util.git_default_branch()}~14')
+        first_tested_commit_hash = dvcs.get_hash(f"{util.git_default_branch()}~14")
 
         repo_path = dvcs.path
-        shutil.move(repo_path, join(basedir, 'repo'))
-        dvcs = tools.Git(join(basedir, 'repo'))
+        shutil.move(repo_path, join(basedir, "repo"))
+        dvcs = tools.Git(join(basedir, "repo"))
 
-        conf = config.Config.from_json({
-            'env_dir': join(basedir, 'env'),
-            'benchmark_dir': join(local, 'benchmark'),
-            'results_dir': join(basedir, 'results_workflow'),
-            'html_dir': join(basedir, 'html'),
-            'repo': join(basedir, 'repo'),
-            'dvcs': 'git',
-            'project': 'asv',
-            'matrix': {"env": {"SOME_TEST_VAR": ["1"]}},
-            'regressions_first_commits': {
-                '.*': first_tested_commit_hash
-            },
-        })
+        conf = config.Config.from_json(
+            {
+                "env_dir": join(basedir, "env"),
+                "benchmark_dir": join(local, "benchmark"),
+                "results_dir": join(basedir, "results_workflow"),
+                "html_dir": join(basedir, "html"),
+                "repo": join(basedir, "repo"),
+                "dvcs": "git",
+                "project": "asv",
+                "matrix": {"env": {"SOME_TEST_VAR": ["1"]}},
+                "regressions_first_commits": {".*": first_tested_commit_hash},
+            }
+        )
 
         if WIN:
             # Tell conda to not use hardlinks: on Windows it's not possible
@@ -72,30 +68,41 @@ def _rebuild_basic_html(basedir):
             # same cache directory may get reused).
             conf.matrix["env"]["CONDA_ALWAYS_COPY"] = ["True"]
 
-        tools.run_asv_with_conf(conf, 'run', 'ALL',
-                                '--show-stderr', '--quick',
-                                '--bench=params_examples[a-z0-9_.]*track_',
-                                _machine_file=machine_file)
+        tools.run_asv_with_conf(
+            conf,
+            "run",
+            "ALL",
+            "--show-stderr",
+            "--quick",
+            "--bench=params_examples[a-z0-9_.]*track_",
+            _machine_file=machine_file,
+        )
 
         # Swap CPU info and obtain some results
         info = util.load_json(machine_file, api_version=1)
 
         # Put in parameter values that need quoting in file names
-        info['orangutan']['cpu'] = 'Not /really/ <fast>'
-        info['orangutan']['ram'] = '?'
-        info['orangutan']['NUL'] = ''
+        info["orangutan"]["cpu"] = "Not /really/ <fast>"
+        info["orangutan"]["ram"] = "?"
+        info["orangutan"]["NUL"] = ""
 
         util.write_json(machine_file, info, api_version=1)
 
-        tools.run_asv_with_conf(conf, 'run', f'{util.git_default_branch()}~10..', '--steps=3',
-                                '--show-stderr', '--quick',
-                                '--bench=params_examples[a-z0-9_.]*track_',
-                                _machine_file=machine_file)
+        tools.run_asv_with_conf(
+            conf,
+            "run",
+            f"{util.git_default_branch()}~10..",
+            "--steps=3",
+            "--show-stderr",
+            "--quick",
+            "--bench=params_examples[a-z0-9_.]*track_",
+            _machine_file=machine_file,
+        )
 
         # Output
-        tools.run_asv_with_conf(conf, 'publish')
+        tools.run_asv_with_conf(conf, "publish")
 
-        shutil.rmtree(join(basedir, 'env'))
+        shutil.rmtree(join(basedir, "env"))
     finally:
         os.chdir(cwd)
 
@@ -111,46 +118,47 @@ def test_web_summarygrid(browser, basic_html):
     with tools.preview(html_dir) as base_url:
         get_with_retry(browser, base_url)
 
-        WebDriverWait(browser, WAIT_TIME).until(EC.title_is(
-            'airspeed velocity of an unladen asv'))
+        WebDriverWait(browser, WAIT_TIME).until(EC.title_is("airspeed velocity of an unladen asv"))
 
         # Verify benchmark names are displayed as expected
         for href, expected in (
-            ('#subdir.time_subdir.time_foo', u'time_subdir.time_foo'),
-            ('#params_examples.ParamSuite.track_value', u'ParamSuite.track_value'),
-            ('#custom.time_function', u'My Custom Function'),
-            ('#named.track_custom_pretty_name', u'this.is/the.answer'),
+            ("#subdir.time_subdir.time_foo", "time_subdir.time_foo"),
+            ("#params_examples.ParamSuite.track_value", "ParamSuite.track_value"),
+            ("#custom.time_function", "My Custom Function"),
+            ("#named.track_custom_pretty_name", "this.is/the.answer"),
         ):
-            item = browser.find_element(By.XPATH,
-                                        f"//a[@href='{href}']/div[@class='benchmark-text']")
+            item = browser.find_element(
+                By.XPATH, f"//a[@href='{href}']/div[@class='benchmark-text']"
+            )
             assert item.text == expected
 
         # Open a graph display, scroll to item and click
-        item = browser.find_element(By.LINK_TEXT, 'track_param')
+        item = browser.find_element(By.LINK_TEXT, "track_param")
 
-        y = item.location['y']
-        browser.execute_script(f'window.scrollTo(0, {y - 200})')
+        y = item.location["y"]
+        browser.execute_script(f"window.scrollTo(0, {y - 200})")
 
         item.click()
 
         # Verify there's a plot of some sort
-        browser.find_element(By.CSS_SELECTOR, 'canvas.flot-base')
+        browser.find_element(By.CSS_SELECTOR, "canvas.flot-base")
 
         # Click a parameterized test button, which should toggle the button
-        param_button = browser.find_element(By.LINK_TEXT, 'benchmark.params_examples.ClassOne')
-        assert 'active' in param_button.get_attribute('class').split()
+        param_button = browser.find_element(By.LINK_TEXT, "benchmark.params_examples.ClassOne")
+        assert "active" in param_button.get_attribute("class").split()
         param_button.click()
 
         def check(*args):
-            param_button = browser.find_element(By.LINK_TEXT, 'benchmark.params_examples.ClassOne')
-            return 'active' not in param_button.get_attribute('class').split()
+            param_button = browser.find_element(By.LINK_TEXT, "benchmark.params_examples.ClassOne")
+            return "active" not in param_button.get_attribute("class").split()
+
         WebDriverWait(browser, WAIT_TIME, ignored_exceptions=ignore_exc).until(check)
 
         # Check there's no error popup; needs an explicit wait because
         # there is no event that occurs on successful load that
         # doesn't also occur on a failed load
         time.sleep(1.0)
-        error_box = browser.find_element(By.ID, 'error-message')
+        error_box = browser.find_element(By.ID, "error-message")
         assert not error_box.is_displayed()
 
 
@@ -158,7 +166,7 @@ def test_web_summarygrid(browser, basic_html):
 def test_web_regressions(browser, basic_html):
     html_dir, dvcs = basic_html
 
-    bad_commit_hash = dvcs.get_hash(f'{util.git_default_branch()}~9')
+    bad_commit_hash = dvcs.get_hash(f"{util.git_default_branch()}~9")
 
     ignore_exc = (NoSuchElementException, StaleElementReferenceException)
 
@@ -167,116 +175,135 @@ def test_web_regressions(browser, basic_html):
     with tools.preview(html_dir) as base_url:
         get_with_retry(browser, base_url)
 
-        regressions_btn = browser.find_element(By.LINK_TEXT, 'Regressions')
+        regressions_btn = browser.find_element(By.LINK_TEXT, "Regressions")
         regressions_btn.click()
 
         # Wait for element to appear in the table
-        WebDriverWait(browser, WAIT_TIME).until(EC.text_to_be_present_in_element(
-            ('xpath', '//table[1]/tbody/tr[2]/td[1]'), 'params_examples.track_find_test'
-        ))
+        WebDriverWait(browser, WAIT_TIME).until(
+            EC.text_to_be_present_in_element(
+                ("xpath", "//table[1]/tbody/tr[2]/td[1]"), "params_examples.track_find_test"
+            )
+        )
 
         # Check that the expected links appear in the table
-        regression_1 = browser.find_element(By.LINK_TEXT, 'params_examples.track_find_test(1)')
-        browser.find_element(By.LINK_TEXT, 'params_examples.track_find_test(2)')
+        regression_1 = browser.find_element(By.LINK_TEXT, "params_examples.track_find_test(1)")
+        browser.find_element(By.LINK_TEXT, "params_examples.track_find_test(2)")
         browser.find_element(By.LINK_TEXT, bad_commit_hash[:8])
 
-        href = regression_1.get_attribute('href')
-        assert '/#params_examples.track_find_test?' in href
-        assert 'commits=' in href
+        href = regression_1.get_attribute("href")
+        assert "/#params_examples.track_find_test?" in href
+        assert "commits=" in href
 
         # Sort the tables vs. benchmark name (PhantomJS doesn't allow doing it via actionchains)
         browser.execute_script("$('thead th').eq(0).stupidsort('asc')")
-        WebDriverWait(browser, WAIT_TIME).until(EC.text_to_be_present_in_element(
-            ('xpath', '//table[1]/tbody/tr[1]/td[1]'), 'params_examples.track_find_test(1)'
-        ))
+        WebDriverWait(browser, WAIT_TIME).until(
+            EC.text_to_be_present_in_element(
+                ("xpath", "//table[1]/tbody/tr[1]/td[1]"), "params_examples.track_find_test(1)"
+            )
+        )
 
         # Check the contents of the table
-        table_rows = browser.find_elements(By.XPATH, '//table[1]/tbody/tr')
+        table_rows = browser.find_elements(By.XPATH, "//table[1]/tbody/tr")
         assert len(table_rows) == 2
-        cols1 = [td.text for td in table_rows[0].find_elements(By.XPATH, 'td')]
-        cols2 = [td.text for td in table_rows[1].find_elements(By.XPATH, 'td')]
+        cols1 = [td.text for td in table_rows[0].find_elements(By.XPATH, "td")]
+        cols2 = [td.text for td in table_rows[1].find_elements(By.XPATH, "td")]
 
-        assert cols1[0] == 'params_examples.track_find_test(1)'
-        assert cols2[0] == 'params_examples.track_find_test(2)'
+        assert cols1[0] == "params_examples.track_find_test(1)"
+        assert cols2[0] == "params_examples.track_find_test(2)"
 
-        assert re.match(r'^\d\d\d\d-\d\d-\d\d \d\d:\d\d$', cols1[1])
-        assert re.match(r'^\d\d\d\d-\d\d-\d\d \d\d:\d\d$', cols2[1])
+        assert re.match(r"^\d\d\d\d-\d\d-\d\d \d\d:\d\d$", cols1[1])
+        assert re.match(r"^\d\d\d\d-\d\d-\d\d \d\d:\d\d$", cols2[1])
 
-        assert cols1[2:] == [bad_commit_hash[:8], '2.00x', '1.00', '2.00', 'Ignore']
-        assert cols2[2:] == [bad_commit_hash[:8], '2.00x', '1.00', '2.00', 'Ignore']
+        assert cols1[2:] == [bad_commit_hash[:8], "2.00x", "1.00", "2.00", "Ignore"]
+        assert cols2[2:] == [bad_commit_hash[:8], "2.00x", "1.00", "2.00", "Ignore"]
 
         # Check that the ignore buttons work as expected
-        buttons = [button for button in browser.find_elements(By.XPATH, '//button')
-                   if button.text == 'Ignore']
+        buttons = [
+            button
+            for button in browser.find_elements(By.XPATH, "//button")
+            if button.text == "Ignore"
+        ]
         buttons[0].click()
 
         # The button should disappear, together with the link
         WebDriverWait(browser, WAIT_TIME).until_not(EC.visibility_of(buttons[0]))
         WebDriverWait(browser, WAIT_TIME).until_not(EC.visibility_of(regression_1))
 
-        table_rows = browser.find_elements(By.XPATH, '//table[1]/tbody/tr')
+        table_rows = browser.find_elements(By.XPATH, "//table[1]/tbody/tr")
         assert len(table_rows) == 1
 
         # There's a second button for showing the links, clicking
         # which makes the elements reappear
-        show_button = [button for button in browser.find_elements(By.XPATH, '//button')
-                       if button.text == 'Show ignored regressions...'][0]
+        show_button = [
+            button
+            for button in browser.find_elements(By.XPATH, "//button")
+            if button.text == "Show ignored regressions..."
+        ][0]
         show_button.click()
 
-        regression_1 = browser.find_element(By.LINK_TEXT, 'params_examples.track_find_test(1)')
+        regression_1 = browser.find_element(By.LINK_TEXT, "params_examples.track_find_test(1)")
         WebDriverWait(browser, WAIT_TIME).until(EC.visibility_of(regression_1))
 
-        table_rows = browser.find_elements(By.XPATH, '//table[2]/tbody/tr')
+        table_rows = browser.find_elements(By.XPATH, "//table[2]/tbody/tr")
         assert len(table_rows) == 1
 
         # There's a config sample element
-        pre_div = browser.find_element(By.XPATH, '//pre')
+        pre_div = browser.find_element(By.XPATH, "//pre")
         assert "params_examples\\\\.track_find_test\\\\(1\\\\)" in pre_div.text
 
         # There's an unignore button that moves the element back to the main table
-        unignore_button = [button for button in browser.find_elements(By.XPATH, '//button')
-                           if button.text == 'Unignore'][0]
+        unignore_button = [
+            button
+            for button in browser.find_elements(By.XPATH, "//button")
+            if button.text == "Unignore"
+        ][0]
         unignore_button.click()
 
         # wait until the table has two rows
-        browser.find_elements(By.XPATH, '//table[1]/tbody/tr[2]')
+        browser.find_elements(By.XPATH, "//table[1]/tbody/tr[2]")
 
-        table_rows = browser.find_elements(By.XPATH, '//table[1]/tbody/tr')
+        table_rows = browser.find_elements(By.XPATH, "//table[1]/tbody/tr")
         assert len(table_rows) == 2
 
         # Check that a plot of some sort appears on mouseover.  The
         # page needs to be scrolled first so that the mouseover popup
         # has enough space to appear.
-        regression_1 = browser.find_element(By.LINK_TEXT, 'params_examples.track_find_test(1)')
+        regression_1 = browser.find_element(By.LINK_TEXT, "params_examples.track_find_test(1)")
 
-        y = regression_1.location['y']
-        browser.execute_script(f'window.scrollTo(0, {y - 200})')
+        y = regression_1.location["y"]
+        browser.execute_script(f"window.scrollTo(0, {y - 200})")
 
         chain = ActionChains(browser)
         chain.move_to_element(regression_1)
         chain.perform()
 
-        browser.find_element(By.CSS_SELECTOR, 'div.popover-content')
-        browser.find_element(By.CSS_SELECTOR, 'canvas.flot-base')
+        browser.find_element(By.CSS_SELECTOR, "div.popover-content")
+        browser.find_element(By.CSS_SELECTOR, "canvas.flot-base")
 
         # Check group/ungroup button functionality
-        group_button, = [button for button in browser.find_elements(By.XPATH, '//button')
-                         if button.text == "Group regressions"]
+        (group_button,) = [
+            button
+            for button in browser.find_elements(By.XPATH, "//button")
+            if button.text == "Group regressions"
+        ]
         group_button.click()
 
         def check(*args):
-            columns = browser.find_element(By.XPATH, '//table/thead/tr[1]').text
-            return columns == 'Benchmark Last date Commits Factor Best Current'
+            columns = browser.find_element(By.XPATH, "//table/thead/tr[1]").text
+            return columns == "Benchmark Last date Commits Factor Best Current"
 
         WebDriverWait(browser, WAIT_TIME, ignored_exceptions=ignore_exc).until(check)
 
-        ungroup_button, = [button for button in browser.find_elements(By.XPATH, '//button')
-                           if button.text == "Ungroup regressions"]
+        (ungroup_button,) = [
+            button
+            for button in browser.find_elements(By.XPATH, "//button")
+            if button.text == "Ungroup regressions"
+        ]
         ungroup_button.click()
 
         def check(*args):
-            columns = browser.find_element(By.XPATH, '//table/thead/tr[1]').text
-            return columns == 'Benchmark Date Commit Factor Before Best after'
+            columns = browser.find_element(By.XPATH, "//table/thead/tr[1]").text
+            return columns == "Benchmark Date Commit Factor Before Best after"
 
         WebDriverWait(browser, WAIT_TIME, ignored_exceptions=ignore_exc).until(check)
 
@@ -287,65 +314,72 @@ def test_web_summarylist(browser, basic_html):
 
     html_dir, dvcs = basic_html
 
-    last_change_hash = dvcs.get_hash(f'{util.git_default_branch()}~4')
+    last_change_hash = dvcs.get_hash(f"{util.git_default_branch()}~4")
 
     browser.set_window_size(1200, 900)
 
     with tools.preview(html_dir) as base_url:
         get_with_retry(browser, base_url)
 
-        summarylist_btn = browser.find_element(By.LINK_TEXT, 'Benchmark list')
+        summarylist_btn = browser.find_element(By.LINK_TEXT, "Benchmark list")
         summarylist_btn.click()
 
         # Check text content in the table
-        base_link = browser.find_element(By.LINK_TEXT, 'params_examples.track_find_test')
-        cur_row = base_link.find_element(By.XPATH, '../..')
-        m = re.match('params_examples.track_find_test \\([12]\\) 2.00 \u221233.3% \\(-1.00\\).*' +
-                     last_change_hash[:8],
-                     cur_row.text)
+        base_link = browser.find_element(By.LINK_TEXT, "params_examples.track_find_test")
+        cur_row = base_link.find_element(By.XPATH, "../..")
+        m = re.match(
+            "params_examples.track_find_test \\([12]\\) 2.00 \u221233.3% \\(-1.00\\).*"
+            + last_change_hash[:8],
+            cur_row.text,
+        )
         assert m, cur_row.text
 
         # Check units in row
-        base_link2 = browser.find_element(By.LINK_TEXT, 'params_examples.track_bytes')
-        cur_row2 = base_link2.find_element(By.XPATH, '../..')
-        m = re.match(r'params_examples.track_bytes\s*1.000M', cur_row2.text)
+        base_link2 = browser.find_element(By.LINK_TEXT, "params_examples.track_bytes")
+        cur_row2 = base_link2.find_element(By.XPATH, "../..")
+        m = re.match(r"params_examples.track_bytes\s*1.000M", cur_row2.text)
         assert m, cur_row2.text
 
         # Check link
-        base_href, qs = urllib.parse.splitquery(base_link.get_attribute('href'))
+        base_href, qs = urllib.parse.splitquery(base_link.get_attribute("href"))
         base_url, tag = urllib.parse.splittag(base_href)
-        assert urllib.parse.parse_qs(qs) == {'ram': ['128GB'], 'cpu': ['Blazingly fast'],
-                                             'NUL': ['[none]']}
-        assert tag == 'params_examples.track_find_test'
+        assert urllib.parse.parse_qs(qs) == {
+            "ram": ["128GB"],
+            "cpu": ["Blazingly fast"],
+            "NUL": ["[none]"],
+        }
+        assert tag == "params_examples.track_find_test"
 
         # Change table sort (sorting is async, so needs waits)
         sort_th = browser.find_element(By.XPATH, '//th[text()="Recent change"]')
         sort_th.click()
         WebDriverWait(browser, WAIT_TIME).until(
-            EC.text_to_be_present_in_element(('xpath', '//tbody/tr[1]'),
-                                             'params_examples.track_find_test'))
+            EC.text_to_be_present_in_element(
+                ("xpath", "//tbody/tr[1]"), "params_examples.track_find_test"
+            )
+        )
 
         # Try to click cpu selector link in the panel
-        cpu_select = browser.find_element(By.LINK_TEXT, 'Not /really/ <fast>')
+        cpu_select = browser.find_element(By.LINK_TEXT, "Not /really/ <fast>")
         cpu_select.click()
 
         # For the other CPU, there is no recent change recorded, only
         # the latest result is available
         def check(*args):
-            links = browser.find_elements(By.LINK_TEXT, 'params_examples.track_find_test')
+            links = browser.find_elements(By.LINK_TEXT, "params_examples.track_find_test")
             visible_links = [item for item in links if item.is_displayed()]
 
-            row_texts = [link.find_element(By.XPATH, '../..').text
-                         for link in visible_links]
+            row_texts = [link.find_element(By.XPATH, "../..").text for link in visible_links]
             row_texts.sort()
 
             if len(row_texts) != 2:
                 return False
 
-            ok = (re.match(r'^params_examples\.track_find_test \(1\) 2\.00 .*\(-1\.00\).*$',
-                           row_texts[0]) and
-                  re.match(r'^params_examples\.track_find_test \(2\) 2\.00 .*\(-1\.00\).*$',
-                  row_texts[1]))
+            ok = re.match(
+                r"^params_examples\.track_find_test \(1\) 2\.00 .*\(-1\.00\).*$", row_texts[0]
+            ) and re.match(
+                r"^params_examples\.track_find_test \(2\) 2\.00 .*\(-1\.00\).*$", row_texts[1]
+            )
             return ok
 
         WebDriverWait(browser, WAIT_TIME, ignored_exceptions=ignore_exc).until(check)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -23,37 +23,54 @@ def test_run_publish(capfd, basic_conf_2):
     }
 
     # Tests a typical complete run/publish workflow
-    ret = tools.run_asv_with_conf(conf, 'run', f"{util.git_default_branch()}", '--steps=2',
-                                  '--quick', '--show-stderr', '--profile',
-                                  '-a', 'warmup_time=0',
-                                  '--durations=5',
-                                  _machine_file=machine_file)
+    ret = tools.run_asv_with_conf(
+        conf,
+        "run",
+        f"{util.git_default_branch()}",
+        "--steps=2",
+        "--quick",
+        "--show-stderr",
+        "--profile",
+        "-a",
+        "warmup_time=0",
+        "--durations=5",
+        _machine_file=machine_file,
+    )
     assert ret == 2
     text, err = capfd.readouterr()
 
-    assert len(os.listdir(join(tmpdir, 'results_workflow', 'orangutan'))) == 5
-    assert len(os.listdir(join(tmpdir, 'results_workflow'))) == 2
-    assert 'asv: benchmark timed out (timeout 0.1s)' in text
-    assert 'total duration' in text
+    assert len(os.listdir(join(tmpdir, "results_workflow", "orangutan"))) == 5
+    assert len(os.listdir(join(tmpdir, "results_workflow"))) == 2
+    assert "asv: benchmark timed out (timeout 0.1s)" in text
+    assert "total duration" in text
 
-    tools.run_asv_with_conf(conf, 'publish')
+    tools.run_asv_with_conf(conf, "publish")
 
-    assert isfile(join(tmpdir, 'html', 'index.html'))
-    assert isfile(join(tmpdir, 'html', 'index.json'))
-    assert isfile(join(tmpdir, 'html', 'asv.js'))
-    assert isfile(join(tmpdir, 'html', 'asv.css'))
+    assert isfile(join(tmpdir, "html", "index.html"))
+    assert isfile(join(tmpdir, "html", "index.json"))
+    assert isfile(join(tmpdir, "html", "asv.js"))
+    assert isfile(join(tmpdir, "html", "asv.css"))
 
     # Check parameterized test json data format
-    filename = glob.glob(join(tmpdir, 'html', 'graphs', 'arch-x86_64',
-                              'asv_dummy_test_package_1',
-                              'asv_dummy_test_package_2-' + tools.DUMMY2_VERSIONS[1],
-                              'branch-master',
-                              'cpu-Blazingly fast',
-                              'env-SOME_TEST_VAR-1',
-                              'machine-orangutan',
-                              'os-GNU_Linux', 'python-*', 'ram-128GB',
-                              'params_examples.time_skip.json'))[0]
-    with open(filename, 'r') as fp:
+    filename = glob.glob(
+        join(
+            tmpdir,
+            "html",
+            "graphs",
+            "arch-x86_64",
+            "asv_dummy_test_package_1",
+            "asv_dummy_test_package_2-" + tools.DUMMY2_VERSIONS[1],
+            "branch-master",
+            "cpu-Blazingly fast",
+            "env-SOME_TEST_VAR-1",
+            "machine-orangutan",
+            "os-GNU_Linux",
+            "python-*",
+            "ram-128GB",
+            "params_examples.time_skip.json",
+        )
+    )[0]
+    with open(filename, "r") as fp:
         data = json.load(fp)
         assert len(data) == 2
         assert isinstance(data[0][0], int)  # revision
@@ -65,30 +82,47 @@ def test_run_publish(capfd, basic_conf_2):
 
     # Check that the skip options work
     capfd.readouterr()
-    tools.run_asv_with_conf(conf, 'run', f"{util.git_default_branch()}", '--steps=2',
-                            '--quick', '--skip-existing-successful',
-                            '--bench=time_secondary.track_value',
-                            '--skip-existing-failed',
-                            _machine_file=join(tmpdir, 'asv-machine.json'))
-    tools.run_asv_with_conf(conf, 'run', f"{util.git_default_branch()}", '--steps=2',
-                            '--bench=time_secondary.track_value',
-                            '--quick', '--skip-existing-commits',
-                            _machine_file=join(tmpdir, 'asv-machine.json'))
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        f"{util.git_default_branch()}",
+        "--steps=2",
+        "--quick",
+        "--skip-existing-successful",
+        "--bench=time_secondary.track_value",
+        "--skip-existing-failed",
+        _machine_file=join(tmpdir, "asv-machine.json"),
+    )
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        f"{util.git_default_branch()}",
+        "--steps=2",
+        "--bench=time_secondary.track_value",
+        "--quick",
+        "--skip-existing-commits",
+        _machine_file=join(tmpdir, "asv-machine.json"),
+    )
     text, err = capfd.readouterr()
-    assert 'Running benchmarks.' not in text
+    assert "Running benchmarks." not in text
 
     # Check EXISTING and --environment work
     python = "{0[0]}.{0[1]}".format(sys.version_info)
     env_type = tools.get_default_environment_type(conf, python)
     env_spec = ("-E", env_type + ":" + python)
-    tools.run_asv_with_conf(conf, 'run', "EXISTING", '--quick',
-                            '--bench=time_secondary.track_value',
-                            *env_spec,
-                            _machine_file=machine_file)
+    tools.run_asv_with_conf(
+        conf,
+        "run",
+        "EXISTING",
+        "--quick",
+        "--bench=time_secondary.track_value",
+        *env_spec,
+        _machine_file=machine_file,
+    )
 
     # Remove the benchmarks.json file and check publish fails
 
     os.remove(join(tmpdir, "results_workflow", "benchmarks.json"))
 
     with pytest.raises(util.UserError):
-        tools.run_asv_with_conf(conf, 'publish')
+        tools.run_asv_with_conf(conf, "publish")


### PR DESCRIPTION
We enforce linting rules (now with `ruff` as of #1260) but without an auto-formatter the burden falls on the user to make sure the code conforms. I'd rather just defer to `black` for ensuring the code will pass the linter, it works well with `ruff` and doesn't seem to be too much uglier or even that different (subjectively).