### PR TITLE
CI: Test on min/max supported ranges of python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.10", "3.12.0-rc.2", "pypy-3.8", "pypy-3.9"]
+        python-version: ["3.7", "3.12", "pypy-3.8", "pypy-3.9"]
         r-version: ['release']
     timeout-minutes: 30
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Testing",
 ]
 dynamic = [


### PR DESCRIPTION
This updates the test matrix to make sure tests are run on every supported Python version. Also updates the Python 3.12 tests to use the released instead of release candidate version.