### PR TITLE
MAINT: Add an install group for `virtualenv`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - ``asv`` timestamps via ``datetime`` are now Python 3.12 compatible (#1331)
+- ``asv`` now provides ``asv[virtualenv]`` as an installable target
 
 0.6.0 (2023-08-20)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - ``mamba`` and ``conda`` use ``environment.yml`` if it exists
+- ``virtualenv`` now requires ``packaging`` due to ``distutils`` deprecations (#1240)
 - Wheels are now built for CPython ``3.8, 3.9, 3.10, 3.11``
 
 0.5.1 (2021-02-06)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "asv-runner>=v0.0.9",
     "json5",
     "tabulate",
+    "packaging",
     "colorama; os_name == 'nt'",
     "pyyaml; platform_python_implementation != \"PyPy\"",
     "pympler; platform_python_implementation != \"PyPy\"",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "asv-runner>=v0.0.9",
     "json5",
     "tabulate",
-    "packaging",
     "colorama; os_name == 'nt'",
     "pyyaml; platform_python_implementation != \"PyPy\"",
     "pympler; platform_python_implementation != \"PyPy\"",
@@ -64,6 +63,10 @@ doc = [
 dev = [
     "ruff",
     "isort >= 5.11.5",
+]
+virtualenv = [
+    "virtualenv",
+    "packaging",
 ]
 hg = [
     "python-hglib",


### PR DESCRIPTION
Needed since `distutils` deprecation in https://github.com/airspeed-velocity/asv/pull/1240.

Closes https://github.com/airspeed-velocity/asv/issues/1323.

Also https://github.com/sympy/sympy/pull/25562 and https://github.com/sympy/sympy/issues/25561.

**NOTE:** `asv` doesn't typically ensure any dependencies for its environment management plugins are present, and I am personally more of the opinion that this is not a bug and shouldn't be added to `asv`. However, `virtualenv` is pretty much the default for `asv` and so maybe an argument could be made for ensuring dependencies for it. In that case, it would be best to just depend on `virtualenv` as well.


**NOTE_II**: If `asv` shouldn't maintain dependencies for plugins (my preference) then this PR should be reworked to **just** have the changelog update.