### PR TITLE
before cd, change arg.config to full path

### DIFF
--- a/asv/main.py
+++ b/asv/main.py
@@ -22,6 +22,7 @@ def main():
     # the run.
     # If using the default path, stay in the same dir.
     if args.config:
+        args.config = os.path.abspath(args.config)
         os.chdir(os.path.dirname(os.path.abspath(args.config)))
 
     try:

--- a/test/test_conf.py
+++ b/test/test_conf.py
@@ -2,6 +2,7 @@
 
 import os
 from os.path import dirname, join
+import sys
 
 from asv import commands, config, environment, util
 from asv.commands import Command
@@ -64,3 +65,10 @@ def test_load_plugin():
             break
     else:
         assert False, "Custom plugin not loaded"
+
+def test_cmd_line_config():
+    # issue 1538
+    util.check_call(
+        [sys.executable, "-m", "asv", "machine", "--yes", "--config", "test/asv.conf.json"],
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+    )


### PR DESCRIPTION
Closes #1538

In #1426 the logic changed, and providing `--config <file>` as a cmd-line argument was subtly changed. Now the path of that file is used as the cwd, but that path is not changed to accomodate the change in directory. A line that changed the value of `args.config` to the absolute path of `<file>` was removed. This PR restores it, and adds a test mimicing the failure in #1538. I verified that it fails before, passes after this PR.