### PR TITLE
ENH: Add `py-rattler`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: browser-actions/setup-chrome@latest
 
       - name: Set up R version ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@v2.11.0
+        uses: r-lib/actions/setup-r@v2.11.1
         with:
           r-version: ${{ matrix.r-version }}
 
@@ -72,7 +72,6 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        r-version: ['release']
       fail-fast: false
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
       fail-fast: false
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/triggered.yml
+++ b/.github/workflows/triggered.yml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.12", "pypy-3.10"]
-        r-version: ['release']
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -43,11 +42,6 @@ jobs:
 
       - name: Setup a browser for more tests
         uses: browser-actions/setup-chrome@latest
-
-      - name: Set up R version ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@v2.11.1
-        with:
-          r-version: ${{ matrix.r-version }}
 
       - name: Install dependencies
         run: python -m pip install ".[test,hg]"

--- a/.github/workflows/triggered.yml
+++ b/.github/workflows/triggered.yml
@@ -45,7 +45,7 @@ jobs:
         uses: browser-actions/setup-chrome@latest
 
       - name: Set up R version ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@v2.11.0
+        uses: r-lib/actions/setup-r@v2.11.1
         with:
           r-version: ${{ matrix.r-version }}
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,18 +1,3 @@
-0.6.5 (2024-08-12)
-------------------
-
-Bug Fixes
-^^^^^^^^^
-
-- Multiple Python versions are handled correctly (#1444)
-- JSONC fixes (#1426)
-
-Other Changes and Additions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- New documentation design
-
-
 0.6.4 (2024-08-12)
 ------------------
 

--- a/asv/plugin_manager.py
+++ b/asv/plugin_manager.py
@@ -30,7 +30,7 @@ class PluginManager:
                 self.init_plugin(mod)
                 self._plugins.append(mod)
             except ModuleNotFoundError as err:
-                if any(keyword in name for keyword in [".mamba", ".virtualenv", ".conda"]):
+                if any(keyword in name for keyword in [".mamba", ".virtualenv", ".conda", ".rattler"]):
                     continue  # Fine to not have these
                 else:
                     log.error(f"Couldn't load {name} because\n{err}")

--- a/asv/plugin_manager.py
+++ b/asv/plugin_manager.py
@@ -7,6 +7,7 @@ import importlib
 from . import commands, plugins
 from .console import log
 
+ENV_PLUGINS = [".mamba", ".virtualenv", ".conda", ".rattler"]
 
 class PluginManager:
     """
@@ -30,7 +31,7 @@ class PluginManager:
                 self.init_plugin(mod)
                 self._plugins.append(mod)
             except ModuleNotFoundError as err:
-                if any(keyword in name for keyword in [".mamba", ".virtualenv", ".conda", ".rattler"]):
+                if any(keyword in name for keyword in ENV_PLUGINS):
                     continue  # Fine to not have these
                 else:
                     log.error(f"Couldn't load {name} because\n{err}")

--- a/asv/plugins/rattler.py
+++ b/asv/plugins/rattler.py
@@ -1,4 +1,3 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 import asyncio
 from pathlib import Path

--- a/asv/plugins/rattler.py
+++ b/asv/plugins/rattler.py
@@ -1,0 +1,135 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
+import re
+from pathlib import Path
+import asyncio
+
+from .. import environment, util
+from ..console import log
+
+from rattler import solve, install, VirtualPackage
+
+
+class Rattler(environment.Environment):
+    """
+    Manage an environment using py-rattler.
+
+    Dependencies are installed using py-rattler. The benchmarked
+    project is installed using the build command specified.
+    """
+
+    tool_name = "rattler"
+
+    def __init__(self, conf, python, requirements, tagged_env_vars):
+        """
+        Parameters
+        ----------
+        conf : Config instance
+
+        python : str
+            Version of Python.  Must be of the form "MAJOR.MINOR".
+
+        requirements : dict
+            Dictionary mapping a PyPI package name to a version
+            identifier string.
+        """
+        self._python = python
+        self._requirements = requirements
+        self._channels = conf.conda_channels
+        self._environment_file = None
+
+        if conf.conda_environment_file == "IGNORE":
+            log.debug(
+                "Skipping environment file due to conda_environment_file set to IGNORE"
+            )
+            self._environment_file = None
+        elif not conf.conda_environment_file:
+            if (Path("environment.yml")).exists():
+                log.debug("Using environment.yml")
+                self._environment_file = "environment.yml"
+        else:
+            if (Path(conf.conda_environment_file)).exists():
+                log.debug(f"Using {conf.conda_environment_file}")
+                self._environment_file = conf.conda_environment_file
+            else:
+                log.debug(
+                    f"Environment file {conf.conda_environment_file} not found, ignoring"
+                )
+
+        super(Rattler, self).__init__(conf, python, requirements, tagged_env_vars)
+        # Rattler configuration things
+        self._pkg_cache = f"{self._env_dir}/pkgs"
+
+        # TODO(haozeke): Do we need to handle mambarc or something? Have a way to provide channel priority, see mamba
+
+    def _setup(self):
+        asyncio.run(self._async_setup())
+
+    async def _async_setup(self):
+        log.info(f"Creating environment for {self.name}")
+
+        _args, pip_args = self._get_requirements()
+        _pkgs = ["python", "wheel", "pip"]  # baseline, overwritten by env file
+        env = dict(os.environ)
+        env.update(self.build_env_vars)
+        if self._environment_file:
+            # For named environments
+            env_file_name = self._environment_file
+            env_data = load(Path(env_file_name).open(), Loader=Loader)
+            _pkgs = [x for x in env_data.get("dependencies", []) if isinstance(x, str)]
+            self._channels += [
+                x for x in env_data.get("channels", []) if isinstance(x, str)
+            ]
+            self._channels = list(dict.fromkeys(self._channels).keys())
+            # Handle possible pip keys
+            pip_maybe = [
+                x for x in env_data.get("dependencies", []) if isinstance(x, dict)
+            ]
+            if len(pip_maybe) == 1:
+                try:
+                    pip_args += pip_maybe[0]["pip"]
+                except KeyError:
+                    raise KeyError("Only pip is supported as a secondary key")
+        _pkgs += _args
+        _pkgs = [util.replace_python_version(pkg, self._python) for pkg in _pkgs]
+        solved_records = await solve(
+            # Channels to use for solving
+            channels=self._channels,
+            # The specs to solve for
+            specs=_pkgs,
+            # Virtual packages define the specifications of the environment
+            virtual_packages=VirtualPackage.detect(),
+        )
+        await install(records=solved_records, target_prefix=self._path)
+        if pip_args:
+            for declaration in pip_args:
+                parsed_declaration = util.ParsedPipDeclaration(declaration)
+                pip_call = util.construct_pip_call(self._run_pip, parsed_declaration)
+                pip_call()
+
+    def _get_requirements(self):
+        _args = []
+        pip_args = []
+
+        for key, val in {**self._requirements, **self._base_requirements}.items():
+            if key.startswith("pip+"):
+                pip_args.append(f"{key[4:]} {val}")
+            else:
+                if val:
+                    _args.append(f"{key}={val}")
+                else:
+                    _args.append(key)
+
+        return _args, pip_args
+
+    def run_executable(self, executable, args, **kwargs):
+        return super(Rattler, self).run_executable(executable, args, **kwargs)
+
+    def run(self, args, **kwargs):
+        log.debug(f"Running '{' '.join(args)}' in {self.name}")
+        return self.run_executable("python", args, **kwargs)
+
+    def _run_pip(self, args, **kwargs):
+        # Run pip via python -m pip, so that it works on Windows when
+        # upgrading pip itself, and avoids shebang length limit on Linux
+        return self.run_executable("python", ["-mpip"] + list(args), **kwargs)

--- a/asv/plugins/rattler.py
+++ b/asv/plugins/rattler.py
@@ -1,13 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
-import re
-from pathlib import Path
 import asyncio
+from pathlib import Path
+
+from yaml import load
+
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+from rattler import solve, install, VirtualPackage
 
 from .. import environment, util
 from ..console import log
-
-from rattler import solve, install, VirtualPackage
 
 
 class Rattler(environment.Environment):
@@ -60,7 +66,7 @@ class Rattler(environment.Environment):
         # Rattler configuration things
         self._pkg_cache = f"{self._env_dir}/pkgs"
 
-        # TODO(haozeke): Do we need to handle mambarc or something? Have a way to provide channel priority, see mamba
+        # TODO(haozeke): Provide channel priority, see mamba
 
     def _setup(self):
         asyncio.run(self._async_setup())

--- a/changelog.d/+cdf9af28.misc.rst
+++ b/changelog.d/+cdf9af28.misc.rst
@@ -1,0 +1,1 @@
+New documentation design

--- a/changelog.d/1426.bugfix.rst
+++ b/changelog.d/1426.bugfix.rst
@@ -1,0 +1,1 @@
+JSONC fixes

--- a/changelog.d/1444.bugfix.rst
+++ b/changelog.d/1444.bugfix.rst
@@ -1,0 +1,1 @@
+Multiple python versions are now handled correctly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,12 +80,14 @@ hg = [
 ]
 plugs = [
     "asv-bench-memray",
+]
+envs = [
     "py-rattler",
 ]
 testR = [
     "rpy2; platform_system != 'Windows' and platform_python_implementation != 'PyPy'",
 ]
-all = ["asv[doc,dev,hg,plugs]"]
+all = ["asv[doc,dev,hg,envs]"]
 [build-system]
 requires = [
     "wheel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ hg = [
 ]
 plugs = [
     "asv-bench-memray",
+    "py-rattler",
 ]
 testR = [
     "rpy2; platform_system != 'Windows' and platform_python_implementation != 'PyPy'",

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -11,6 +11,7 @@ import pytest
 
 from asv import config, util
 
+from .tools import HAS_VIRTUALENV, HAS_PYPY, WIN
 from . import tools
 
 dummy_values = (
@@ -71,7 +72,10 @@ def basic_conf(tmpdir, dummy_packages):
     return generate_basic_conf(tmpdir)
 
 
-@pytest.mark.skipif(tools.HAS_PYPY or (os.name == 'nt'), reason="Flaky on pypy and windows")
+@pytest.mark.skipif(
+    HAS_PYPY or (not HAS_VIRTUALENV) or WIN,
+    reason="Flaky on pypy and windows, needs virtualenv",
+)
 def test_run_publish(capfd, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
     tmpdir = util.long_path(tmpdir)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -11,7 +11,7 @@ import pytest
 
 from asv import config, util
 
-from .tools import HAS_VIRTUALENV, HAS_PYPY, WIN
+from .tools import HAS_PYPY, WIN
 from . import tools
 
 dummy_values = (
@@ -73,8 +73,8 @@ def basic_conf(tmpdir, dummy_packages):
 
 
 @pytest.mark.skipif(
-    HAS_PYPY or (not HAS_VIRTUALENV) or WIN,
-    reason="Flaky on pypy and windows, needs virtualenv",
+    HAS_PYPY or WIN or sys.version_info >= (3, 12),
+    reason="Flaky on pypy and windows, doesn't work on Python >= 3.12",
 )
 def test_run_publish(capfd, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf

--- a/test/tools.py
+++ b/test/tools.py
@@ -80,6 +80,13 @@ except ImportError:
 
 
 try:
+    import rattler  # noqa F401 checking if installed
+    HAS_RATTLER = True
+except ImportError:
+    HAS_RATTLER = False
+
+
+try:
     util.which(f'python{PYTHON_VER2}')
     HAS_PYTHON_VER2 = True
 except (RuntimeError, OSError):


### PR DESCRIPTION
As it says on the tin. Some notes:
- This is much faster than both `libmambapy` and `conda`
- It is more featureful than `virtualenv` (supports installing python versions)
- Has a well documented API
- Is supported by `Python >= 3.8`


Regarding the version bump; `asv` itself is no longer installed into the project, only `asv-runner`, which is used to actually drive the benchmarks, and that is still pure Python `3.7` as I recall, so it should be fine.
