### PR TITLE
Allow `asv.conf.jsonc` file by default

### DIFF
--- a/asv/config.py
+++ b/asv/config.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
 import sys
 from pathlib import Path
 
@@ -22,7 +21,7 @@ def _get_config_path():
     num_matches = 0
     for e in extensions:
         p = path.with_suffix(e)
-        if p.exists:
+        if p.exists():
             num_matches += 1
             path = p
 
@@ -37,7 +36,7 @@ def _get_config_path():
         )
     else:
         # exactly one valid config file found
-        return path
+        return str(path)
 
 
 class Config:

--- a/asv/config.py
+++ b/asv/config.py
@@ -32,7 +32,7 @@ def _get_config_path():
     elif num_matches > 1:
         raise util.UserError(
             f"Multiple `asv.conf` files found for valid extensions: {extensions}. "
-            f"Please specifiy which file to use with `--config=FILEPATH`."
+            f"Please specify which file to use with `--config=FILEPATH`."
         )
     else:
         # exactly one valid config file found


### PR DESCRIPTION
In SciPy, we have lots of comments in [our `asv.conf.json` file](https://github.com/scipy/scipy/blob/main/benchmarks/asv.conf.json). But comments are not allowed in JSON files (hence developers on GitHub or VSCode see lots of red highlighting).

This PR allows the config file to be named `asv.conf.jsonc`(a JSON with comments file), without having to pass the name to `--config`.