### PR TITLE
MAINT: Update the license

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,3 +1,4 @@
+Copyright (c) 2018-2023, asv Developers.
 Copyright (c) 2011-2018, Michael Droettboom, Space Telescope Science Institute, Pauli Virtanen
 
 All rights reserved.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,7 @@ root_doc = "index"
 
 # General information about the project.
 project = "airspeed velocity"
-copyright = "2013--present, Michael Droettboom, Pauli Virtanen, asv Developers"
+copyright = "2018--present, asv Developers"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This is to make other code changes easier (e.g. splitting `asv.benchmark` etc.)

@mattip and I have discussed that this would be a more sustainable choice in the long run.