### PR TITLE
Report the last error when failing to discover benchmarks

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -211,6 +211,8 @@ class Benchmarks(dict):
                 finally:
                     util.long_path_rmtree(result_dir)
             else:
+                if last_err is not None:
+                    log.error("Last error: " + str(last_err))
                 raise util.UserError("Failed to build the project and import the benchmark suite.")
 
         if check:


### PR DESCRIPTION
While trying to use asv for the first time, I've got to a situation that was hard to debug without cloning the repo.
In this PR I'm trying to make it easier for the next person that makes the same (or similar) config mistake I did.

This might be related to https://github.com/airspeed-velocity/asv/issues/1453.

When running `asv run -v`, I got:

```
      Compiling geo-trace v0.0.1 ([...]/geo_trace/.asv/env/28ce2c79fdbca74891d3623705fc0783/project)
       Finished `release` profile [optimized] target(s) in 37.98s
   🚉 Overriding platform tag from _PYTHON_HOST_PLATFORM environment variable as linux_x86_64.
   📖 Found type stub file at geo_trace.pyi
   📦 Built wheel for CPython 3.10 to [...]/geo_trace/.asv/env/28ce2c79fdbca74891d3623705fc0783/project/geo_trace-0.0.1-cp310-cp310-linux_x86_64.whl
·· Running '[...]/bin/git name-rev --name-only --exclude=remotes/* --no-undefined 9851fde784e599ea9d027bf38aa351bb0b6284fd'
   OUTPUT -------->
   master
·· Installing 9851fde7 <master> into virtualenv-py3.10
·· Failed to build the project and import the benchmark suite.
```

After about 2 hours of tweaking configs and trying to debug it from the outside, I've cloned asv and installed it locally as editable so I could debug it from the inside.

Eventually, I've added:

```python
if last_err is not None:
    log.error("Failed to discover benchmarks: " + str(last_err))
```
just before `raise util.UserError("Failed to build the project and import the benchmark suite.")`, and got:
```
·· Failed to discover benchmarks: Configuration error: {wheel_file} not available when substituting into command 'in-dir={env_dir} python -m pip install {wheel_file} --force-reinstall' Available: {'project': 'geo-trace', 'conf_dir': '[...]/geo_trace', 'env_name': 'virtualenv-py3.10', 'env_dir': '[...]/geo_trace/.asv/env/28ce2c79fdbca74891d3623705fc0783', 'env_type': 'virtualenv', 'commit': '9851fde784e599ea9d027bf38aa351bb0b6284fd', 'build_dir': '[...]/geo_trace/.asv/env/28ce2c79fdbca74891d3623705fc0783/project', 'build_cache_dir': '[...]/geo_trace/.asv/env/28ce2c79fdbca74891d3623705fc0783/asv-build-cache/9851fde784e599ea9d027bf38aa351bb0b6284fd'}
```

This eventually led me to the understanding that the build command should use `build_cache_dir` instead of `build_dir` (the full command in my use-case now is `python -m maturin build --release --out {build_cache_dir}`).