### PR TITLE
BUG: build/include only asv in bdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,6 @@ license-files = [
     "LICENSE.rst",
 ]
 
-[tool.setuptools.packages.find]
-namespaces = false
 [tool.setuptools.exclude-package-data]
 "*" = ["*.sh"]
 


### PR DESCRIPTION
setuptools [automatically detects the flat-layout](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#flat-layout) and excludes items accordingly. Fixes #1348 