### PR TITLE
MAINT: Apply ruff/flake8-logging rules (LOG)

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -25,7 +25,7 @@ def _do_build(args):
     started_at = time.time()
     success = False
     try:
-        with log.set_level(logging.WARN):
+        with log.set_level(logging.WARNING):
             env.install_project(conf, repo, commit_hash)
         success = True
     except util.ProcessError:

--- a/asv/commands/setup.py
+++ b/asv/commands/setup.py
@@ -10,7 +10,7 @@ from . import Command, common_args
 
 
 def _create(env):
-    with log.set_level(logging.WARN):
+    with log.set_level(logging.WARNING):
         env.create()
 
 


### PR DESCRIPTION
> LOG009 Use of undocumented `logging.WARN` constant

Use [`logging.WARNING`](https://docs.python.org/3/library/logging.html#logging.WARNING) instead.