### PR TITLE
BUG: Fix multiple Python version usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+0.6.5 (2024-08-12)
+------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- Multiple Python versions are handled correctly (#1444)
+- JSONC fixes (#1426)
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- New documentation design
+
+
 0.6.4 (2024-08-12)
 ------------------
 

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -131,9 +131,14 @@ class Conda(environment.Environment):
         env = dict(os.environ)
         env.update(self.build_env_vars)
 
+        # Changed in v0.6.5, gh-1294
+        # previously, the user provided environment was assumed to handle the python version
+        conda_args = [
+            f"python={self._python}" if arg.startswith("python") else arg for arg in conda_args
+        ]
+
         if not self._conda_environment_file:
-            # The user-provided env file is assumed to set the python version
-            conda_args = [f'python={self._python}', 'wheel', 'pip'] + conda_args
+            conda_args = ['wheel', 'pip'] + conda_args
 
         # Create a temporary environment.yml file
         # and use that to generate the env for benchmarking.

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -133,7 +133,7 @@ class Conda(environment.Environment):
 
         # Changed in v0.6.5, gh-1294
         # previously, the user provided environment was assumed to handle the python version
-        conda_args = [util.replace_python_version(arg, self._python) for pkg in conda_args]
+        conda_args = [util.replace_python_version(arg, self._python) for arg in conda_args]
 
         if not self._conda_environment_file:
             conda_args = ['wheel', 'pip'] + conda_args

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -133,9 +133,7 @@ class Conda(environment.Environment):
 
         # Changed in v0.6.5, gh-1294
         # previously, the user provided environment was assumed to handle the python version
-        conda_args = [
-            f"python={self._python}" if arg.startswith("python") else arg for arg in conda_args
-        ]
+        conda_args = [util.replace_python_version(arg, self._python) for pkg in conda_args]
 
         if not self._conda_environment_file:
             conda_args = ['wheel', 'pip'] + conda_args

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -138,8 +138,8 @@ class Mamba(environment.Environment):
         env.update(self.build_env_vars)
         Path(f"{self._path}/conda-meta").mkdir(parents=True, exist_ok=True)
         if not self._mamba_environment_file:
-            # Construct payload, env file sets python version
-            mamba_pkgs = [f"python={self._python}", "wheel", "pip"]
+            # Construct payload
+            mamba_pkgs = ["wheel", "pip"]
         else:
             # For named environments
             env_file_name = self._mamba_environment_file
@@ -155,6 +155,11 @@ class Mamba(environment.Environment):
                 except KeyError:
                     raise KeyError("Only pip is supported as a secondary key")
         mamba_pkgs += mamba_args
+        # Changed in v0.6.5, gh-1294
+        # previously, the user provided environment was assumed to handle the python version
+        mamba_pkgs = [
+            f"python={self._python}" if a.startswith("python") else a for a in mamba_pkgs
+        ]
         self.context.prefix_params.target_prefix = self._path
         solver = MambaSolver(
             self._mamba_channels, None, self.context  # or target_platform

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -155,6 +155,7 @@ class Mamba(environment.Environment):
                 except KeyError:
                     raise KeyError("Only pip is supported as a secondary key")
         mamba_pkgs += mamba_args
+        self.context.prefix_params.target_prefix = self._path
         solver = MambaSolver(
             self._mamba_channels, None, self.context  # or target_platform
         )

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -80,7 +80,7 @@ class Mamba(environment.Environment):
 
         super(Mamba, self).__init__(conf, python, requirements, tagged_env_vars)
         self.context = libmambapy.Context()
-        self.context.target_prefix = self._path
+        self.context.pkgs_dirs = [f"{self._env_dir}/pkgs"]
         # Handle MAMBARC environment variable
         mambarc_path = Path(os.getenv("MAMBARC", ""))
         if mambarc_path.is_file():

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -158,7 +158,7 @@ class Mamba(environment.Environment):
         # Changed in v0.6.5, gh-1294
         # previously, the user provided environment was assumed to handle the python version
         mamba_pkgs = [
-            f"python={self._python}" if a.startswith("python") else a for a in mamba_pkgs
+            util.replace_python_version(arg, self._python) for pkg in mamba_pkgs
         ]
         self.context.prefix_params.target_prefix = self._path
         solver = MambaSolver(

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -158,7 +158,7 @@ class Mamba(environment.Environment):
         # Changed in v0.6.5, gh-1294
         # previously, the user provided environment was assumed to handle the python version
         mamba_pkgs = [
-            util.replace_python_version(arg, self._python) for pkg in mamba_pkgs
+            util.replace_python_version(pkg, self._python) for pkg in mamba_pkgs
         ]
         self.context.prefix_params.target_prefix = self._path
         solver = MambaSolver(

--- a/asv/util.py
+++ b/asv/util.py
@@ -1431,3 +1431,10 @@ def get_matching_environment(environments, result=None):
         ),
         None,
     )
+
+def replace_python_version(arg, new_version):
+    match = re.match(r'^python(\W|$)', arg)
+    if match and not match.group(1).isalnum():
+        return f"python={new_version}"
+    else:
+        return arg

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -551,3 +551,14 @@ def test_construct_pip_call(declaration, expected_result):
     parsed_declaration = util.ParsedPipDeclaration(declaration)
     result = util.construct_pip_call(pip_caller, parsed_declaration)
     assert result() == expected_result
+
+
+@pytest.mark.parametrize("arg, new_version, expected", [
+    ("python", "3.10", "python=3.10"),
+    ("python==2.7", "3.10", "python=3.10"),
+    ("python>=3.8", "3.10", "python=3.10"),
+    ("python==3.7", "3.10", "python=3.10"),
+    ("python_package", "3.10", "python_package"),
+])
+def test_replace_python_version(arg, new_version, expected):
+    assert util.replace_python_version(arg, new_version) == expected


### PR DESCRIPTION
Closes #1294. Basically ensures that the `asv.config` defined `python` takes precedence over the one written into an `environment.yml` file. This may cause resolution issues if there are a lot of pinned packages in the file, but that's basically user error.

Also fixes a subtle bug within the `mamba` plugin which caused incorrect environments to be created for multiple python versions.