### PR TITLE
docs: Add timeouts to asv.conf.json reference

### DIFF
--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -469,6 +469,12 @@ are stored in.  If not provided, defaults to ``"results"``.
 The directory, relative to the current directory, to save the website
 content in.  If not provided, defaults to ``"html"``.
 
+``install_timeout``, ``default_benchmark_timeout``
+------------------------------------------------------------
+The maximum time in seconds that an install or benchmark is allowed to run
+before it is terminated. Benchmark timeout can also be set individually, see
+`benchmark attributes <writing_benchmarks.html#benchmark-attributes>`_.
+
 ``hash_length``
 ---------------
 The number of characters to retain in the commit hashes when displayed


### PR DESCRIPTION
Previously, `default_benchmark_timeout` was mentioned near the end of [Writing benchmarks, Setup and Teardown](https://asv.readthedocs.io/en/stable/writing_benchmarks.html#setup-and-teardown-functions), [User Guide, Setting up new project](https://asv.readthedocs.io/en/stable/using.html#setting-up-a-new-benchmarking-project), and commented-out in the starting default asv.conf.json.  `install_timeout` was only mentioned commented out in the default asv.conf.json.  This PR adds entries for these config parameters in the reference for asv.conf.json, which is where I had been looking for information about them originally.

Builds successfully in sphinx:

![image](https://github.com/user-attachments/assets/532e2fbc-2108-41d3-b64c-2df2ffded7f4)
