### PR TITLE
MAINT: Do not always add dependencies section to update conda environment file

### DIFF
--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -139,10 +139,10 @@ class Conda(environment.Environment):
         try:
             env_file.write(f'name: {self.name}\nchannels:\n')
             env_file.writelines((f'   - {ch}\n' for ch in self._conda_channels))
-            env_file.write('dependencies:\n')
-
-            # categorize & write dependencies based on pip vs. conda
-            env_file.writelines((f'   - {s}\n' for s in conda_args))
+            if conda_args:
+                env_file.write('dependencies:\n')
+                # categorize & write dependencies based on pip vs. conda
+                env_file.writelines((f'   - {s}\n' for s in conda_args))
             env_file.close()
             try:
                 env_file_name = self._conda_environment_file or env_file.name


### PR DESCRIPTION
If the user specifies "pythons", but has an empty conda "matrix", this would create an invalid environment file that would cause a failure.