### PR TITLE
ENH,BUG: Update pip parser for git urls with branches / tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,18 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
+        r-version: ['release']
       fail-fast: false
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Set up R version ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r-version }}
 
       - uses: mamba-org/setup-micromamba@v1
         with:

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -154,7 +154,7 @@ class Conda(environment.Environment):
                     self._run_conda(['env', 'create', '-f', env_file_name,
                                  '-p', self._path, "--yes"],
                                 env=env)
-                else:  # Backward compatbility
+                else:  # Backward compatibility
                     self._run_conda(['env', 'create', '-f', env_file_name,
                                     '-p', self._path, '--force'],
                                     env=env)

--- a/asv/util.py
+++ b/asv/util.py
@@ -1328,6 +1328,7 @@ class ParsedPipDeclaration:
         # Match git URLs
         git_url_pattern = (
             r'(git\+https:\/\/[a-zA-Z0-9-_\/.]+)' # match the git URL
+            r'(?:@([a-zA-Z0-9-_\/.]+))?' # optional branch or tag
             r'(?:#egg=([a-zA-Z0-9-_]+))?' # optional egg fragment
         )
         git_url_match = re.search(git_url_pattern, declaration)
@@ -1335,8 +1336,11 @@ class ParsedPipDeclaration:
         # If there's a git URL match, remove it from the declaration
         if git_url_match:
             self.path = git_url_match.group(1)
-            if git_url_match.group(2):
-                self.pkgname = git_url_match.group(2)
+            branch_or_tag = git_url_match.group(2)
+            if branch_or_tag:
+                self.path += f"@{branch_or_tag}"
+            if git_url_match.group(3):
+                self.pkgname = git_url_match.group(3)
             declaration = declaration.replace(git_url_match.group(0), '', 1)
 
         # Match local paths

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -479,11 +479,25 @@ def mock_pip_caller(args):
         'pkgname': None, 'specification': None,
         'flags': [], 'is_editable': False, 'path': 'git+https://github.com/user/repo.git'
     }),
+
+    # Git installations with a branch specified
+    ("git+https://github.com/user/repo.git@branch", {
+        'pkgname': None, 'specification': None,
+        'flags': [], 'is_editable': False, 'path': 'git+https://github.com/user/repo.git@branch'
+    }),
+
     # Editable git installations with #egg= suffix
-    ("-e git+https://github.com/user/repo.git#egg=repo", {
-        'pkgname': 'repo', 'specification': None,
+    ("-e git+https://github.com/user/repo.git#egg=pkgname", {
+        'pkgname': 'pkgname', 'specification': None,
         'flags': ['-e'], 'is_editable': True, 'path': 'git+https://github.com/user/repo.git'
     }),
+
+    # Git installations with a branch and egg specified
+    ("git+https://github.com/user/pythonrepo.git@branch#egg=repo", {
+        'pkgname': 'repo', 'specification': None,
+        'flags': [], 'is_editable': False, 'path': 'git+https://github.com/user/pythonrepo.git@branch'
+    }),
+
     # Flags with values
     ("--install-option=\"--prefix=/my/path\" numpy", {
         'pkgname': 'numpy', 'specification': None,
@@ -512,6 +526,10 @@ def pip_caller(args):
         # Test with a git URL
         ("git+https://github.com/numpy/numpy.git#egg=numpy",
          ["install", "-v", "--upgrade", "git+https://github.com/numpy/numpy.git"]),
+
+        # Test with a git URL and branch
+        ("git+https://github.com/numpy/numpy.git@branch",
+         ["install", "-v", "--upgrade", "git+https://github.com/numpy/numpy.git@branch"]),
 
         # Test with a local path
         ("./localpackage/", ["install", "-v", "--upgrade", "./localpackage/"]),

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -495,7 +495,8 @@ def mock_pip_caller(args):
     # Git installations with a branch and egg specified
     ("git+https://github.com/user/pythonrepo.git@branch#egg=repo", {
         'pkgname': 'repo', 'specification': None,
-        'flags': [], 'is_editable': False, 'path': 'git+https://github.com/user/pythonrepo.git@branch'
+        'flags': [], 'is_editable': False,
+        'path': 'git+https://github.com/user/pythonrepo.git@branch'
     }),
 
     # Flags with values


### PR DESCRIPTION
Closes #1395 by expanding the regexs to cover the missing cases.