### PR TITLE
docs: document pitfalls of changing `benchmark_name` benchmark attribute

### DIFF
--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -59,6 +59,19 @@ benchmark types:
 
 - ``benchmark_name``: If given, used as benchmark function name instead of generated one
   ``<module>.<class>.<function>``.
+   
+        Not just any string can be ``benchmark_name`` - ``asv`` still expects the name
+        to be dotted with at least two parts - ``<module>`` and ``<function>`` (e.g.
+        ``"my_file.time_something"``).
+   
+        - First dotted part, the ``<module>``, is used as a group name. It can be any string,
+          so even string like ``"My Group.time_something"`` is valid.
+   
+        - The last dotted part, the ``<function>``, is used for determining whether a function
+          is ``time_``, ``time_raw_``, ``mem_``, etc. As such, the function name MUST start with
+          one of the prefixes (e.g. ``"my_file.time_something"``). Otherwise, the function will be ignored!
+
+        - The benchmark name MUST NOT contain a dash (``-``) in any of its parts.
 
 - ``pretty_name``: If given, used to display the benchmark name instead of the
   benchmark function name.


### PR DESCRIPTION
As I was trying to configure the `benchmark_name` attribute to be able to group tests, I saw that none of the tests with the changed `benchmark_names` were being picked up by the discovery process.

Looking deeper, it turns out that when I changed the `benchmark_name`, then `asv` relied on that to tell if the given test is of type `time_`, `mem_`, etc.

Another pit I fell into was that the benchmark names acually have special handling for dashes `-` ([see source](https://github.com/airspeed-velocity/asv_runner/blob/1c88c4907993a8f84e1bec99d4aa2a31de4cc583/asv_runner/discovery.py#L198)). I triggered this because I wanted to use a dash in the module name, since I'm overriding the module name to have human-readable group names in the dashboard. I didn't look into how the dash is used internally.

Hence, I rather just updated the docs to highlight these pitfalls.