### PR TITLE
BUG: Add `MAMBARC` support to `mamba`

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,7 +22,7 @@ jobs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout asv
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -58,7 +58,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy3.8', 'pypy3.9']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Echo Python version and build platform
         run: echo Building wheel for ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}
       - uses: actions/setup-python@v4
@@ -80,7 +80,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build sdist
         shell: bash -l {0}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -34,7 +34,7 @@ jobs:
           echo "message=$COMMIT_MSG" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   build_wheels:
-    name: Build wheel for ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}
+    name: Build wheels
     needs: get_commit_message
     if: >-
       contains(needs.get_commit_message.outputs.message, '[wheel build]') ||
@@ -59,7 +59,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Echo Python version and build platform
+        run: echo Building wheel for ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         r-version: ['release']
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -96,7 +96,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Linux CI
+name: Linux and MacOS CI
 
 on: [push, pull_request]
 
@@ -60,7 +60,7 @@ jobs:
 
   test_env:
     name: test_environments
-    runs-on: [ "ubuntu-latest", "macos-latest" ]
+    runs-on: [ ubuntu-latest, macos-latest ]
     strategy:
       fail-fast: false
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
   test_env:
     name: test_environments
-    runs-on: "ubuntu-latest"
+    runs-on: [ "ubuntu-latest", "macos-latest" ]
     strategy:
       fail-fast: false
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,10 @@ jobs:
 
   test_env:
     name: test_environments
-    runs-on: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
       fail-fast: false
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -1,0 +1,72 @@
+name: Windows CI
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["windows-latest"]
+        python-version: ["3.7"]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python version ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install and test
+        shell: pwsh
+        run: |
+          python.exe -m pip install .[test]
+          python.exe -m pip install packaging virtualenv
+          python.exe -m pytest -v -l -x --timeout=300 --durations=100 test --environment-type=virtualenv
+
+
+  test_env:
+    name: test_environments
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          init-shell: >-
+            powershell
+          environment-name: test-env
+          cache-environment: true
+          create-args: >-
+            python
+            pip
+            libmambapy
+            conda-build
+
+      - name: Install dependencies
+        run: python -m pip install ".[test,hg]" --pre
+        shell: micromamba-shell {0}
+
+      - name: Install asv
+        run: pip install .
+        shell: micromamba-shell {0}
+
+      - name: Run tests
+        run: pytest -k environment_bench -vvvvv
+        shell: micromamba-shell {0}

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.7"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/triggered.yml
+++ b/.github/workflows/triggered.yml
@@ -23,7 +23,7 @@ jobs:
         r-version: ['release']
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
         run: python -m pip install ".[test,hg]"
 
       - name: Get asv_runner to be tested
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: airspeed-velocity/asv_runner
           ref: refs/pull/${{ github.event.inputs.pr_number }}/head

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ API Changes
 Bug Fixes
 ^^^^^^^^^
 - The ``mamba`` plugin works correctly for newer versions (>=1.5) of ``libmambapy`` (#1372)
+- Fixed a bug where ``matrix`` requirements were dropped if an environment file was specified. (#1373)
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Bug Fixes
 - The ``mamba`` plugin works correctly for newer versions (>=1.5) of ``libmambapy`` (#1372)
 - The ``mamba`` plugin respects the ``MAMBARC`` environment if set, taking
   channels and channel priority from the file in the environment variable. (#1373)
+- ``conda-forge`` is no longer a default channel for ``mamba``. (#1373)
 - Fixed a bug where ``matrix`` requirements were dropped if an environment file was specified. (#1373)
 
 Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ API Changes
 Bug Fixes
 ^^^^^^^^^
 - The ``mamba`` plugin works correctly for newer versions (>=1.5) of ``libmambapy`` (#1372)
+- The ``mamba`` plugin respects the ``MAMBARC`` environment if set, taking
+  channels and channel priority from the file in the environment variable. (#1373)
 - Fixed a bug where ``matrix`` requirements were dropped if an environment file was specified. (#1373)
 
 Other Changes and Additions

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -132,7 +132,7 @@ class Mamba(environment.Environment):
         Path(f"{self._path}/conda-meta").mkdir(parents=True, exist_ok=True)
         if not self._mamba_environment_file:
             # Construct payload, env file sets python version
-            mamba_pkgs = [f"python={self._python}", "wheel", "pip"] + mamba_args
+            mamba_pkgs = [f"python={self._python}", "wheel", "pip"]
         else:
             # For named environments
             env_file_name = self._mamba_environment_file
@@ -147,6 +147,7 @@ class Mamba(environment.Environment):
                     pip_args += pip_maybe[0]["pip"]
                 except KeyError:
                     raise KeyError("Only pip is supported as a secondary key")
+        mamba_pkgs += mamba_args
         solver = MambaSolver(
             self._mamba_channels, None, self.context  # or target_platform
         )

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -84,6 +84,7 @@ class Mamba(environment.Environment):
         # Apply channel settings
         if 'channels' in condarc_data:
             self.context.channels = condarc_data['channels']
+            self._mamba_channels.extend(condarc_data['channels'])
 
         # Apply channel priority settings
         channel_priority_map = {

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -4,6 +4,7 @@ import os
 import re
 from pathlib import Path
 
+import yaml
 from yaml import load
 
 try:
@@ -54,7 +55,7 @@ class Mamba(environment.Environment):
         self._requirements = requirements
         self._mamba_channels = conf.conda_channels
         self._mamba_environment_file = None
-        if "conda-forge" not in conf.conda_channels:
+        if "conda-forge" not in conf.conda_channels and not os.getenv("MAMBARC"):
             self._mamba_channels += ["conda-forge"]
 
         if conf.conda_environment_file == "IGNORE":
@@ -74,6 +75,30 @@ class Mamba(environment.Environment):
         super(Mamba, self).__init__(conf, python, requirements, tagged_env_vars)
         self.context = libmambapy.Context()
         self.context.target_prefix = self._path
+        # Handle MAMBARC environment variable
+        mambarc_path = Path(os.getenv("MAMBARC", ""))
+        if mambarc_path.is_file():
+            with mambarc_path.open() as f:
+                condarc_data = yaml.safe_load(f)
+                self._apply_condarc_settings(condarc_data)
+
+    def _apply_condarc_settings(self, condarc_data):
+        # Apply channel settings
+        if 'channels' in condarc_data:
+            self.context.channels = condarc_data['channels']
+
+        # Apply channel priority settings
+        channel_priority_map = {
+            'strict': libmambapy.ChannelPriority.kStrict,
+            'flexible': libmambapy.ChannelPriority.kFlexible,
+            'disabled': libmambapy.ChannelPriority.kDisabled
+        }
+        if 'channel_priority' in condarc_data:
+            priority_str = condarc_data['channel_priority']
+            if priority_str in channel_priority_map:
+                self.context.channel_priority = channel_priority_map[priority_str]
+            else:
+                log.debug(f"Unknown channel priority: {priority_str}")
 
     @classmethod
     def matches(cls, python):

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -55,8 +55,6 @@ class Mamba(environment.Environment):
         self._requirements = requirements
         self._mamba_channels = conf.conda_channels
         self._mamba_environment_file = None
-        if "conda-forge" not in conf.conda_channels and not os.getenv("MAMBARC"):
-            self._mamba_channels += ["conda-forge"]
 
         if conf.conda_environment_file == "IGNORE":
             log.debug("Skipping environment file due to conda_environment_file set to IGNORE")

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -280,6 +280,14 @@ the project being benchmarked may specify in its ``setup.py`` file.
        These specifications in ``environment.yml`` or another (user-defined)
        file will be overridden by the environment matrix.
 
+    .. versionadded::0.6.2
+
+       The ``mamba`` plugin will now take channels and channel priority from the
+       ``MAMBARC`` environment variable if it is provided. e.g.
+       ``MAMBARC=$HOME/.condarc asv run``. By default user ``.rc`` files are not
+       read to enforce isolation. The ``conda-forge`` channel is used as a
+       default only if neither an environment file nor the ``MAMBARC`` variable
+       is set.
 
 The ``env`` and ``env_nobuild`` dictionaries can be used to set also
 environment variables::

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -285,9 +285,7 @@ the project being benchmarked may specify in its ``setup.py`` file.
        The ``mamba`` plugin will now take channels and channel priority from the
        ``MAMBARC`` environment variable if it is provided. e.g.
        ``MAMBARC=$HOME/.condarc asv run``. By default user ``.rc`` files are not
-       read to enforce isolation. The ``conda-forge`` channel is used as a
-       default only if neither an environment file nor the ``MAMBARC`` variable
-       is set.
+       read to enforce isolation.
 
 The ``env`` and ``env_nobuild`` dictionaries can be used to set also
 environment variables::

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -9,6 +9,7 @@ from asv import config, environment, util
 from asv.repo import get_repo
 from asv.util import shlex_quote as quote
 
+from . import tools
 from .tools import (PYTHON_VER1, PYTHON_VER2, DUMMY1_VERSION, DUMMY2_VERSIONS, WIN, HAS_PYPY,
                     HAS_CONDA, HAS_VIRTUALENV, HAS_PYTHON_VER2, generate_test_repo)
 
@@ -682,6 +683,7 @@ def test_build_isolation(tmpdir):
     env.install_project(conf, repo, commit_hash)
 
 
+@pytest.mark.skipif(tools.HAS_PYPY, reason="Flaky on pypy")
 def test_custom_commands(tmpdir):
     # check custom install/uninstall/build commands work
     tmpdir = str(tmpdir)

--- a/test/test_environment_bench.py
+++ b/test/test_environment_bench.py
@@ -23,6 +23,7 @@ ASV_CONFIG = {
     "repo": ".",
     "branches": ["main"],
     "environment_type": "virtualenv",
+    "conda_channels": ["conda-forge", "nodefaults"],
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
     "html_dir": ".asv/html",

--- a/test/test_environment_bench.py
+++ b/test/test_environment_bench.py
@@ -27,6 +27,9 @@ ASV_CONFIG = {
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
     "html_dir": ".asv/html",
+    "matrix": {
+        "asv_runner": [],  # On conda-forge, not defaults
+    },
 }
 
 BENCHMARK_CODE = """
@@ -51,49 +54,67 @@ setup(
 )
 """
 
+CONDARC_CONTENT = """
+channels:
+  - conda-forge
+  - nodefaults
+channel_priority: disabled
+auto_activate_base: false
+"""
 
-@pytest.fixture(scope="session", autouse=True)
-def setup_asv_project(tmp_path_factory):
+
+@pytest.fixture(scope="session")
+def asv_project_factory(tmp_path_factory):
     """
-    Fixture to set up an ASV project in a temporary directory
+    Factory to set up an ASV project with customizable configurations.
     """
-    tmp_path = tmp_path_factory.mktemp("asv_project")
-    original_dir = os.getcwd()
-    os.chdir(tmp_path)
 
-    os.makedirs("benchmarks", exist_ok=True)
-    with open("benchmarks/example_bench.py", "w") as f:
-        f.write(BENCHMARK_CODE)
-    with open("benchmarks/__init__.py", "w") as f:
-        f.write("")
-    with open("asv.conf.json", "w") as f:
-        json.dump(ASV_CONFIG, f, indent=4)
-    with open("setup.py", "w") as f:
-        f.write(SETUP_CODE)
+    def _create_asv_project(custom_config=None, create_condarc=False):
+        tmp_path = tmp_path_factory.mktemp("asv_project")
+        original_dir = os.getcwd()
+        os.chdir(tmp_path)
 
-    subprocess.run(["git", "init"], cwd=tmp_path, check=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True
-    )
-    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial ASV setup"], cwd=tmp_path, check=True
-    )
-    subprocess.run(["git", "branch", "-M", "main"], cwd=tmp_path, check=True)
+        os.makedirs("benchmarks", exist_ok=True)
+        benchmark_file = tmp_path / "benchmarks" / "example_bench.py"
+        benchmark_file.write_text(BENCHMARK_CODE)
+        (tmp_path / "benchmarks" / "__init__.py").write_text("")
 
-    yield tmp_path
-    os.chdir(original_dir)
+        config = ASV_CONFIG.copy()
+        if custom_config:
+            config.update(custom_config)
+        (tmp_path / "asv.conf.json").write_text(json.dumps(config, indent=4))
+        (tmp_path / "setup.py").write_text(SETUP_CODE)
+
+        if create_condarc:
+            (tmp_path / ".condarc").write_text(CONDARC_CONTENT)
+
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=tmp_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True
+        )
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial ASV setup"], cwd=tmp_path, check=True
+        )
+        subprocess.run(["git", "branch", "-M", "main"], cwd=tmp_path, check=True)
+
+        os.chdir(original_dir)
+        return tmp_path
+
+    return _create_asv_project
 
 
 @pytest.mark.parametrize("env", ENVIRONMENTS)
-def test_asv_benchmark(setup_asv_project, env):
+def test_asv_benchmark(asv_project_factory, env):
     """
     Test running ASV benchmarks in the specified environment.
     """
-    project_dir = setup_asv_project
+    project_dir = asv_project_factory(custom_config={})
     subprocess.run(["asv", "machine", "--yes"], cwd=project_dir, check=True)
     result = subprocess.run(
         ["asv", "run", "--quick", "--dry-run", "--environment", env],
@@ -104,3 +125,112 @@ def test_asv_benchmark(setup_asv_project, env):
     assert (
         result.returncode == 0
     ), f"ASV benchmark failed in {env} environment: {result.stderr}"
+
+
+@pytest.mark.parametrize(
+    "config_modifier, expected_success, expected_error",
+    [
+        pytest.param(
+            {"conda_channels": ["conda-forge", "nodefaults"]},
+            True,
+            None,
+            id="with_conda_forge",
+        ),
+        pytest.param(
+            {"conda_channels": []},
+            False,
+            "Solver could not find solution",
+            id="empty_conda_channels",
+        ),
+    ],
+)
+def test_asv_mamba(
+    asv_project_factory, config_modifier, expected_success, expected_error
+):
+    """
+    Test running ASV benchmarks with various configurations,
+    checking for specific errors when failures are expected.
+    """
+    project_dir = asv_project_factory(custom_config=config_modifier)
+    try:
+        subprocess.run(
+            ["asv", "run", "--quick", "--dry-run", "--environment", "mamba"],
+            cwd=project_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        if not expected_success:
+            pytest.fail("Expected failure, but succeeded")
+    except subprocess.CalledProcessError as exc:
+        if expected_success:
+            pytest.fail(f"ASV benchmark unexpectedly failed: {exc.stderr}")
+        elif expected_error and expected_error not in exc.stderr:
+            pytest.fail(
+                f"Expected error '{expected_error}' not found in stderr: {exc.stderr}"
+            )
+
+
+@pytest.mark.parametrize(
+    "create_condarc, set_mambarc, expected_success, expected_error",
+    [
+        pytest.param(
+            True,
+            True,
+            True,
+            None,
+            id="with_proper_condarc_and_mambarc",
+        ),
+        pytest.param(
+            True,
+            False,
+            False,
+            "Solver could not find solution",
+            id="with_condarc_but_no_mambarc",
+        ),
+        pytest.param(
+            False,
+            False,
+            False,
+            "Solver could not find solution",
+            id="without_condarc_and_mambarc",
+        ),
+    ],
+)
+@pytest.mark.skipif(not tools.HAS_MAMBA,
+                    reason="needs mamba")
+def test_asv_mamba_condarc(
+    asv_project_factory,
+    create_condarc,
+    set_mambarc,
+    expected_success,
+    expected_error,
+    monkeypatch,
+):
+    project_dir = asv_project_factory(
+        custom_config={"conda_channels": [], "environment_type": "mamba"},
+        create_condarc=create_condarc,
+    )
+
+    env = os.environ.copy()
+    if set_mambarc:
+        env["MAMBARC"] = str(project_dir.resolve() / ".condarc")
+
+    try:
+        subprocess.run(
+            ["asv", "run", "--quick", "--dry-run"],
+            cwd=project_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if not expected_success:
+            pytest.fail("Expected failure, but succeeded")
+    except subprocess.CalledProcessError as exc:
+        if expected_success:
+            pytest.fail(f"ASV benchmark unexpectedly failed: {exc.stderr}")
+        elif expected_error and expected_error not in exc.stderr:
+            pytest.fail(
+                f"Expected error '{expected_error}' not found in stderr: {exc.stderr}"
+            )

--- a/test/test_environment_bench.py
+++ b/test/test_environment_bench.py
@@ -144,6 +144,8 @@ def test_asv_benchmark(asv_project_factory, env):
         ),
     ],
 )
+@pytest.mark.skipif(not tools.HAS_MAMBA,
+                    reason="needs mamba")
 def test_asv_mamba(
     asv_project_factory, config_modifier, expected_success, expected_error
 ):

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -206,6 +206,7 @@ def test_regression_double(generate_result_dir):
     assert regressions == expected
 
 
+@pytest.mark.skipif(tools.HAS_PYPY, reason="Flaky on pypy")
 def test_regression_first_commits(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 10 * [10])
     # Ignore before 5th commit

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -442,6 +442,7 @@ def test_regression_atom_feed_update(dvcs_type, tmpdir):
         b_content = b.find('{http://www.w3.org/2005/Atom}content')
         assert a_content.text != b_content.text
 
+@pytest.mark.skipif(tools.HAS_PYPY, reason="Flaky on pypy")
 def test_branch_name_is_also_filename(tmpdir):
     # gh-1209
     tmpdir = str(tmpdir)

--- a/test/tools.py
+++ b/test/tools.py
@@ -94,14 +94,16 @@ except ImportError:
 
 
 def _check_mamba():
-    conda = _find_conda()
     try:
-        importlib.import_module('libmambapy')
-        subprocess.check_call([conda, 'build', '--version'],
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
+        conda = _find_conda()
+        importlib.import_module("libmambapy")
+        subprocess.check_call(
+            [conda, "build", "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         return True
-    except (ImportError, subprocess.CalledProcessError, FileNotFoundError):
+    except (ImportError, OSError, subprocess.CalledProcessError, FileNotFoundError):
         return False
 
 


### PR DESCRIPTION
~**Cannot be reviewed until #1372 is in**~

Closes #1358. Also explicitly removes `conda-forge` as a default for `mamba`. Users are free to either:
- Specify it in their `.condarc` and use `export MAMBARC=$HOME/.condarc`
or (better)
- Explicitly provide an `environment.yml` or set the corresponding variable in `asv.conf.json`

The documentation has also been updated to reflect the same.