### PR TITLE
MAINT: Bump setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Environment :: Web Environment",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
* Require setuptools 77.0.3 for [PEP 639 support](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).
* Pin to currently latest setuptools 80.9.0.
* Avoid setuptools_scm 8.