### PR TITLE
DOC: platform → sys_platform

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -89,7 +89,7 @@
     //     // additional env for python3.12
     //     {"python": "3.12", "numpy": "1.26"},
     //     // additional env if run on windows+conda
-    //     {"platform": "win32", "environment_type": "conda", "python": "3.12", "libpython": ""},
+    //     {"sys_platform": "win32", "environment_type": "conda", "python": "3.12", "libpython": ""},
     // ],
 
     // The directory (relative to the current directory) that benchmarks are


### PR DESCRIPTION
According to https://asv.readthedocs.io/en/latest/asv.conf.json.html#include, it's `sys_platform`.