### PR TITLE
TST: Fix testsuite rattler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install dependencies (with --pre)
         if: matrix.python-version == '3.12.0-rc.2'
-        run: python -m pip install ".[test,hg,testR]" --pre
+        run: python -m pip install ".[test,hg,testR,envs]" --pre
 
       - name: Install asv
         run: pip install .
@@ -92,7 +92,7 @@ jobs:
             conda-build
 
       - name: Install dependencies
-        run: python -m pip install ".[test,hg]" --pre
+        run: python -m pip install ".[test,hg,envs]" --pre
         shell: micromamba-shell {0}
 
       - name: Install asv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install dependencies (standard)
         if: matrix.python-version != '3.12.0-rc.2'
-        run: python -m pip install ".[test,hg,testR]"
+        run: python -m pip install ".[test,hg,testR,envs]"
 
       - name: Install dependencies (with --pre)
         if: matrix.python-version == '3.12.0-rc.2'

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Install and test
         shell: pwsh
         run: |
-          python.exe -m pip install .[test]
-          python.exe -m pip install packaging virtualenv
-          python.exe -m pytest -v -l -x --timeout=300 --durations=100 test --environment-type=virtualenv
+          python.exe -m pip install .[test,envs]
+          python.exe -m pip install packaging
+          python.exe -m pytest -v -l -x --timeout=300 --durations=100 test --environment-type=rattler
 
 
   test_env:
@@ -59,7 +59,7 @@ jobs:
             conda-build
 
       - name: Install dependencies
-        run: python -m pip install ".[test,hg]" --pre
+        run: python -m pip install ".[test,hg,envs]" --pre
         shell: pwsh
 
       - name: Install asv

--- a/.github/workflows/triggered.yml
+++ b/.github/workflows/triggered.yml
@@ -44,7 +44,7 @@ jobs:
         uses: browser-actions/setup-chrome@latest
 
       - name: Install dependencies
-        run: python -m pip install ".[test,hg]"
+        run: python -m pip install ".[test,hg,envs]"
 
       - name: Get asv_runner to be tested
         uses: actions/checkout@v4

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -11,7 +11,7 @@ from asv_runner.console import color_print
 from . import Command, common_args
 from ..benchmarks import Benchmarks
 from ..console import log
-from ..environment import get_environments, is_existing_only
+from ..environment import get_environments, is_existing_only, ExistingEnvironment
 from ..machine import Machine
 from ..profiling import ProfilerGui
 from ..repo import get_repo, NoSuchNameError
@@ -172,6 +172,7 @@ class Profile(Command):
                     env
                     for env in environments
                     if util.env_py_is_sys_version(env.python)
+                    or isinstance(env, ExistingEnvironment)
                 ][0]
 
             benchmarks = Benchmarks.discover(conf, repo, environments,

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -4,7 +4,6 @@ import contextlib
 import io
 import os
 import pstats
-import sys
 import tempfile
 
 from asv_runner.console import color_print
@@ -172,8 +171,7 @@ class Profile(Command):
                 env = [
                     env
                     for env in environments
-                    if util.extract_cpython_version(env.python)
-                    == "{0}.{1}".format(*sys.version_info[:2])
+                    if util.env_py_is_sys_version(env.python)
                 ][0]
 
             benchmarks = Benchmarks.discover(conf, repo, environments,

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -168,13 +168,13 @@ class Profile(Command):
                             "using an existing environment.")
 
             if env is None:
-                # Fallback
-                env = environments[0]
-
-            if env.python != "{0}.{1}".format(*sys.version_info[:2]):
-                raise util.UserError(
-                    "Profiles must be run in the same version of Python as the "
-                    "asv main process")
+                # Fallback, first valid python environment
+                env = [
+                    env
+                    for env in environments
+                    if util.extract_cpython_version(env.python)
+                    == "{0}.{1}".format(*sys.version_info[:2])
+                ][0]
 
             benchmarks = Benchmarks.discover(conf, repo, environments,
                                              [commit_hash],

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -501,6 +501,7 @@ class Environment:
 
         """
         self._env_dir = conf.env_dir
+        self._python = python
         self._repo_subdir = conf.repo_subdir
         self._install_timeout = conf.install_timeout  # gh-391
         self._default_benchmark_timeout = conf.default_benchmark_timeout # gh-973

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -432,7 +432,7 @@ def get_environment_class(conf, python):
         classes.insert(0, cls)
 
     for cls in classes:
-        if cls.matches_python_fallback and cls.matches(python):
+        if cls.matches_python_fallback or cls.matches(python):
             return cls
     raise EnvironmentUnavailable(
         f"No way to create environment for python='{python}'")

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -423,7 +423,7 @@ def get_environment_class(conf, python):
     if python == 'same':
         return ExistingEnvironment
 
-    classes = util.iter_subclasses(Environment)
+    classes = list(util.iter_subclasses(Environment))
 
     if conf.environment_type:
         cls = get_environment_class_by_name(conf.environment_type)

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -423,13 +423,14 @@ def get_environment_class(conf, python):
     if python == 'same':
         return ExistingEnvironment
 
-    # Try the subclasses in reverse order so custom plugins come first
-    classes = list(util.iter_subclasses(Environment))[::-1]
+    classes = util.iter_subclasses(Environment)
 
     if conf.environment_type:
         cls = get_environment_class_by_name(conf.environment_type)
         classes.remove(cls)
         classes.insert(0, cls)
+    else:
+        raise RuntimeError("Environment type must be specified")
 
     for cls in classes:
         if cls.matches_python_fallback or cls.matches(python):

--- a/asv/plugin_manager.py
+++ b/asv/plugin_manager.py
@@ -7,7 +7,7 @@ import importlib
 from . import commands, plugins
 from .console import log
 
-ENV_PLUGINS = [".mamba", ".virtualenv", ".conda", ".rattler"]
+ENV_PLUGINS = [".mamba", "._mamba_helpers", ".virtualenv", ".conda", ".rattler"]
 
 class PluginManager:
     """

--- a/asv/plugin_manager.py
+++ b/asv/plugin_manager.py
@@ -1,13 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import sys
+import re
 import pkgutil
 import importlib
 
 from . import commands, plugins
 from .console import log
 
-ENV_PLUGINS = [".mamba", "._mamba_helpers", ".virtualenv", ".conda", ".rattler"]
+ENV_PLUGIN_REGEXES = [
+    r"\.mamba$",
+    r"\._mamba_helpers$",
+    r"\.virtualenv$",
+    r"\.conda$",
+    r"\.rattler$",
+]
+
 
 class PluginManager:
     """
@@ -25,20 +33,24 @@ class PluginManager:
 
     def load_plugins(self, package):
         prefix = package.__name__ + "."
-        for module_finder, name, ispkg in pkgutil.iter_modules(package.__path__, prefix):
+        for module_finder, name, ispkg in pkgutil.iter_modules(
+            package.__path__, prefix
+        ):
             try:
                 mod = importlib.import_module(name)
                 self.init_plugin(mod)
                 self._plugins.append(mod)
             except ModuleNotFoundError as err:
-                if any(keyword in name for keyword in ENV_PLUGINS):
+                if any(re.search(regex, name) for regex in ENV_PLUGIN_REGEXES):
                     continue  # Fine to not have these
                 else:
                     log.error(f"Couldn't load {name} because\n{err}")
 
     def _load_plugin_by_name(self, name):
         prefix = plugins.__name__ + "."
-        for module_finder, module_name, ispkg in pkgutil.iter_modules(plugins.__path__, prefix):
+        for module_finder, module_name, ispkg in pkgutil.iter_modules(
+            plugins.__path__, prefix
+        ):
             if name in module_name:
                 mod = importlib.import_module(module_name)
                 return mod

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -133,7 +133,7 @@ class Conda(environment.Environment):
 
         # Changed in v0.6.5, gh-1294
         # previously, the user provided environment was assumed to handle the python version
-        conda_args = [util.replace_python_version(arg, self._python) for arg in conda_args]
+        conda_args = [util.replace_cpython_version(arg, self._python) for arg in conda_args]
 
         if not self._conda_environment_file:
             conda_args = ['wheel', 'pip'] + conda_args

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -158,7 +158,7 @@ class Mamba(environment.Environment):
         # Changed in v0.6.5, gh-1294
         # previously, the user provided environment was assumed to handle the python version
         mamba_pkgs = [
-            util.replace_python_version(pkg, self._python) for pkg in mamba_pkgs
+            util.replace_cpython_version(pkg, self._python) for pkg in mamba_pkgs
         ]
         self.context.prefix_params.target_prefix = self._path
         solver = MambaSolver(

--- a/asv/plugins/rattler.py
+++ b/asv/plugins/rattler.py
@@ -96,7 +96,7 @@ class Rattler(environment.Environment):
                 except KeyError:
                     raise KeyError("Only pip is supported as a secondary key")
         _pkgs += _args
-        _pkgs = [util.replace_python_version(pkg, self._python) for pkg in _pkgs]
+        _pkgs = [util.replace_cpython_version(pkg, self._python) for pkg in _pkgs]
         solved_records = await solve(
             # Channels to use for solving
             channels=self._channels,

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -49,7 +49,7 @@
     // "dvcs": "git",
 
     // The tool to use to create environments.  May be "conda",
-    // "virtualenv", "mamba" (above 3.8)
+    // "virtualenv", "mamba" or "rattler" (above 3.8)
     // or other value depending on the plugins in use.
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment

--- a/asv/util.py
+++ b/asv/util.py
@@ -1442,7 +1442,7 @@ def replace_cpython_version(arg, new_version):
 
 
 def extract_cpython_version(env_python):
-    version_regex = r"python(\d+\.\d+)"
+    version_regex = r"(\d+\.\d+)$"
     match = re.search(version_regex, env_python)
     if match:
         return match.group(1)

--- a/asv/util.py
+++ b/asv/util.py
@@ -1434,7 +1434,7 @@ def get_matching_environment(environments, result=None):
     )
 
 
-def replace_python_version(arg, new_version):
+def replace_cpython_version(arg, new_version):
     match = re.match(r"^python(\W|$)", arg)
     if match and not match.group(1).isalnum():
         return f"python={new_version}"

--- a/asv/util.py
+++ b/asv/util.py
@@ -1427,8 +1427,7 @@ def get_matching_environment(environments, result=None):
             env
             for env in environments
             if (result is None or result.env_name == env.name)
-            and extract_python_version(env.python)
-            == "{0}.{1}".format(*sys.version_info[:2])
+            and env_py_is_sys_version(env.python)
         ),
         None,
     )
@@ -1449,3 +1448,9 @@ def extract_cpython_version(env_python):
         return match.group(1)
     else:
         return None
+
+
+def env_py_is_sys_version(env_python):
+    return extract_cpython_version(env_python) == "{0}.{1}".format(
+        *sys.version_info[:2]
+    )

--- a/asv/util.py
+++ b/asv/util.py
@@ -1427,14 +1427,25 @@ def get_matching_environment(environments, result=None):
             env
             for env in environments
             if (result is None or result.env_name == env.name)
-            and env.python == "{0}.{1}".format(*sys.version_info[:2])
+            and extract_python_version(env.python)
+            == "{0}.{1}".format(*sys.version_info[:2])
         ),
         None,
     )
 
+
 def replace_python_version(arg, new_version):
-    match = re.match(r'^python(\W|$)', arg)
+    match = re.match(r"^python(\W|$)", arg)
     if match and not match.group(1).isalnum():
         return f"python={new_version}"
     else:
         return arg
+
+
+def extract_cpython_version(env_python):
+    version_regex = r"python(\d+\.\d+)"
+    match = re.search(version_regex, env_python)
+    if match:
+        return match.group(1)
+    else:
+        return None

--- a/changelog.d/1446.bugfix.rst
+++ b/changelog.d/1446.bugfix.rst
@@ -1,0 +1,1 @@
+Environment types can be specified for pytest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,7 +46,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runflaky", action="store_true", default=False, help="run flaky tests"
     )
-    parser.addoption("--environment-type", action="store", default="rattler",
+    parser.addoption("--environment-type", action="store", default="virtualenv",
                      choices=("conda", "virtualenv", "mamba", "rattler"),
                      help="environment_type to use in tests by default")
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -47,7 +47,7 @@ def pytest_addoption(parser):
         "--runflaky", action="store_true", default=False, help="run flaky tests"
     )
     parser.addoption("--environment-type", action="store", default=None,
-                     choices=("conda", "virtualenv", "mamba"),
+                     choices=("conda", "virtualenv", "mamba", "rattler"),
                      help="environment_type to use in tests by default")
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -75,6 +75,7 @@ def generate_basic_conf(tmpdir,
     # values not in test_dev.py copy
     repo_path = tools.generate_test_repo(tmpdir, values,
                                          subdir=repo_subdir).path
+    global env_type
 
     conf_dict = {
         'env_dir': 'env',
@@ -82,20 +83,21 @@ def generate_basic_conf(tmpdir,
         'results_dir': 'results_workflow',
         'html_dir': 'html',
         'repo': relpath(repo_path),
+        'environment_type': env_type,
         'project': 'asv',
         'conda_channels': ["conda-forge"],
         'dvcs': 'git',
         'matrix': {
-            "asv-dummy-test-package-1": [None],
-            "asv-dummy-test-package-2": tools.DUMMY2_VERSIONS,
+            "pip+asv-dummy-test-package-1": [None],
+            "pip+asv-dummy-test-package-2": tools.DUMMY2_VERSIONS,
         },
     }
     if not dummy_packages:
         conf_dict['matrix'] = {}
     elif conf_version == 2:
         conf_dict['matrix'] = {
-            "asv_dummy_test_package_1": [""],
-            "asv_dummy_test_package_2": tools.DUMMY2_VERSIONS,
+            "pip+asv_dummy_test_package_1": [""],
+            "pip+asv_dummy_test_package_2": tools.DUMMY2_VERSIONS,
         }
     if repo_subdir:
         conf_dict['repo_subdir'] = repo_subdir
@@ -112,6 +114,8 @@ def pytest_sessionstart(session):
     _monkeypatch_conda_lock(session.config)
 
     # Unregister unwanted environment types
+    # XXX: Ugly hack to get the variable into generate_basic_conf
+    global env_type
     env_type = session.config.getoption('environment_type')
     if env_type is not None:
         import asv.environment

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -83,6 +83,7 @@ def generate_basic_conf(tmpdir,
         'html_dir': 'html',
         'repo': relpath(repo_path),
         'project': 'asv',
+        'conda_channels': ["conda-forge"],
         'dvcs': 'git',
         'matrix': {
             "asv-dummy-test-package-1": [None],
@@ -343,7 +344,7 @@ def basic_html(request):
 
 
 @pytest.fixture
-def benchmarks_fixture(tmpdir):
+def benchmarks_fixture(tmpdir, request: pytest.FixtureRequest):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
@@ -353,6 +354,8 @@ def benchmarks_fixture(tmpdir):
     d.update(ASV_CONF_JSON)
     d['env_dir'] = "env"
     d['benchmark_dir'] = 'benchmark'
+    d['environment_type'] = request.config.getoption('environment_type')
+    d['conda_channels'] = ["conda-forge"]
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     d['branches'] = ["master"]
     conf = config.Config.from_json(d)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -442,3 +442,15 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "flaky" in item.keywords:
             item.add_marker(skip_flaky)
+
+
+@pytest.fixture
+def skip_virtualenv(request: pytest.FixtureRequest):
+    if request.config.getoption('environment_type') == 'virtualenv':
+        pytest.skip('Cannot run this test with virtualenv')
+
+
+@pytest.fixture
+def skip_no_conda(request: pytest.FixtureRequest):
+    if request.config.getoption('environment_type') != 'conda':
+        pytest.skip('Needs to be run with conda')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,7 +46,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runflaky", action="store_true", default=False, help="run flaky tests"
     )
-    parser.addoption("--environment-type", action="store", default=None,
+    parser.addoption("--environment-type", action="store", default="rattler",
                      choices=("conda", "virtualenv", "mamba", "rattler"),
                      help="environment_type to use in tests by default")
 

--- a/test/example_plugin.py
+++ b/test/example_plugin.py
@@ -4,4 +4,22 @@ print("Imported custom environment")
 
 
 class MyEnvironment(Environment):
-    pass
+    tool_name = "myenv"
+    def __init__(self, conf, python, requirements, tagged_env_vars):
+        """
+        Parameters
+        ----------
+        conf : Config instance
+
+        python : str
+            Version of Python.  Must be of the form "MAJOR.MINOR".
+
+        requirements : dict
+            Dictionary mapping a PyPI package name to a version
+            identifier string.
+        """
+        self._python = python
+        self._requirements = requirements
+        self._channels = conf.conda_channels
+        self._environment_file = None
+        super(MyEnvironment, self).__init__(conf, python, requirements, tagged_env_vars)

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -96,7 +96,7 @@ def test_discover_benchmarks(benchmarks_fixture):
     assert b['timeraw_examples.TimerawSuite.timeraw_setup']['number'] == 1
 
 
-def test_invalid_benchmark_tree(tmpdir):
+def test_invalid_benchmark_tree(tmpdir, request: pytest.FixtureRequest):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
@@ -104,6 +104,8 @@ def test_invalid_benchmark_tree(tmpdir):
     d.update(ASV_CONF_JSON)
     d['benchmark_dir'] = INVALID_BENCHMARK_DIR
     d['env_dir'] = "env"
+    d['environment_type'] = request.config.getoption('environment_type')
+    d['conda_channels'] = ["conda-forge"]
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -115,7 +115,7 @@ def test_invalid_benchmark_tree(tmpdir):
         benchmarks.Benchmarks.discover(conf, repo, envs, [commit_hash])
 
 
-def test_find_benchmarks_cwd_imports(tmpdir):
+def test_find_benchmarks_cwd_imports(tmpdir, request: pytest.FixtureRequest):
     # Test that files in the directory above the benchmark suite are
     # not importable
 
@@ -144,6 +144,8 @@ def track_this():
     d = {}
     d.update(ASV_CONF_JSON)
     d['env_dir'] = "env"
+    d['environment_type'] = request.config.getoption('environment_type')
+    d['conda_channels'] = ["conda-forge"]
     d['benchmark_dir'] = 'benchmark'
     d['repo'] = tools.generate_test_repo(tmpdir, [[0, 1]]).path
     conf = config.Config.from_json(d)
@@ -157,7 +159,7 @@ def track_this():
     assert len(b) == 1
 
 
-def test_import_failure_retry(tmpdir):
+def test_import_failure_retry(tmpdir, request: pytest.FixtureRequest):
     # Test that a different commit is tried on import failure
 
     tmpdir = str(tmpdir)
@@ -183,6 +185,8 @@ def test_import_failure_retry(tmpdir):
     d.update(ASV_CONF_JSON)
     d['env_dir'] = "env"
     d['benchmark_dir'] = 'benchmark'
+    d['environment_type'] = request.config.getoption('environment_type')
+    d['conda_channels'] = ["conda-forge"]
     d['repo'] = dvcs.path
     conf = config.Config.from_json(d)
 
@@ -195,7 +199,7 @@ def test_import_failure_retry(tmpdir):
     assert b['time_foo']['number'] == 1
 
 
-def test_conf_inside_benchmarks_dir(tmpdir):
+def test_conf_inside_benchmarks_dir(tmpdir, request: pytest.FixtureRequest):
     # Test that the configuration file can be inside the benchmark suite
 
     tmpdir = str(tmpdir)
@@ -212,6 +216,8 @@ def test_conf_inside_benchmarks_dir(tmpdir):
     d = {}
     d.update(ASV_CONF_JSON)
     d['env_dir'] = "env"
+    d['environment_type'] = request.config.getoption('environment_type')
+    d['conda_channels'] = ["conda-forge"]
     d['benchmark_dir'] = '.'
     d['repo'] = tools.generate_test_repo(tmpdir, [[0, 1]]).path
     conf = config.Config.from_json(d)
@@ -228,7 +234,7 @@ def test_conf_inside_benchmarks_dir(tmpdir):
     assert set(b.keys()) == {'track_this', 'bench.track_this'}
 
 
-def test_code_extraction(tmpdir):
+def test_code_extraction(tmpdir, request: pytest.FixtureRequest):
     tmpdir = str(tmpdir)
     os.chdir(tmpdir)
 
@@ -238,6 +244,8 @@ def test_code_extraction(tmpdir):
     d.update(ASV_CONF_JSON)
     d['env_dir'] = "env"
     d['benchmark_dir'] = 'benchmark'
+    d['environment_type'] = request.config.getoption('environment_type')
+    d['conda_channels'] = ["conda-forge"]
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -21,6 +21,7 @@ CAN_BUILD_PYTHON = (HAS_CONDA or HAS_MAMBA or HAS_RATTLER)
     reason="Requires two usable Python versions",
 )
 def test_matrix_environments(tmpdir, dummy_packages,
+                             skip_virtualenv: pytest.FixtureRequest,
                              request: pytest.FixtureRequest):
     conf = config.Config()
 
@@ -55,7 +56,9 @@ def test_matrix_environments(tmpdir, dummy_packages,
 
 @pytest.mark.skipif((not CAN_BUILD_PYTHON),
                     reason="Requires a plugin to build python")
-def test_large_environment_matrix(tmpdir, request: pytest.FixtureRequest):
+def test_large_environment_matrix(tmpdir,
+                             skip_virtualenv: pytest.FixtureRequest,
+                             request: pytest.FixtureRequest):
     # As seen in issue #169, conda can't handle using really long
     # directory names in its environment.  This creates an environment
     # with many dependencies in order to ensure it still works.
@@ -86,7 +89,8 @@ def test_large_environment_matrix(tmpdir, request: pytest.FixtureRequest):
 @pytest.mark.skipif((not CAN_BUILD_PYTHON),
                     reason="Requires a plugin to build python")
 def test_presence_checks(tmpdir, monkeypatch,
-                         request: pytest.FixtureRequest):
+                             skip_virtualenv: pytest.FixtureRequest,
+                             request: pytest.FixtureRequest):
     conf = config.Config()
     conf.environment_type = request.config.getoption('environment_type')
     conf.conda_channels = ["conda-forge"]
@@ -204,7 +208,9 @@ def test_matrix_expand_include():
 
 @pytest.mark.skipif(not (HAS_PYTHON_VER2 or CAN_BUILD_PYTHON),
                     reason="Requires two usable Python versions")
-def test_matrix_expand_include_detect_env_type(request: pytest.FixtureRequest):
+def test_matrix_expand_include_detect_env_type(
+        skip_virtualenv: pytest.FixtureRequest,
+        request: pytest.FixtureRequest):
     conf = config.Config()
     conf.environment_type = request.config.getoption('environment_type')
     conf.conda_channels = ["conda-forge"]
@@ -332,7 +338,7 @@ def test_iter_env_matrix_combinations():
 
 
 @pytest.mark.skipif((not HAS_CONDA), reason="Requires conda and conda-build")
-def test_conda_pip_install(tmpdir, dummy_packages):
+def test_conda_pip_install(tmpdir, dummy_packages, skip_no_conda: pytest.FixtureRequest):
     # test that we can install with pip into a conda environment.
     conf = config.Config()
 
@@ -356,7 +362,7 @@ def test_conda_pip_install(tmpdir, dummy_packages):
 
 
 @pytest.mark.skipif((not HAS_CONDA), reason="Requires conda and conda-build")
-def test_conda_environment_file(tmpdir, dummy_packages):
+def test_conda_environment_file(tmpdir, dummy_packages, skip_no_conda: pytest.FixtureRequest):
     env_file_name = str(tmpdir.join("environment.yml"))
     with open(env_file_name, "w") as temp_environment_file:
         temp_environment_file.write(
@@ -410,7 +416,7 @@ def test_conda_run_executable(tmpdir):
 
 @pytest.mark.skipif(not (HAS_PYTHON_VER2 or HAS_CONDA),
                     reason="Requires two usable Python versions")
-def test_environment_select(request: pytest.FixtureRequest):
+def test_environment_select(request: pytest.FixtureRequest, skip_no_conda: pytest.FixtureRequest):
     conf = config.Config()
     conf.environment_type = "conda"
     conf.pythons = ["2.7", "3.5"]
@@ -485,7 +491,8 @@ def test_environment_select(request: pytest.FixtureRequest):
 
 @pytest.mark.skipif(not (HAS_PYTHON_VER2 or HAS_CONDA),
                     reason="Requires two usable Python versions")
-def test_environment_select_autodetect():
+def test_environment_select_autodetect(skip_no_conda: pytest.FixtureRequest):
+    skip_no_conda
     conf = config.Config()
     conf.environment_type = "conda"
     conf.pythons = [PYTHON_VER1]
@@ -513,7 +520,7 @@ def test_environment_select_autodetect():
     assert len(environments) == 1
 
 @pytest.mark.skipif((not HAS_CONDA), reason="Requires conda")
-def test_matrix_empty():
+def test_matrix_empty(skip_no_conda: pytest.FixtureRequest):
     conf = config.Config()
     conf.environment_type = ""
     conf.pythons = [PYTHON_VER1]
@@ -526,7 +533,7 @@ def test_matrix_empty():
 
 
 @pytest.mark.skipif((not HAS_CONDA), reason="Requires conda")
-def test_matrix_existing():
+def test_matrix_existing(skip_no_conda: pytest.FixtureRequest):
     conf = config.Config()
     conf.environment_type = "existing"
     conf.pythons = ["same"]
@@ -553,7 +560,8 @@ def test_matrix_existing():
 ])
 def test_conda_channel_addition(tmpdir,
                                 channel_list,
-                                expected_channel):
+                                expected_channel,
+                                skip_no_conda: pytest.FixtureRequest):
     # test that we can add conda channels to environments
     # and that we respect the specified priority order
     # of channels
@@ -619,7 +627,7 @@ def test_pypy_virtualenv(tmpdir, request: pytest.FixtureRequest):
 
 
 @pytest.mark.skipif((not HAS_CONDA), reason="Requires conda")
-def test_environment_name_sanitization():
+def test_environment_name_sanitization(skip_no_conda: pytest.FixtureRequest):
     conf = config.Config()
     conf.environment_type = "conda"
     conf.pythons = ["3.5"]
@@ -641,7 +649,9 @@ def test_environment_name_sanitization():
     #              marks=pytest.mark.skipif(not (HAS_PYTHON_VER2 and HAS_VIRTUALENV),
     #                                       reason="needs virtualenv and python 3.8"))
 ])
-def test_environment_environ_path(environment_type, tmpdir, monkeypatch):
+def test_environment_environ_path(
+    environment_type, tmpdir, monkeypatch, skip_no_conda: pytest.FixtureRequest
+):
     # Check that virtualenv binary dirs are in the PATH
     conf = config.Config()
     conf.env_dir = str(tmpdir.join("env"))
@@ -673,7 +683,9 @@ def test_environment_environ_path(environment_type, tmpdir, monkeypatch):
 
 @pytest.mark.skipif(not (HAS_PYTHON_VER2 or HAS_CONDA),
                     reason="Requires two usable Python versions")
-def test_build_isolation(tmpdir, request: pytest.FixtureRequest):
+def test_build_isolation(
+        tmpdir, request: pytest.FixtureRequest, skip_virtualenv: pytest.FixtureRequest
+):
     # build should not fail with build_cache on projects that have pyproject.toml
     tmpdir = str(tmpdir)
 
@@ -708,7 +720,9 @@ def test_build_isolation(tmpdir, request: pytest.FixtureRequest):
 
 
 @pytest.mark.skipif(tools.HAS_PYPY, reason="Flaky on pypy")
-def test_custom_commands(tmpdir, request: pytest.FixtureRequest):
+def test_custom_commands(
+        tmpdir, request: pytest.FixtureRequest, skip_virtualenv: pytest.FixtureRequest
+):
     # check custom install/uninstall/build commands work
     tmpdir = str(tmpdir)
 
@@ -799,7 +813,9 @@ def test_custom_commands(tmpdir, request: pytest.FixtureRequest):
         env.install_project(conf, repo, commit_hash)
 
 
-def test_installed_commit_hash(tmpdir, request: pytest.FixtureRequest):
+def test_installed_commit_hash(
+        tmpdir, request: pytest.FixtureRequest, skip_virtualenv: pytest.FixtureRequest
+):
     tmpdir = str(tmpdir)
 
     dvcs = generate_test_repo(tmpdir, [0], dvcs_type='git')
@@ -848,7 +864,9 @@ def test_installed_commit_hash(tmpdir, request: pytest.FixtureRequest):
     assert env._global_env_vars.get('ASV_COMMIT') is None
 
 
-def test_install_success(tmpdir, request: pytest.FixtureRequest):
+def test_install_success(
+        tmpdir, request: pytest.FixtureRequest, skip_virtualenv: pytest.FixtureRequest
+):
     # Check that install_project really installs the package. (gh-805)
     # This may fail if pip in install_command e.g. gets confused by an .egg-info
     # directory in its cwd to think the package is already installed.
@@ -875,7 +893,9 @@ def test_install_success(tmpdir, request: pytest.FixtureRequest):
     env.run(['-c', 'import asv_test_repo as t, sys; sys.exit(0 if t.dummy_value == 0 else 1)'])
 
 
-def test_install_env_matrix_values(tmpdir, request: pytest.FixtureRequest):
+def test_install_env_matrix_values(
+        tmpdir, request: pytest.FixtureRequest, skip_virtualenv: pytest.FixtureRequest
+):
     tmpdir = str(tmpdir)
 
     dvcs = generate_test_repo(tmpdir, [0], dvcs_type='git')
@@ -905,7 +925,7 @@ def test_install_env_matrix_values(tmpdir, request: pytest.FixtureRequest):
              'sys.exit(0 if "SOME_ASV_TEST_NON_BUILD_VALUE" not in t.env else 1)'])
 
 
-def test_environment_env_matrix():
+def test_environment_env_matrix(request: pytest.FixtureRequest):
     # (build_vars, non_build_vars, environ_count, build_count)
     configs = [
         ({}, {}, 1, 1),
@@ -920,6 +940,8 @@ def test_environment_env_matrix():
 
     for build_vars, non_build_vars, environ_count, build_count in configs:
         conf = config.Config()
+        conf.environment_type = request.config.getoption('environment_type')
+        conf.conda_channels = ["conda-forge"]
 
         conf.matrix = {
             "env": build_vars,

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -10,9 +10,9 @@ from asv.repo import get_repo
 from asv.util import shlex_quote as quote
 
 from . import tools
-from .tools import (PYTHON_VER1, PYTHON_VER2, DUMMY1_VERSION, DUMMY2_VERSIONS,
-                    WIN, HAS_PYPY, HAS_CONDA, HAS_VIRTUALENV, HAS_RATTLER,
-                    HAS_MAMBA, HAS_PYTHON_VER2, generate_test_repo)
+from .tools import (PYTHON_VER1, PYTHON_VER2, DUMMY1_VERSION, DUMMY2_VERSIONS, WIN, HAS_PYPY,
+                    HAS_CONDA, HAS_VIRTUALENV, HAS_RATTLER, HAS_MAMBA, HAS_PYTHON_VER2,
+                    generate_test_repo)
 
 CAN_BUILD_PYTHON = (HAS_CONDA or HAS_MAMBA or HAS_RATTLER)
 
@@ -456,7 +456,9 @@ def test_environment_select(request: pytest.FixtureRequest):
                                                             ":" + executable]))
     # TODO(rg): Fix this later
     # assert len(environments) == 3
-    # for env in [e for e in environments if e.tool_name != request.config.getoption('environment_type')]:
+    # for env in [
+    # e for e in environments if e.tool_name != request.config.getoption('environment_type')
+    # ]:
     #     assert env.tool_name == "existing"
     #     assert env.python == "{0[0]}.{0[1]}".format(sys.version_info)
     #     assert os.path.normcase(

--- a/test/test_environment_bench.py
+++ b/test/test_environment_bench.py
@@ -4,6 +4,8 @@ import json
 
 import pytest
 
+from asv import util
+
 from . import tools
 
 ENVIRONMENTS = []
@@ -116,6 +118,8 @@ def test_asv_benchmark(asv_project_factory, env):
     """
     Test running ASV benchmarks in the specified environment.
     """
+    if util.ON_PYPY and env in ["rattler", "mamba"]:
+        pytest.skip("mamba and py-rattler only work for CPython")
     project_dir = asv_project_factory(custom_config={})
     subprocess.run(["asv", "machine", "--yes"], cwd=project_dir, check=True)
     result = subprocess.run(
@@ -175,6 +179,8 @@ def test_asv_mamba(
     Test running ASV benchmarks with various configurations,
     checking for specific errors when failures are expected.
     """
+    if util.ON_PYPY:
+        pytest.skip("mamba and py-rattler only work for CPython")
     project_dir = asv_project_factory(custom_config=config_modifier)
     try:
         subprocess.run(

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -23,6 +23,10 @@ def test_profile_python_same(capsys, basic_conf):
     assert "Installing" not in text
 
 
+@pytest.mark.skipif(
+    util.ON_PYPY,
+    reason="pypy doesn't support profiles",
+)
 def test_profile_python_commit(capsys, basic_conf):
 
     tmpdir, local, conf, machine_file = basic_conf
@@ -35,31 +39,18 @@ def test_profile_python_commit(capsys, basic_conf):
     assert "Installing" in text
 
     # Query the previous empty results results; there should be no issues here
-    if not util.ON_PYPY:
-        tools.run_asv_with_conf(conf, 'profile', "time_secondary.track_value",
-                                f'{util.git_default_branch()}', _machine_file=machine_file)
-        text, err = capsys.readouterr()
+    tools.run_asv_with_conf(conf, 'profile', "time_secondary.track_value",
+                            f'{util.git_default_branch()}', _machine_file=machine_file)
+    text, err = capsys.readouterr()
 
-        assert "Profile data does not already exist" in text
+    assert "Profile data does not already exist" in text
 
-        tools.run_asv_with_conf(conf, 'run', "--profile",
-                                "--bench=time_secondary.track_value",
-                                f'{util.git_default_branch()}^!', _machine_file=machine_file)
-    else:
-        # The ASV main process doesn't use PyPy
-        with pytest.raises(util.UserError):
-            tools.run_asv_with_conf(conf, 'profile', "time_secondary.track_value",
-                                    f'{util.git_default_branch()}', _machine_file=machine_file)
-
+    tools.run_asv_with_conf(conf, 'run', "--profile",
+                            "--bench=time_secondary.track_value",
+                            f'{util.git_default_branch()}^!', _machine_file=machine_file)
     # Profile results should be present now
-    if not util.ON_PYPY:
-        tools.run_asv_with_conf(conf, 'profile', "time_secondary.track_value",
-                                f'{util.git_default_branch()}', _machine_file=machine_file)
-        text, err = capsys.readouterr()
+    tools.run_asv_with_conf(conf, 'profile', "time_secondary.track_value",
+                            f'{util.git_default_branch()}', _machine_file=machine_file)
+    text, err = capsys.readouterr()
 
-        assert "Profile data does not already exist" not in text
-    else:
-        # The ASV main process doesn't use PyPy
-        with pytest.raises(util.UserError):
-            tools.run_asv_with_conf(conf, 'profile', "time_secondary.track_value",
-                                    f'{util.git_default_branch()}', _machine_file=machine_file)
+    assert "Profile data does not already exist" not in text

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -42,7 +42,7 @@ def test_profile_python_commit(capsys, basic_conf):
 
         assert "Profile data does not already exist" in text
 
-        tools.run_asv_with_conf(conf, 'run', "--quick", "--profile",
+        tools.run_asv_with_conf(conf, 'run', "--profile",
                                 "--bench=time_secondary.track_value",
                                 f'{util.git_default_branch()}^!', _machine_file=machine_file)
     else:

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -82,8 +82,8 @@ def test_run_spec(basic_conf_2):
         expected = set(['machine.json'])
         for commit in expected_commits:
             for psver in tools.DUMMY2_VERSIONS:
-                expected.add(f'{commit[:8]}-{tool_name}-py{pyver}-asv_dummy_'
-                             f'test_package_1-asv_dummy_test_package_2{psver}.json')
+                expected.add(f'{commit[:8]}-{tool_name}-py{pyver}-pip+asv_dummy_'
+                             f'test_package_1-pip+asv_dummy_test_package_2{psver}.json')
 
         result_files = os.listdir(join(tmpdir, 'results_workflow', 'orangutan'))
 
@@ -231,7 +231,7 @@ def test_run_append_samples(basic_conf_2):
     tmpdir, local, conf, machine_file = basic_conf_2
 
     # Only one environment
-    conf.matrix['asv_dummy_test_package_2'] = conf.matrix['asv_dummy_test_package_2'][:1]
+    conf.matrix['pip+asv_dummy_test_package_2'] = conf.matrix['pip+asv_dummy_test_package_2'][:1]
 
     # Tests multiple calls to "asv run --append-samples"
     def run_it():

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -308,7 +308,9 @@ def test_env_matrix_value(basic_conf):
     check_env_matrix({'SOME_TEST_VAR': ['1', '2']}, {})
 
 
-@pytest.mark.skipif(tools.HAS_PYPY, reason="Times out randomly on pypy")
+@pytest.mark.skipif(
+    tools.HAS_PYPY or tools.WIN, reason="Times out randomly on pypy, buggy on windows"
+)
 def test_parallel(basic_conf_2, dummy_packages):
     tmpdir, local, conf, machine_file = basic_conf_2
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import sys
 import os
 import re
 import shutil
@@ -16,7 +15,6 @@ from asv.commands.run import Run
 from asv.commands import make_argparser
 
 from . import tools
-from .tools import WIN
 
 
 def test_set_commit_hash(capsys, existing_env_conf):
@@ -313,12 +311,6 @@ def test_env_matrix_value(basic_conf):
 @pytest.mark.skipif(tools.HAS_PYPY, reason="Times out randomly on pypy")
 def test_parallel(basic_conf_2, dummy_packages):
     tmpdir, local, conf, machine_file = basic_conf_2
-
-    if WIN and os.path.basename(sys.argv[0]).lower().startswith('py.test'):
-        # Multiprocessing in spawn mode can result to problems with py.test
-        # Find.run calls Setup.run in parallel mode by default
-        pytest.skip("Multiprocessing spawn mode on Windows not safe to run "
-                    "from py.test runner.")
 
     conf.matrix = {
         "req": dict(conf.matrix),

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -562,3 +562,14 @@ def test_construct_pip_call(declaration, expected_result):
 ])
 def test_replace_cpython_version(arg, new_version, expected):
     assert util.replace_cpython_version(arg, new_version) == expected
+
+
+@pytest.mark.parametrize("path, expected_version", [
+    ("/home/jdoe/micromamba/envs/asv_exp/bin/python3.11", "3.11"),
+    ("/usr/local/bin/python3.12", "3.12"),
+    ("/opt/anaconda3/bin/python3.9", "3.9"),
+    ("/usr/bin/python", None),
+    ("/home/user/custom_python/python_alpha", None),
+])
+def test_extract_python_version(path, expected_version):
+    assert util.extract_cpython_version(path) == expected_version

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -560,5 +560,5 @@ def test_construct_pip_call(declaration, expected_result):
     ("python==3.7", "3.10", "python=3.10"),
     ("python_package", "3.10", "python_package"),
 ])
-def test_replace_python_version(arg, new_version, expected):
-    assert util.replace_python_version(arg, new_version) == expected
+def test_replace_cpython_version(arg, new_version, expected):
+    assert util.replace_cpython_version(arg, new_version) == expected

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -80,6 +80,9 @@ def test_run_publish(capfd, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
     tmpdir = util.long_path(tmpdir)
 
+    conf.environment_type = request.config.getoption('environment_type')
+    conf.conda_channels = ["conda-forge"]
+
     conf.matrix = {
         "req": dict(conf.matrix),
         "env": {"SOME_TEST_VAR": ["1"]},

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -76,7 +76,7 @@ def basic_conf(tmpdir, dummy_packages):
     HAS_PYPY or WIN or sys.version_info >= (3, 12),
     reason="Flaky on pypy and windows, doesn't work on Python >= 3.12",
 )
-def test_run_publish(capfd, basic_conf):
+def test_run_publish(capfd, basic_conf, request: pytest.FixtureRequest):
     tmpdir, local, conf, machine_file = basic_conf
     tmpdir = util.long_path(tmpdir)
 

--- a/test/tools.py
+++ b/test/tools.py
@@ -14,7 +14,6 @@ import textwrap
 import sys
 import shutil
 import subprocess
-import platform
 import http.server
 import importlib
 from os.path import abspath, join, dirname, relpath, isdir

--- a/test/tools.py
+++ b/test/tools.py
@@ -36,7 +36,7 @@ from asv.results import Results
 from asv.plugins.conda import _find_conda
 
 # Two Python versions for testing
-PYTHON_VER1, PYTHON_VER2 = '3.8', platform.python_version()
+PYTHON_VER1, PYTHON_VER2 = '3.8', f"{sys.version_info[0]}.{sys.version_info[1]}"
 
 # Installable library versions to use in tests
 DUMMY1_VERSION = "0.14"


### PR DESCRIPTION
Closes #1446.
Follow up for #1445.


- [X] Fixes for #1446 
  - So benchmarks on the total testsuite can be run
  - ~~Also to set `rattler` as the default in the CI~~