### PR TITLE
CI: Enable wheel builds again

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,10 +1,7 @@
 # Build on every branch push, tag push, and pull request change:
 # From: https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml
 name: Build wheels
-on:
-  release:
-    types:
-      - published
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,7 +11,6 @@ jobs:
   build_wheels:
     name: Build wheel for ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}
     runs-on: ${{ matrix.buildplat[0] }}
-    environment: pypi
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
@@ -28,7 +24,7 @@ jobs:
           - [macos-12, macosx_x86_64]
           - [macos-12, macosx_arm64]
           - [windows-2019, win_amd64]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -65,7 +61,7 @@ jobs:
     permissions:
       id-token: write  # for trusted publishing
     # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'airspeed-velocity/asv'
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:


### PR DESCRIPTION
Should close #1337. Well, once we have [TPM setup](https://docs.pypi.org/trusted-publishers/using-a-publisher/).