### PR TITLE
docs addition for launch-method

### DIFF
--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -82,8 +82,9 @@ is well-formatted, without actually running any benchmarks::
 
 .. note::
 
-    When running benchmarks reliant on CUDA, the --launch-method flag should be set to 'spawn'.
-    This prevents the child process from inheriting the CUDA context of the parent process.
+    When running benchmarks reliant on CUDA, the ``--launch-method`` flag should be set 
+    to ``spawn``. This prevents the child process from inheriting the CUDA context of 
+    the parent process.
 
 .. _setup-and-teardown:
 


### PR DESCRIPTION
Suggested change to https://asv.readthedocs.io/en/stable/writing_benchmarks.html that addresses subtle CUDA failure when the default launch-method is used for GPU benchmarks on Linux.