### PR TITLE
Remove `asv dev` from docs

### DIFF
--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -303,10 +303,6 @@ for this machine::
 
 .. note::
 
-   There is a special version of ``asv run`` that is useful when
-   developing benchmarks, called ``asv dev``.  See
-   :ref:`writing-benchmarks` for more information.
-
    You can also do a validity check for the benchmark suite without
    running benchmarks, using ``asv check``.
 

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -64,6 +64,9 @@ these features together with::
 
        asv run --python=same --quick --show-stderr --dry-run
 
+.. versionchanged:: 0.6.0
+   This replaces the now removed ``asv dev`` command.
+
 You may also want to only do a basic check whether the benchmark suite
 is well-formatted, without actually running any benchmarks::
 

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -59,8 +59,8 @@ that your benchmarks may produce, pass the ``--show-stderr`` flag::
 
        asv run --show-stderr
 
-Finally, there is a special command, ``asv dev``, that uses all of
-these features and is equivalent to::
+Finally, a quick way to test out the benchmark suite before doing a full run is to use all of
+these features together with::
 
        asv run --python=same --quick --show-stderr --dry-run
 


### PR DESCRIPTION
#1200 and subsequent releases removed `asv dev` from the CLI, but the docs still had remnant mentions of it