### PR TITLE
MAINT: Do not list wheel as a build-dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ testR = [
 all = ["asv[doc,dev,hg,envs]"]
 [build-system]
 requires = [
-    "wheel",
     # pin setuptools:
     # https://github.com/airspeed-velocity/asv/pull/1426#issuecomment-2290658198
     "setuptools>=64,<72.2.0",


### PR DESCRIPTION
Do not include "`wheel`" in your `build-system.requires`, setuptools does this via PEP 517 already. Setuptools will also only require this for actual wheel builds, and might have version limits.

Addresses [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=airspeed-velocity%2Fasv&ref=main&refType=branch) suggestion.