### PR TITLE
BUG: Remove prepended entry from sys.path

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -22,6 +22,7 @@ internal commands:
       Run a Unix socket forkserver.
 """
 
+import os
 import sys
 
 from asv_runner.discovery import _discover
@@ -49,6 +50,17 @@ commands = {
 
 
 def main():
+    # Remove asv package directory from `sys.path`. This script file resides
+    # there although it's not part of the package, so Python prepends it to
+    # `sys.path` on start which can shadow other modules. On Python 3.11+ it is
+    # possible to use `PYTHONSAFEPATH` to prevent this, but the script needs to
+    # work for older versions of Python.
+    if (
+        not getattr(sys.flags, 'safe_path', False)  # Python 3.11+ only.
+        and sys.path[0] == os.path.dirname(os.path.abspath(__file__))
+    ):
+        sys.path.pop(0)
+
     if len(sys.argv) < 2:
         _help([])
         sys.exit(1)


### PR DESCRIPTION
Python prepends the directory of the script being executed to `sys.path` and this can cause other packages to be shadowed, e.g. the builtin `statistics` module being shadowed by `asv.statistics` because the path of the `asv` package is prepended when the benchmark runner script is executed. There was a prior fix for this but it was removed as part of refactoring and splitting into `asv_runner`.

Python 3.11+ has a mechanism to avoid this via use of `-P` on the command line or setting the `PYTHONSAFEPATH` environment variable. This doesn't really help though as support for older versions of Python is required. This patch does, however, check `sys.flags.safe_path` to avoid fixing up the path if this feature is being used.

This further highlights that the original approach is not particularly robust as it removed the first item unconditionally and sometimes tried to add it back in. Instead this patch checks for and removes the path only if it matches the directory that the runner script resides in.

Other alternatives could be to consider running with the `-I` command line flag to force isolated mode (Python 3.4+), although that might cause other unexpected breakage as it implies `-E` (which ignores all `PYTHON*` environment variables), etc.

See the following links for details:

- https://docs.python.org/3/library/sys.html#sys.path
- https://docs.python.org/3/using/cmdline.html#envvar-PYTHONSAFEPATH
- https://docs.python.org/3/using/cmdline.html#cmdoption-P
- https://docs.python.org/3/using/cmdline.html#cmdoption-I

Regression in 5ab2d29d039a080c3a3f48ecac65526842faa7f1.