### PR TITLE
BUG: Set defaults in conda_channels for rattler

### DIFF
--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -69,7 +69,7 @@
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order
-    // "conda_channels": ["conda-forge"],
+    // "conda_channels": ["conda-forge", "defaults"],
 
     // A conda environment file that is used for environment creation.
     // "conda_environment_file": "environment.yml",

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -234,7 +234,7 @@ environment file.
 A list of ``conda`` channel names (strings) to use in the provided
 order as the source channels for the dependencies. For example::
 
-    "conda_channels": ["conda-forge"]
+    "conda_channels": ["conda-forge", "defaults"]
 
 The channels will be parsed by ``asv`` to populate the ``channels``
 section of a temporary environment.yml file used to build the


### PR DESCRIPTION
Closes #1534. Handling of `defaults` in `rattler` was in #1525 but I forgot to add it back to the template.