### PR TITLE
BUG: fix extraction of conda version

### DIFF
--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -5,6 +5,8 @@ import tempfile
 import contextlib
 from pathlib import Path
 
+from packaging.version import Version
+
 from .. import environment, util
 from ..console import log
 
@@ -153,7 +155,7 @@ class Conda(environment.Environment):
                 )[0]
                 log.info(f"conda version: {conda_version}")
                 # https://conda.io/projects/conda/en/latest/release-notes.html#id8
-                if conda_version >= "24.3.0":
+                if Version(conda_version) >= Version("24.3.0"):
                     self._run_conda(['env', 'create', '-f', env_file_name,
                                  '-p', self._path, "--yes"],
                                 env=env)

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -147,7 +147,10 @@ class Conda(environment.Environment):
             try:
                 env_file_name = self._conda_environment_file or env_file.name
 
-                conda_version = self._run_conda(['--version'], env=env)
+                conda_version = re.search(
+                    r'\d+(\.\d+)+',
+                    self._run_conda(['--version'], env=env)
+                )[0]
                 log.info(f"conda version: {conda_version}")
                 # https://conda.io/projects/conda/en/latest/release-notes.html#id8
                 if conda_version >= "24.3.0":

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -73,6 +73,7 @@ The rest of the contributors are listed in alphabetical order.
 - Rok Mihevc
 - Sayed Adel
 - serge-sans-paille
+- Sofía Miñano
 - Sourcery AI
 - Thomas Pfaff
 - Thomas Robitaille

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,9 @@ plugs = [
 [build-system]
 requires = [
     "wheel",
-    "setuptools>=64",
+    # pin setuptools:
+    # https://github.com/airspeed-velocity/asv/pull/1426#issuecomment-2290658198
+    "setuptools>=64,<72.2.0",
     "setuptools_scm>=6",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
When creating a conda environment, the conda version is checked to determine the syntax of the command.

However, the version is currently extracted incorrectly. The command `conda --version` returns `conda xx.xx.xx` rather than the version string `xx.xx.xx` as the code assumes. 

As a result, for conda version `23.3.1`, we have `conda_version = "conda 23.3.1"` and `conda_version >= "24.3.0"` is evaluated as `True`, when it should be `False`.

This PR:
- adds a regexp to extract the conda version from the output of the `conda --version` command, and
- uses `packaging.version.Version` for a safer comparison of version strings.

It also pins setuptools following the recommendation given in PR #1426 to ensure CI passes.

**Question**: 
Should we test that environments are created correctly for different conda versions? 