### PR TITLE
CI: Use cibuildwheel for getting wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -63,8 +63,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip wheel -w ./wheelhouse/ .
-
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.15.0
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,14 @@ only_sections = true
 
 [tool.setuptools_scm]
 write_to = "asv/_version.py"
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
+musllinux-x86_64-image = "musllinux_1_1"
+
+[tool.cibuildwheel.macos]
+archs = "x86_64 arm64"
+
+[tool.cibuildwheel.windows]
+archs = ['AMD64']


### PR DESCRIPTION
Forgot to generate PyPI compatible wheels.