### PR TITLE
MAINT: Apply assorted ruff/pyupgrade rules (UP)

### DIFF
--- a/asv/commands/preview.py
+++ b/asv/commands/preview.py
@@ -4,7 +4,6 @@ import errno
 import http.server
 import os
 import random
-import socket
 import socketserver
 
 from .. import util
@@ -39,7 +38,7 @@ def create_httpd(handler_cls, port=0):
             httpd = MyTCPServer(("", port), handler_cls)
             base_url = f"http://127.0.0.1:{port}/"
             break
-        except socket.error as e:
+        except OSError as e:
             if e.errno == errno.EADDRINUSE:
                 continue
             else:

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import contextlib
-import io
 import os
 import pstats
 import sys
@@ -26,7 +25,7 @@ from . import Command, common_args
 def temp_profile(profile_data):
     profile_fd, profile_path = tempfile.mkstemp()
     try:
-        with io.open(profile_fd, 'wb', closefd=True) as fd:
+        with open(profile_fd, 'wb', closefd=True) as fd:
             fd.write(profile_data)
 
         yield profile_path
@@ -215,7 +214,7 @@ class Profile(Command):
             with temp_profile(profile_data) as profile_path:
                 return cls.guis[gui].open_profiler_gui(profile_path)
         elif output is not None:
-            with io.open(output, 'wb') as fd:
+            with open(output, 'wb') as fd:
                 fd.write(profile_data)
         else:
             color_print('')

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -998,7 +998,7 @@ class Environment:
         # may have been set from a pip config file) is incompatible with
         # virtualenvs.
         kwargs["env"] = dict(env,
-                             PIP_USER=str("false"),
+                             PIP_USER="false",
                              PATH=str(os.pathsep.join(paths)))
         exe = self.find_executable(executable)
         if kwargs.get("timeout", None) is None:

--- a/asv/feed.py
+++ b/asv/feed.py
@@ -176,13 +176,13 @@ def _get_id(owner, date, content):
     """
     h = hashlib.sha256()
     # Hash still contains the original project url, keep as is
-    h.update("github.com/spacetelescope/asv".encode('utf-8'))
+    h.update(b"github.com/spacetelescope/asv")
     for x in content:
         if x is None:
-            h.update(",".encode('utf-8'))
+            h.update(b",")
         else:
             h.update(x.encode('utf-8'))
-        h.update(",".encode('utf-8'))
+        h.update(b",")
 
     if date is None:
         date = datetime.datetime(

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -235,7 +235,7 @@ class Conda(environment.Environment):
 
         # Conda doesn't guarantee that user site directories are excluded
         kwargs["env"] = dict(kwargs.pop("env", os.environ),
-                             PYTHONNOUSERSITE=str("True"))
+                             PYTHONNOUSERSITE="True")
 
         with lock():
             return super(Conda, self).run_executable(executable, args, **kwargs)

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -143,11 +143,11 @@ class Conda(environment.Environment):
         env_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".yml")
         try:
             env_file.write(f'name: {self.name}\nchannels:\n')
-            env_file.writelines((f'   - {ch}\n' for ch in self._conda_channels))
+            env_file.writelines(f'   - {ch}\n' for ch in self._conda_channels)
             if conda_args:
                 env_file.write('dependencies:\n')
                 # categorize & write dependencies based on pip vs. conda
-                env_file.writelines((f'   - {s}\n' for s in conda_args))
+                env_file.writelines(f'   - {s}\n' for s in conda_args)
             env_file.close()
             try:
                 env_file_name = self._conda_environment_file or env_file.name

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -809,7 +809,7 @@ class ForkServer(Spawner):
             try:
                 s.connect(self.socket_name)
                 break
-            except socket.error:
+            except OSError:
                 if retry > 1:
                     time.sleep(0.2)
                 else:

--- a/asv/runner.py
+++ b/asv/runner.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import datetime
-import io
 import itertools
 import json
 import math
@@ -647,7 +646,7 @@ def _run_benchmark_single_param(benchmark, spawner, param_idx,
             out = f"For parameters: {', '.join(params)}\n{out}"
 
         if profile:
-            with io.open(profile_path, 'rb') as profile_fd:
+            with open(profile_path, 'rb') as profile_fd:
                 profile_data = profile_fd.read()
             profile_data = profile_data if profile_data else None
         else:

--- a/asv/util.py
+++ b/asv/util.py
@@ -534,7 +534,7 @@ def check_output(args, valid_return_codes=(0,), timeout=600, dots=True,
                     else:
                         rlist, wlist, xlist = select.select(
                             list(fds.keys()), [], [], timeout)
-                except select.error as err:
+                except OSError as err:
                     if err.args[0] == errno.EINTR:
                         # interrupted by signal handler; try again
                         continue

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -314,10 +314,10 @@ def dummy_packages(request, monkeypatch):
     with locked_cache_dir(request.config, "asv-wheels", timeout=900, tag=tag) as cache_dir:
         wheel_dir = os.path.abspath(join(str(cache_dir), 'wheels'))
 
-        monkeypatch.setenv(str('PIP_FIND_LINKS'), str('file://' + wheel_dir))
+        monkeypatch.setenv('PIP_FIND_LINKS', str('file://' + wheel_dir))
 
         condarc = join(wheel_dir, 'condarc')
-        monkeypatch.setenv(str('CONDARC'), str(condarc))
+        monkeypatch.setenv('CONDARC', str(condarc))
 
         if os.path.isdir(wheel_dir):
             return

--- a/test/test_console.py
+++ b/test/test_console.py
@@ -40,7 +40,7 @@ def test_write_with_fallback(tmpdir, capfd):
 
             # Check writing to a file
             fn = os.path.join(tmpdir, 'tmp.txt')
-            with io.open(fn, 'w', encoding=stream_encoding) as stream:
+            with open(fn, 'w', encoding=stream_encoding) as stream:
                 _write_with_fallback(value, stream)
             with open(fn, 'rb') as stream:
                 got = stream.read()

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -92,7 +92,7 @@ def test_presence_checks(tmpdir, monkeypatch):
         # Tell conda to not use hardlinks: on Windows it's not possible
         # to delete hard links to files in use, which causes problem when
         # trying to cleanup environments during this test
-        monkeypatch.setenv(str('CONDA_ALWAYS_COPY'), str('True'))
+        monkeypatch.setenv('CONDA_ALWAYS_COPY', 'True')
 
     conf.env_dir = str(tmpdir.join("env"))
 
@@ -649,11 +649,11 @@ def test_environment_environ_path(environment_type, tmpdir, monkeypatch):
     assert usersite_in_syspath == "False"
 
     # Check PYTHONPATH is ignored
-    monkeypatch.setenv(str('PYTHONPATH'), str(tmpdir))
+    monkeypatch.setenv('PYTHONPATH', str(tmpdir))
     output = env.run(['-c', 'import os; print(os.environ.get("PYTHONPATH", ""))'])
     assert output.strip() == ""
 
-    monkeypatch.setenv(str('ASV_PYTHONPATH'), str("Hello python path"))
+    monkeypatch.setenv('ASV_PYTHONPATH', "Hello python path")
     output = env.run(['-c', 'import os; print(os.environ["PYTHONPATH"])'])
     assert output.strip() == "Hello python path"
 

--- a/test/test_gh_pages.py
+++ b/test/test_gh_pages.py
@@ -13,9 +13,9 @@ from . import tools
 def test_gh_pages(rewrite, tmpdir, generate_result_dir, monkeypatch):
     tmpdir = os.path.abspath(str(tmpdir))
 
-    monkeypatch.setenv(str('EMAIL'), str('test@asv'))
-    monkeypatch.setenv(str('GIT_COMMITTER_NAME'), str('asv test'))
-    monkeypatch.setenv(str('GIT_AUTHOR_NAME'), str('asv test'))
+    monkeypatch.setenv('EMAIL', 'test@asv')
+    monkeypatch.setenv('GIT_COMMITTER_NAME', 'asv test')
+    monkeypatch.setenv('GIT_AUTHOR_NAME', 'asv test')
 
     conf, repo, commits = generate_result_dir([1, 2, 3, 4])
 

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -97,7 +97,7 @@ def test_run_benchmarks(benchmarks_fixture, tmpdir):
     assert times[
         'time_secondary.track_value'].result == [42.0]
     assert times['time_secondary.track_value'].profile is not None
-    assert isinstance(times['time_examples.time_with_warnings'].stderr, type(''))
+    assert isinstance(times['time_examples.time_with_warnings'].stderr, str)
     assert times['time_examples.time_with_warnings'].errcode != 0
     assert times['time_secondary.track_fail_errcode_123'].errcode == 123
     if hasattr(os, 'kill') and hasattr(os, 'getpid'):

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -118,7 +118,7 @@ print(os.environ['TEST_ASV_BAR'])
     env = os.environ.copy()
     env['TEST_ASV_FOO'] = 'foo'
     # Force unicode string on Python 2
-    env['TEST_ASV_BAR'] = u'bar'
+    env['TEST_ASV_BAR'] = 'bar'
     output = util.check_output([sys.executable, "-c", code], env=env)
     assert output.splitlines() == ['foo', 'bar']
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -116,10 +116,10 @@ def test_web_summarygrid(browser, basic_html):
 
         # Verify benchmark names are displayed as expected
         for href, expected in (
-            ('#subdir.time_subdir.time_foo', u'time_subdir.time_foo'),
-            ('#params_examples.ParamSuite.track_value', u'ParamSuite.track_value'),
-            ('#custom.time_function', u'My Custom Function'),
-            ('#named.track_custom_pretty_name', u'this.is/the.answer'),
+            ('#subdir.time_subdir.time_foo', 'time_subdir.time_foo'),
+            ('#params_examples.ParamSuite.track_value', 'ParamSuite.track_value'),
+            ('#custom.time_function', 'My Custom Function'),
+            ('#named.track_custom_pretty_name', 'this.is/the.answer'),
         ):
             item = browser.find_element(By.XPATH,
                                         f"//a[@href='{href}']/div[@class='benchmark-text']")

--- a/test/tools.py
+++ b/test/tools.py
@@ -7,7 +7,6 @@ This file contains utilities to generate test repositories.
 import datetime
 import http.server
 import importlib
-import io
 import os
 import platform
 import shutil
@@ -266,7 +265,7 @@ class Hg:
 
     def init(self):
         hglib.init(self.path)
-        with io.open(join(self.path, '.hg', 'hgrc'), 'w', encoding="utf-8") as fd:
+        with open(join(self.path, '.hg', 'hgrc'), 'w', encoding="utf-8") as fd:
             fd.write(_hg_config)
         self._repo = hglib.open(self.path.encode(sys.getfilesystemencoding()),
                                 encoding=self.encoding)
@@ -335,18 +334,18 @@ def copy_template(src, dst, dvcs, values):
             dst_path = join(dst, relpath(src_path, src))
 
             try:
-                with io.open(src_path, 'r', encoding='utf-8') as fd:
+                with open(src_path, 'r', encoding='utf-8') as fd:
                     content = fd.read()
             except UnicodeDecodeError:
                 # File is some sort of binary file...  just copy it
                 # directly with no template substitution
-                with io.open(src_path, 'rb') as fd:
+                with open(src_path, 'rb') as fd:
                     content = fd.read()
-                with io.open(dst_path, 'wb') as fd:
+                with open(dst_path, 'wb') as fd:
                     fd.write(content)
             else:
                 content = content.format(**values)
-                with io.open(dst_path, 'w', encoding='utf-8') as fd:
+                with open(dst_path, 'w', encoding='utf-8') as fd:
                     fd.write(content)
 
             dvcs.add(dst_path)


### PR DESCRIPTION
Remove deprecated Python. Among other:
* [`io.open()`](https://docs.python.org/3/library/io.html#io.open) is an alias for the builtin [`open()`](https://docs.python.org/3/library/functions.html#open) function.
* [`socket.error`](https://docs.python.org/3/library/socket.html#socket.error) is a deprecated alias of [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError).