### PR TITLE
Handle partially-skipped benchmarks

### DIFF
--- a/asv/results.py
+++ b/asv/results.py
@@ -932,7 +932,7 @@ def format_benchmark_result(results, benchmark):
         if failure_count == 0:
             info = "ok"
 
-        display_result = [(v, get_err(v, s) if s is not None else None)
+        display_result = [(v, get_err(v, s) if s else None)
                           for v, s in zip(result, stats)]
         display = _format_benchmark_result(display_result, benchmark)
         display = "\n".join(display).strip()


### PR DESCRIPTION
This is a fix for #1028 so that partially-skipped benchmarks can still have their results displayed. The fix follows comment https://github.com/airspeed-velocity/asv/issues/1028#issuecomment-1793496681. It does not include a test though.