### PR TITLE
Add instructions to build the package with pyproject.toml only

### DIFF
--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -18,15 +18,24 @@
     // of the repository.
     // "repo_subdir": "",
 
-    // Customizable commands for building, installing, and
-    // uninstalling the project. See asv.conf.json documentation.
-    //
-    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
-    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // Customizable commands for building the project. 
+    // See asv.conf.json documentation.
+    // Uncomment the following lines if installing the package using pyproject.toml (PEP518)
+    // "build_command": [
+    //     "python -m pip install build",
+    //     "python -m build",
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+    // Uncomment the following lines if installing the package using setuptools and a setup.py file
     // "build_command": [
     //     "python setup.py build",
     //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     // ],
+    
+    // Customizable commands for installing and uninstalling the project. 
+    // See asv.conf.json documentation.
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -20,13 +20,13 @@
 
     // Customizable commands for building the project. 
     // See asv.conf.json documentation.
-    // Uncomment the following lines if installing the package using pyproject.toml (PEP518)
+    // To build the package using pyproject.toml (PEP518), uncomment the following lines
     // "build_command": [
     //     "python -m pip install build",
     //     "python -m build",
     //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     // ],
-    // Uncomment the following lines if installing the package using setuptools and a setup.py file
+    // To build the package using setuptools and a setup.py file, uncomment the following lines
     // "build_command": [
     //     "python setup.py build",
     //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -78,13 +78,16 @@ benchmark code.
 The uninstall commands should uninstall the project from the
 environment.
 
-If a build command is not specified in the ``asv.conf.json``, the default assumes
-the build system requirements are defined in a ``setup.py`` file. However, the 
-``asv.conf.json`` template also includes as a comment the commands to build 
-the project using a ``pyproject.toml`` file. ``pyproject.toml`` is the preferred 
-file format to define the build 
-system requirements of Python projects (`PEP518 <https://peps.python.org/pep-0518/>`_),
-and this approach will be the default from ``asv v0.6`` onwards.
+.. versionchanged:: 0.6
+
+    If a build command is not specified in the ``asv.conf.json``, the default
+    assumes the build system requirements are defined in a ``setup.py`` file.
+    However, the  ``asv.conf.json`` template also includes as a comment the
+    commands to build  the project using a ``pyproject.toml`` file.
+    ``pyproject.toml`` is the preferred  file format to define the build  system
+    requirements of Python projects (`PEP518
+    <https://peps.python.org/pep-0518/>`_), and this approach will be the
+    default from ``asv v0.6`` onwards.
 
 The build commands can optionally be used to cache build results in the
 cache directory ``{build_cache_dir}``, which is commit and

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -78,17 +78,18 @@ benchmark code.
 The uninstall commands should uninstall the project from the
 environment.
 
-.. versionchanged:: 0.6
+.. note::
 
-    If a build command is not specified in the ``asv.conf.json``, the default
-    assumes the build system requirements are defined in a ``setup.py`` file.
-    However, the  ``asv.conf.json`` template also includes as a comment the
-    commands to build  the project using a ``pyproject.toml`` file.
-    ``pyproject.toml`` is the preferred  file format to define the build  system
-    requirements of Python projects (`PEP518
-    <https://peps.python.org/pep-0518/>`_), and this approach will be the
-    default from ``asv v0.6`` onwards.
+    .. versionchanged:: 0.6
 
+        If a build command is not specified in the ``asv.conf.json``, the default
+        assumes the build system requirements are defined in a ``setup.py`` file.
+        However, the  ``asv.conf.json`` template also includes as a comment the
+        commands to build  the project using a ``pyproject.toml`` file.
+        ``pyproject.toml`` is the preferred  file format to define the build  system
+        requirements of Python projects (`PEP518
+        <https://peps.python.org/pep-0518/>`_), and this approach will be the
+        default from ``asv v0.6`` onwards.
 The build commands can optionally be used to cache build results in the
 cache directory ``{build_cache_dir}``, which is commit and
 environment-specific.  If the cache directory contains any files after

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -78,6 +78,14 @@ benchmark code.
 The uninstall commands should uninstall the project from the
 environment.
 
+If a build command is not specified in the ``asv.conf.json``, the default assumes
+the build system requirements are defined in a ``setup.py`` file. However, the 
+``asv.conf.json`` template also includes as a comment the commands to build 
+the project using a ``pyproject.toml`` file. ``pyproject.toml`` is the preferred 
+file format to define the build 
+system requirements of Python projects (`PEP518 <https://peps.python.org/pep-0518/>`_),
+and this approach will be the default from ``asv v0.6`` onwards.
+
 The build commands can optionally be used to cache build results in the
 cache directory ``{build_cache_dir}``, which is commit and
 environment-specific.  If the cache directory contains any files after


### PR DESCRIPTION
Currently the `asv.conf.json` template includes by default instructions on how to build the package using `setuptools` and a `setup.py` file

This PR adds instructions to build the package using a `pyproject.toml` file only - `pyproject.toml` is the specified file format of [PEP518](https://peps.python.org/pep-0518/) to define the build system requirements of Python projects.