### PR TITLE
ENH: Add a configurable default benchmark timeout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ New Features
 - ``asv_runner`` is now used internally, making the addition of custom benchmark types viable (#1287)
 - Benchmarks can be skipped, both wholly and in part using new decorators ``skip_benchmark_if`` and ``skip_params_if`` (#1309)
 - Benchmarks can be skipped during their execution (after setup) by raising ``SkipNotImplemented`` (#1307)
+- Added ``default_benchmark_timeout`` to the configuration object, can also be
+  passed via ``-a timeout=NUMBER`` (#1308)
 
 API Changes
 ^^^^^^^^^^^

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -34,6 +34,10 @@
     // defaults to 10 min
     //"install_timeout": 600,
 
+    // timeout in seconds all benchmarks, can be overridden per benchmark
+    // defaults to 1 min
+    //"default_benchmark_timeout": 60,
+
     // the base URL to show a commit for the project.
     "show_commit_url": "http://github.com/airspeed-velocity/asv/commit/",
 

--- a/asv/config.py
+++ b/asv/config.py
@@ -32,7 +32,8 @@ class Config:
         self.show_commit_url = "#"
         self.hash_length = 8
         self.environment_type = None
-        self.install_timeout = 600
+        self.install_timeout = 600.0
+        self.default_benchmark_timeout = 60.0
         self.dvcs = None
         self.regressions_first_commits = {}
         self.regressions_thresholds = {}

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -492,7 +492,8 @@ class Environment:
         """
         self._env_dir = conf.env_dir
         self._repo_subdir = conf.repo_subdir
-        self._install_timeout = conf.install_timeout  # GH391
+        self._install_timeout = conf.install_timeout  # gh-391
+        self._default_benchmark_timeout = conf.default_benchmark_timeout # gh-973
         self._tagged_env_vars = tagged_env_vars
         self._path = os.path.abspath(os.path.join(
             self._env_dir, self.dir_name))

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -174,6 +174,13 @@ def run_benchmarks(benchmarks, env, results=None,
             return int(benchmark.get('rounds', 1))
 
     for name, benchmark in sorted(benchmarks.items()):
+        # Set benchmark timeout from config if not set
+        # gh-13 gh-973
+        if benchmark.get('timeout') is None:
+            benchmark['timeout'] = extra_params.get(
+                'timeout',
+                env._default_benchmark_timeout
+                )
         key = benchmark.get('setup_cache_key')
         setup_cache_timeout[key] = max(benchmark.get('setup_cache_timeout',
                                                      benchmark['timeout']),

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -183,6 +183,12 @@ The ``setup_cache`` timeout can be specified by setting the
 ``.timeout`` attribute of the ``setup_cache`` function. The default
 value is the maximum of the timeouts of the benchmarks using it.
 
+.. note::
+
+   From version 0.6 onwards, the configuration option
+   ``default_benchmark_timeout`` can also be set for a project-wide
+   timeout.
+
 .. _benchmark-attributes:
 
 Benchmark attributes

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -126,11 +126,13 @@ as skipped.
    the benchmark would be marked as skipped. This behavior was deprecated from
    0.5 onwards.
 
-   From 0.6 onwards, to keep compatibility with earlier versions, it is possible
-   to raise ``asv_runner.benchmark.mark.SkipNotImplemented`` anywhere within a
-   Benchmark, though users are advised to use the skip decorators instead as
-   they are faster and do not execute the ``setup`` function. See
-   :ref:`skipping-benchmarks` for more details.
+   .. versionchanged:: 0.6
+
+      To keep compatibility with earlier versions, it is possible
+      to raise ``asv_runner.benchmark.mark.SkipNotImplemented`` anywhere within a
+      Benchmark, though users are advised to use the skip decorators instead as
+      they are faster and do not execute the ``setup`` function. See
+      :ref:`skipping-benchmarks` for more details.
 
 The ``setup`` method is run multiple times, for each benchmark and for
 each repeat.  If the ``setup`` is especially expensive, the

--- a/test/asv.conf.json
+++ b/test/asv.conf.json
@@ -4,6 +4,8 @@
 
     // timeout in seconds for installing dependencies
     "install_timeout": 3142,
+    // timeout in seconds for all benchmarks
+    "default_benchmark_timeout": 32.5,
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/test/test_conf.py
+++ b/test/test_conf.py
@@ -18,11 +18,18 @@ def test_config():
     }
     assert conf.benchmark_dir == 'benchmark'
     assert conf.branches == [None]
-    assert conf.install_timeout == 3142  # GH391
+    assert conf.install_timeout == 3142  # gh-973
+    assert conf.default_benchmark_timeout == 32.5  # gh-973
+
+
+def test_config_default_benchmark_timeout():
+    # gh-973
+    conf = config.Config()
+    assert conf.default_benchmark_timeout == 60.0
 
 
 def test_config_default_install_timeout():
-    # GH391
+    # gh-391
     conf = config.Config()
     assert conf.install_timeout == 600
 


### PR DESCRIPTION
Closes #973, and also is closer to the original design discussed in #13. A minor change to `asv-runner` is needed for this as well.

Usage:
```bash
cat asv.conf.json
...
"default_benchmark_timeout": 0.02354213,
...
# Or, override via the commandline
asv run -a timeout=0.62
```

The implementation by design does not affect benchmarks which have the `timeout` attribute set.