### PR TITLE
MAINT: Unconditionally depend on virtualenv

### DIFF
--- a/changelog.d/1379.misc.rst
+++ b/changelog.d/1379.misc.rst
@@ -1,0 +1,1 @@
+``asv`` now depends on ``virtualenv``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "asv-runner>=v0.1.0",
     "json5",
     "tabulate",
+    "virtualenv",
     "colorama; platform_system == 'Windows'",
     "pyyaml; platform_python_implementation != \"PyPy\"",
     "pympler; platform_python_implementation != \"PyPy\"",


### PR DESCRIPTION
Closes #1340, and ensures that `pip install asv` doesn't require additional packages to start benchmarking.