### PR TITLE
DOC: Add a space after Python command line option `-m`

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -893,7 +893,7 @@ class Environment:
             # that pip believes to be already installed.
             # --force-reinstall is needed since versions may not change between
             # asv runs (esp. for compare), e.g. gh-1421
-            cmd = ["in-dir={env_dir} python -mpip install {wheel_file} --force-reinstall"]
+            cmd = ["in-dir={env_dir} python -m pip install {wheel_file} --force-reinstall"]
 
         if cmd:
             commit_name = repo.get_decorated_hash(commit_hash, 8)
@@ -912,7 +912,7 @@ class Environment:
         if cmd is None:
             # Run pip via python -m pip, avoids shebang length limit on Linux
             # pip uninstall may fail if not installed, so allow any exit code
-            cmd = ['return-code=any python -mpip uninstall -y {project}']
+            cmd = ['return-code=any python -m pip uninstall -y {project}']
 
         if cmd:
             log.info(f"Uninstalling from {self.name}")
@@ -929,7 +929,7 @@ class Environment:
         if cmd is None:
             cmd = [
                 "PIP_NO_BUILD_ISOLATION=0 python -m build",
-                "python -mpip wheel -w {build_cache_dir} {build_dir}"
+                "python -m pip wheel -w {build_cache_dir} {build_dir}"
             ]
 
         if cmd:

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -243,4 +243,4 @@ class Conda(environment.Environment):
     def _run_pip(self, args, **kwargs):
         # Run pip via python -m pip, so that it works on Windows when
         # upgrading pip itself, and avoids shebang length limit on Linux
-        return self.run_executable("python", ["-mpip"] + list(args), **kwargs)
+        return self.run_executable("python", ["-m", "pip"] + list(args), **kwargs)

--- a/asv/plugins/mamba.py
+++ b/asv/plugins/mamba.py
@@ -199,4 +199,4 @@ class Mamba(environment.Environment):
     def _run_pip(self, args, **kwargs):
         # Run pip via python -m pip, so that it works on Windows when
         # upgrading pip itself, and avoids shebang length limit on Linux
-        return self.run_executable("python", ["-mpip"] + list(args), **kwargs)
+        return self.run_executable("python", ["-m", "pip"] + list(args), **kwargs)

--- a/asv/plugins/rattler.py
+++ b/asv/plugins/rattler.py
@@ -137,4 +137,4 @@ class Rattler(environment.Environment):
     def _run_pip(self, args, **kwargs):
         # Run pip via python -m pip, so that it works on Windows when
         # upgrading pip itself, and avoids shebang length limit on Linux
-        return self.run_executable("python", ["-mpip"] + list(args), **kwargs)
+        return self.run_executable("python", ["-m", "pip"] + list(args), **kwargs)

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -139,7 +139,7 @@ class Virtualenv(environment.Environment):
         log.info(f"Creating virtualenv for {self.name}")
         util.check_call([
             sys.executable,
-            "-mvirtualenv",
+            "-m", "virtualenv",
             *(["--wheel=bundle"] if use_wheel else []),
             "--setuptools=bundle",
             "-p",
@@ -173,7 +173,7 @@ class Virtualenv(environment.Environment):
     def _run_pip(self, args, **kwargs):
         # Run pip via python -m pip, so that it works on Windows when
         # upgrading pip itself, and avoids shebang length limit on Linux
-        return self.run_executable('python', ['-mpip'] + list(args), **kwargs)
+        return self.run_executable('python', ['-m', 'pip'] + list(args), **kwargs)
 
     def run(self, args, **kwargs):
         joined_args = ' '.join(args)

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -24,18 +24,18 @@
     // "build_command": [
     //     "python -m pip install build",
     //     "python -m build",
-    //     "python -mpip wheel -w {build_cache_dir} {build_dir}"
+    //     "python -m pip wheel -w {build_cache_dir} {build_dir}"
     // ],
     // To build the package using setuptools and a setup.py file, uncomment the following lines
     // "build_command": [
     //     "python setup.py build",
-    //     "python -mpip wheel -w {build_cache_dir} {build_dir}"
+    //     "python -m pip wheel -w {build_cache_dir} {build_dir}"
     // ],
 
     // Customizable commands for installing and uninstalling the project.
     // See asv.conf.json documentation.
-    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
-    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // "install_command": ["in-dir={env_dir} python -m pip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -m pip uninstall -y {project}"],
 
     // List of branches to benchmark. If not provided, defaults to "main"
     // (for git) or "default" (for mercurial).

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -77,14 +77,14 @@ Airspeed Velocity rebuilds the project as needed, using these commands.
 The defaults are::
 
   "install_command":
-  ["in-dir={env_dir} python -mpip install {wheel_file}"],
+  ["in-dir={env_dir} python -m pip install {wheel_file}"],
 
   "uninstall_command":
-  ["return-code=any python -mpip uninstall -y {project}"],
+  ["return-code=any python -m pip uninstall -y {project}"],
 
   "build_command":
   ["python setup.py build",
-   "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"],
+   "PIP_NO_BUILD_ISOLATION=false python -m pip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"],
 
 .. note::
 
@@ -95,7 +95,7 @@ The defaults are::
 
           "build_command":
           ["python setup.py build",
-           "python -mpip wheel -w {build_cache_dir} {build_dir}"],
+           "python -m pip wheel -w {build_cache_dir} {build_dir}"],
 
 The install commands should install the project in the active Python
 environment (virtualenv/conda), so that it can be used by the

--- a/docs/source/tuning.rst
+++ b/docs/source/tuning.rst
@@ -62,7 +62,7 @@ on how to tune machines for benchmarking
 <https://pyperf.readthedocs.io/en/latest/system.html>`__.  The simplest
 way to apply basic tuning on Linux using ``pyperf`` is to run::
 
-    sudo python -mpyperf system tune
+    sudo python -m pyperf system tune
 
 This will modify system settings that can be only changed as root, and
 you should read the ``pyperf`` documentation on what it precisely does.


### PR DESCRIPTION
Extends #1474.

While Python understands both variants, `-m<mod>` and `-m <mod>`, the documented way to call Python is with a space after `-m`:
```
-m mod : run library module as a script (terminates option list)
```

Se also [1. Command line and environment](https://docs.python.org/3/using/cmdline.html#command-line-and-environment):
> * When called with `-m module-name`, the given module is located on the Python module path and executed as a script.