### PR TITLE
Allow users to specify the launch_method in the config

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -436,6 +436,12 @@ class Run(Command):
         else:
             run_round_set = [None]
 
+        if launch_method is None:
+            # Allow the users to set the launch_method by the command line argument
+            # if they didn't set it, use the one in the config
+            # and then ultimately default to 'auto' if not set in the config
+            launch_method = conf.launch_method or 'auto'
+
         def iter_rounds_commits():
             for run_rounds in run_round_set:
                 if interleave_rounds and run_rounds[0] % 2 == 0:

--- a/asv/config.py
+++ b/asv/config.py
@@ -72,6 +72,7 @@ class Config:
         self.build_command = None
         self.install_command = None
         self.uninstall_command = None
+        self.launch_method = None
 
     @classmethod
     def load(cls, path=None):

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -191,4 +191,9 @@
     //    "some_benchmark": 0.01,     // Threshold of 1%
     //    "another_benchmark": 0.5,   // Threshold of 50%
     // },
+
+    // launch_method:
+    // How to launch benchmarks. Choices: auto, spawn, forkserver
+    // This parameter may be overwritten by command line arguments
+    // "launch_method": "auto",
 }


### PR DESCRIPTION
We find that with cupy at least, we are unable to allocate GPU memory without setting the method to spawn.

This is easy to forget to specify, and thus creates all these problems for us when we run longer benchmarks

Thanks for considering!