### PR TITLE
Fixup how the default launch method is chosen

### DIFF
--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -289,8 +289,13 @@ def add_launch_method(parser):
         dest="launch_method",
         action="store",
         choices=("auto", "spawn", "forkserver"),
-        default="auto",
-        help="How to launch benchmarks. Choices: auto, spawn, forkserver",
+        default=None,
+        help=(
+            "How to launch benchmarks. Choices: auto, spawn, forkserver. "
+            "By default asv will look in the asv.conf.json file, if not, auto "
+            "will be used."
+        ),
+
     )
 
 


### PR DESCRIPTION
As a followup to #1560 this actually removes the "launch-method" from the args allowing it to be specified by the config file.