### PR TITLE
Improve error message when environment not found

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -440,8 +440,11 @@ def get_environment_class_by_name(environment_type):
     for cls in util.iter_subclasses(Environment):
         if cls.tool_name == environment_type:
             return cls
+    tool_names = [cls.tool_name for cls in util.iter_subclasses(Environment)]
     raise EnvironmentUnavailable(
-        f"Unknown environment type '{environment_type}'")
+        f"Unknown environment type '{environment_type}'. "
+        f"Allowed values are {tool_names}."
+    )
 
 
 def is_existing_only(environments):

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -443,7 +443,7 @@ def get_environment_class_by_name(environment_type):
     tool_names = [cls.tool_name for cls in util.iter_subclasses(Environment)]
     raise EnvironmentUnavailable(
         f"Unknown environment type '{environment_type}'. "
-        f"Allowed values are {tool_names}."
+        f"Allowed values based on existing plugins are {tool_names}."
     )
 
 


### PR DESCRIPTION
Inspired by https://github.com/airspeed-velocity/asv/issues/1353, this improves the error message when an environment type isn't found.

Before: `Unknown environment type 'mamba'.`
After: `Unknown environment type 'mamba'. Possible values are ['existing', 'conda', 'virtualenv']`