### PR TITLE
MAINT: Apply ruff/Pylint rule PLE0704

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -1048,7 +1048,7 @@ else:
                 pass
 
         # Reraise original error
-        raise
+        raise exc_info[1]
 
     def long_path_open(filename, *a, **kw):
         return open(long_path(filename), *a, **kw)


### PR DESCRIPTION
> PLE0704 Bare `raise` statement is not inside an exception handler

Fixes issue introduced in #1072.