### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,32 +1,11 @@
-include README.rst
-include CHANGES.rst
-include LICENSE.rst
-
-recursive-include asv *.html *.js *.css *.ico *.png
-
-include asv.conf.json
-recursive-include benchmarks *.py
-
-include requirements-dev.txt
-include pyproject.toml
-include pytest.ini
-
-include docs/make.bat
-include docs/Makefile
-recursive-include docs *.rst *.txt *.py *.ico *.html *.png *.css
-
-recursive-include test *.json *.py README
-
-prune docs/build
+prune .github
 prune build
-
-global-exclude *.pyc *.o __pycache__
+prune changelog.d
+prune scripts
 
 exclude .codecov.yml
 exclude .coveragerc
-exclude .github
 exclude .gitignore
 exclude .pre-commit-config.yaml
 exclude .readthedocs.yaml
-exclude scripts
 exclude towncrier.toml


### PR DESCRIPTION
* Remove deleted files.
* No need to explictly include files included by setuptools by default.
* Additionally, setuptools-scm pulls all files under version control. Perhaps we should exclude more files instead of including, shouldn't we?

<details>
<summary>Contents of sidst after this change</summary>

```
$ tar tzf dist/asv-0.6.6.dev78+gd59a3eff8.tar.gz
asv-0.6.6.dev78+gd59a3eff8/
asv-0.6.6.dev78+gd59a3eff8/CHANGES.rst
asv-0.6.6.dev78+gd59a3eff8/CODE_OF_CONDUCT.rst
asv-0.6.6.dev78+gd59a3eff8/CONTRIBUTING.rst
asv-0.6.6.dev78+gd59a3eff8/LICENSE.rst
asv-0.6.6.dev78+gd59a3eff8/MANIFEST.in
asv-0.6.6.dev78+gd59a3eff8/PKG-INFO
asv-0.6.6.dev78+gd59a3eff8/README.rst
asv-0.6.6.dev78+gd59a3eff8/asv/
asv-0.6.6.dev78+gd59a3eff8/asv/__init__.py
asv-0.6.6.dev78+gd59a3eff8/asv/__main__.py
asv-0.6.6.dev78+gd59a3eff8/asv/_rangemedian.cpp
asv-0.6.6.dev78+gd59a3eff8/asv/_stats.py
asv-0.6.6.dev78+gd59a3eff8/asv/_version.py
asv-0.6.6.dev78+gd59a3eff8/asv/benchmark.py
asv-0.6.6.dev78+gd59a3eff8/asv/benchmarks.py
asv-0.6.6.dev78+gd59a3eff8/asv/build_cache.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/
asv-0.6.6.dev78+gd59a3eff8/asv/commands/__init__.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/check.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/common_args.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/compare.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/continuous.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/find.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/machine.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/preview.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/profiling.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/publish.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/quickstart.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/rm.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/run.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/setup.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/show.py
asv-0.6.6.dev78+gd59a3eff8/asv/commands/update.py
asv-0.6.6.dev78+gd59a3eff8/asv/config.py
asv-0.6.6.dev78+gd59a3eff8/asv/console.py
asv-0.6.6.dev78+gd59a3eff8/asv/environment.py
asv-0.6.6.dev78+gd59a3eff8/asv/feed.py
asv-0.6.6.dev78+gd59a3eff8/asv/graph.py
asv-0.6.6.dev78+gd59a3eff8/asv/machine.py
asv-0.6.6.dev78+gd59a3eff8/asv/main.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugin_manager.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/__init__.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/conda.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/git.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/github.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/kcachegrind.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/mercurial.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/rattler.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/regressions.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/runsnake.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/snakeviz.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/summarygrid.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/summarylist.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/uv.py
asv-0.6.6.dev78+gd59a3eff8/asv/plugins/virtualenv.py
asv-0.6.6.dev78+gd59a3eff8/asv/profiling.py
asv-0.6.6.dev78+gd59a3eff8/asv/publishing.py
asv-0.6.6.dev78+gd59a3eff8/asv/repo.py
asv-0.6.6.dev78+gd59a3eff8/asv/results.py
asv-0.6.6.dev78+gd59a3eff8/asv/runner.py
asv-0.6.6.dev78+gd59a3eff8/asv/step_detect.py
asv-0.6.6.dev78+gd59a3eff8/asv/template/
asv-0.6.6.dev78+gd59a3eff8/asv/template/.gitignore
asv-0.6.6.dev78+gd59a3eff8/asv/template/asv.conf.json
asv-0.6.6.dev78+gd59a3eff8/asv/template/benchmarks/
asv-0.6.6.dev78+gd59a3eff8/asv/template/benchmarks/__init__.py
asv-0.6.6.dev78+gd59a3eff8/asv/template/benchmarks/benchmarks.py
asv-0.6.6.dev78+gd59a3eff8/asv/util.py
asv-0.6.6.dev78+gd59a3eff8/asv/www/
asv-0.6.6.dev78+gd59a3eff8/asv/www/asv.css
asv-0.6.6.dev78+gd59a3eff8/asv/www/asv.js
asv-0.6.6.dev78+gd59a3eff8/asv/www/asv_ui.js
asv-0.6.6.dev78+gd59a3eff8/asv/www/error.html
asv-0.6.6.dev78+gd59a3eff8/asv/www/graphdisplay.js
asv-0.6.6.dev78+gd59a3eff8/asv/www/index.html
asv-0.6.6.dev78+gd59a3eff8/asv/www/jquery.flot.axislabels.js
asv-0.6.6.dev78+gd59a3eff8/asv/www/regressions.css
asv-0.6.6.dev78+gd59a3eff8/asv/www/regressions.js
asv-0.6.6.dev78+gd59a3eff8/asv/www/summarygrid.js
asv-0.6.6.dev78+gd59a3eff8/asv/www/summarylist.css
asv-0.6.6.dev78+gd59a3eff8/asv/www/summarylist.js
asv-0.6.6.dev78+gd59a3eff8/asv/www/swallow.ico
asv-0.6.6.dev78+gd59a3eff8/asv/www/swallow.png
asv-0.6.6.dev78+gd59a3eff8/asv.conf.json
asv-0.6.6.dev78+gd59a3eff8/asv.egg-info/
asv-0.6.6.dev78+gd59a3eff8/asv.egg-info/PKG-INFO
asv-0.6.6.dev78+gd59a3eff8/asv.egg-info/SOURCES.txt
asv-0.6.6.dev78+gd59a3eff8/asv.egg-info/dependency_links.txt
asv-0.6.6.dev78+gd59a3eff8/asv.egg-info/entry_points.txt
asv-0.6.6.dev78+gd59a3eff8/asv.egg-info/requires.txt
asv-0.6.6.dev78+gd59a3eff8/asv.egg-info/top_level.txt
asv-0.6.6.dev78+gd59a3eff8/benchmarks/
asv-0.6.6.dev78+gd59a3eff8/benchmarks/__init__.py
asv-0.6.6.dev78+gd59a3eff8/benchmarks/step_detect.py
asv-0.6.6.dev78+gd59a3eff8/docs/
asv-0.6.6.dev78+gd59a3eff8/docs/source/
asv-0.6.6.dev78+gd59a3eff8/docs/source/_static/
asv-0.6.6.dev78+gd59a3eff8/docs/source/_static/asv-doc.css
asv-0.6.6.dev78+gd59a3eff8/docs/source/_static/dark_logo.png
asv-0.6.6.dev78+gd59a3eff8/docs/source/_static/light_logo.png
asv-0.6.6.dev78+gd59a3eff8/docs/source/_static/swallow.ico
asv-0.6.6.dev78+gd59a3eff8/docs/source/_templates/
asv-0.6.6.dev78+gd59a3eff8/docs/source/_templates/layout.html
asv-0.6.6.dev78+gd59a3eff8/docs/source/asv.bib
asv-0.6.6.dev78+gd59a3eff8/docs/source/asv.conf.json.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/benchmarks.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/changelog.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/commands.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/conf.py
asv-0.6.6.dev78+gd59a3eff8/docs/source/dev.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/env_vars.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/index.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/installing.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/screenshot-bench.png
asv-0.6.6.dev78+gd59a3eff8/docs/source/screenshot-grid.png
asv-0.6.6.dev78+gd59a3eff8/docs/source/screenshot-regressions.png
asv-0.6.6.dev78+gd59a3eff8/docs/source/step_detection.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/tuning.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/user_reference.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/using.rst
asv-0.6.6.dev78+gd59a3eff8/docs/source/writing_benchmarks.rst
asv-0.6.6.dev78+gd59a3eff8/pyproject.toml
asv-0.6.6.dev78+gd59a3eff8/setup.cfg
asv-0.6.6.dev78+gd59a3eff8/setup.py
asv-0.6.6.dev78+gd59a3eff8/test/
asv-0.6.6.dev78+gd59a3eff8/test/__init__.py
asv-0.6.6.dev78+gd59a3eff8/test/asv-machine.json
asv-0.6.6.dev78+gd59a3eff8/test/asv.conf.json
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/__init__.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/cache_examples.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/code_extraction.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/mem_examples.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/named.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/params_examples.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/peakmem_examples.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/shared.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/subdir/
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/subdir/__init__.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/subdir/time_subdir.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/time_examples.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/time_secondary.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark/timeraw_examples.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark.invalid/
asv-0.6.6.dev78+gd59a3eff8/test/benchmark.invalid/__init__.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark.invalid/foo/
asv-0.6.6.dev78+gd59a3eff8/test/benchmark.invalid/foo/bar.py
asv-0.6.6.dev78+gd59a3eff8/test/benchmark.invalid/foo.py
asv-0.6.6.dev78+gd59a3eff8/test/conftest.py
asv-0.6.6.dev78+gd59a3eff8/test/example_plugin.py
asv-0.6.6.dev78+gd59a3eff8/test/example_results/
asv-0.6.6.dev78+gd59a3eff8/test/example_results/benchmarks.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/05d283b9-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/05d4f83d-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/07d10557-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/0c2f4a1e-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/13dd6571-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/1726ce6e-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/2b12eec5-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/2dc898c9-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/302db689-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/38928c26-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/42100650-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/51b0b7e4-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/5ec73749-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/60cab3e8-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/623fc362-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/624da0aa-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/6c188c11-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/864ce870-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/8a997b01-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/a0954198-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/aaaaaaaa-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/b96fcc53-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/ba9b5125-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/bac1f64f-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/bb414fa5-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/bbbbbbbb-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/c1a0773e-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/cccccccc-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/ce87d43e-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/dccbdea1-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/e1434796-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/e29770c2-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/e54f8049-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/e5b6cdbc-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/e8679b2e-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/f5c0b8ed-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/faae7f3b-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8-foo.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/feea15ca-py2.7-Cython-numpy1.8.json
asv-0.6.6.dev78+gd59a3eff8/test/example_results/cheetah/machine.json
asv-0.6.6.dev78+gd59a3eff8/test/test_benchmarks.py
asv-0.6.6.dev78+gd59a3eff8/test/test_check.py
asv-0.6.6.dev78+gd59a3eff8/test/test_compare.py
asv-0.6.6.dev78+gd59a3eff8/test/test_conf.py
asv-0.6.6.dev78+gd59a3eff8/test/test_console.py
asv-0.6.6.dev78+gd59a3eff8/test/test_continuous.py
asv-0.6.6.dev78+gd59a3eff8/test/test_environment.py
asv-0.6.6.dev78+gd59a3eff8/test/test_environment_bench.py
asv-0.6.6.dev78+gd59a3eff8/test/test_feed.py
asv-0.6.6.dev78+gd59a3eff8/test/test_find.py
asv-0.6.6.dev78+gd59a3eff8/test/test_gh_pages.py
asv-0.6.6.dev78+gd59a3eff8/test/test_graph.py
asv-0.6.6.dev78+gd59a3eff8/test/test_machine.py
asv-0.6.6.dev78+gd59a3eff8/test/test_profile.py
asv-0.6.6.dev78+gd59a3eff8/test/test_publish.py
asv-0.6.6.dev78+gd59a3eff8/test/test_quickstart.py
asv-0.6.6.dev78+gd59a3eff8/test/test_repo.py
asv-0.6.6.dev78+gd59a3eff8/test/test_repo_template/
asv-0.6.6.dev78+gd59a3eff8/test/test_repo_template/README
asv-0.6.6.dev78+gd59a3eff8/test/test_repo_template/asv_test_repo/
asv-0.6.6.dev78+gd59a3eff8/test/test_repo_template/asv_test_repo/__init__.py
asv-0.6.6.dev78+gd59a3eff8/test/test_repo_template/setup.py
asv-0.6.6.dev78+gd59a3eff8/test/test_results.py
asv-0.6.6.dev78+gd59a3eff8/test/test_rm.py
asv-0.6.6.dev78+gd59a3eff8/test/test_run.py
asv-0.6.6.dev78+gd59a3eff8/test/test_runner.py
asv-0.6.6.dev78+gd59a3eff8/test/test_show.py
asv-0.6.6.dev78+gd59a3eff8/test/test_statistics.py
asv-0.6.6.dev78+gd59a3eff8/test/test_step_detect.py
asv-0.6.6.dev78+gd59a3eff8/test/test_subprocess.py
asv-0.6.6.dev78+gd59a3eff8/test/test_update.py
asv-0.6.6.dev78+gd59a3eff8/test/test_util.py
asv-0.6.6.dev78+gd59a3eff8/test/test_web.py
asv-0.6.6.dev78+gd59a3eff8/test/test_workflow.py
asv-0.6.6.dev78+gd59a3eff8/test/tools.py
$ 
```
</details>