### PR TITLE
Bugfix: `mamba` used with an environment file never starts installation due to deadlock

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ API Changes
 
 Bug Fixes
 ^^^^^^^^^
+- Fixed the deadlock when mamba is used with an environment file. (#1300)
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -87,13 +87,13 @@ class Mamba(environment.Environment):
         env = dict(os.environ)
         env.update(self.build_env_vars)
         Path(f"{self._path}/conda-meta").mkdir(parents=True, exist_ok=True)
+        solver = MambaSolver(
+            self._mamba_channels, None, self.context  # or target_platform
+        )
 
         if not self._mamba_environment_file:
             # Construct payload, env file sets python version
             mamba_pkgs = [f"python={self._python}", "wheel", "pip"] + mamba_args
-            solver = MambaSolver(
-                self._mamba_channels, None, self.context  # or target_platform
-            )
 
             with _mamba_lock():
                 transaction = solver.solve(mamba_pkgs)
@@ -110,9 +110,6 @@ class Mamba(environment.Environment):
             self._run_mamba(
                 ["env", "create", "-f", env_file_name, "-p", self._path, "--force"],
                 env=env,
-            )
-            solver = MambaSolver(
-                self._mamba_channels, None, self.context  # or target_platform
             )
             with _mamba_lock():
                 transaction = solver.solve(mamba_pkgs + mamba_args)

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -107,11 +107,10 @@ class Mamba(environment.Environment):
             env_file_name = self._mamba_environment_file
             env_data = load(Path(env_file_name).open(), Loader=Loader)
             mamba_pkgs = [x for x in env_data.get("dependencies") if isinstance(x, str)]
-            with _mamba_lock():
-                self._run_mamba(
-                    ["env", "create", "-f", env_file_name, "-p", self._path, "--force"],
-                    env=env,
-                )
+            self._run_mamba(
+                ["env", "create", "-f", env_file_name, "-p", self._path, "--force"],
+                env=env,
+            )
             solver = MambaSolver(
                 self._mamba_channels, None, self.context  # or target_platform
             )


### PR DESCRIPTION
## Description of the Bug
When using mamba with an environment file, creating an environment never starts.

Here's a brief explanation of what's happening in `mamba.py`:
```python
import asv.util as util
util.new_multiprocessing_lock("mamba_lock")
def _mamba_lock():
    return util.get_multiprocessing_lock("mamba_lock")
def run_mamba():
    with _mamba_lock():
        print("Hello, world!")
with _mamba_lock():
    run_mamba()
```

## Description of the PR
This PR removes one of the locks around `_run_mamba` to avoid grabbing the lock inside the lock.