### PR TITLE
ENH: Add free-threaded Python support

### DIFF
--- a/asv/_rangemedian.cpp
+++ b/asv/_rangemedian.cpp
@@ -92,12 +92,10 @@ private:
     };
 
     std::map<std::pair<size_t, size_t>, Item> items_;
-    mutable std::mutex mtx_;
 
 public:
     Cache() {};
     bool get(size_t left, size_t right, double *mu, double *dist) const {
-        std::lock_guard<std::mutex> lock(mtx_);
         auto it = items_.find(std::make_pair(left, right));
         if (it != items_.end()) {
             *mu = it->second.mu;
@@ -108,7 +106,6 @@ public:
     }
 
     void set(size_t left, size_t right, double mu, double dist) {
-        std::lock_guard<std::mutex> lock(mtx_);
         items_[std::make_pair(left, right)] = { mu, dist };
     }
 };
@@ -127,6 +124,9 @@ typedef struct {
     PyObject_HEAD
     std::vector<std::pair<double,double> > *y;
     Cache *cache;
+#ifdef Py_GIL_DISABLED
+    std::mutex *use_mtx;
+#endif
 } RangeMedianObject;
 
 #define RangeMedianObject_CAST(op)  ((RangeMedianObject *)(op))
@@ -136,10 +136,54 @@ PyObject *RangeMedian_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     RangeMedianObject *self;
     allocfunc rmalloc = (allocfunc)PyType_GetSlot(type, Py_tp_alloc);
     self = (RangeMedianObject*)rmalloc(type, 0);
+    if (self == NULL) {
+        return NULL;
+    }
     self->y = NULL;
     self->cache = NULL;
+#ifdef Py_GIL_DISABLED
+    self->use_mtx = NULL;
+    try {
+        self->use_mtx = new std::mutex();
+    }
+    catch (const std::bad_alloc&) {
+        PyErr_SetString(PyExc_MemoryError, "Allocating memory failed");
+        freefunc free = (freefunc)PyType_GetSlot(type, Py_tp_free);
+        free((PyObject*)self);
+        return NULL;
+    }
+#endif
     return (PyObject*)self;
 }
+
+
+#ifdef Py_GIL_DISABLED
+class RangeMedianUseGuard
+{
+private:
+    std::unique_lock<std::mutex> lock_;
+
+public:
+    explicit RangeMedianUseGuard(std::mutex *mtx) : lock_(*mtx, std::try_to_lock) {}
+
+    bool acquired() const {
+        return lock_.owns_lock();
+    }
+};
+
+static bool
+RangeMedian_try_acquire_use_lock(RangeMedianObject *self, RangeMedianUseGuard *guard)
+{
+    if (!guard->acquired()) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "RangeMedian objects cannot be used concurrently across threads"
+        );
+        return false;
+    }
+    return true;
+}
+#endif
 
 
 int RangeMedian_init(PyObject *op, PyObject *args, PyObject *kwds)
@@ -154,6 +198,13 @@ int RangeMedian_init(PyObject *op, PyObject *args, PyObject *kwds)
                                      &PyList_Type, &w_obj)) {
         return -1;
     }
+
+#ifdef Py_GIL_DISABLED
+    RangeMedianUseGuard guard(self->use_mtx);
+    if (!RangeMedian_try_acquire_use_lock(self, &guard)) {
+        return -1;
+    }
+#endif
 
     size = PyList_Size(y_obj);
     wsize = PyList_Size(w_obj);
@@ -230,6 +281,9 @@ static void RangeMedian_finalize(void *op)
     RangeMedianObject *self = RangeMedianObject_CAST(op);
     delete self->y;
     delete self->cache;
+#ifdef Py_GIL_DISABLED
+    delete self->use_mtx;
+#endif
 }
 
 
@@ -273,6 +327,14 @@ static PyObject *RangeMedian_mu(PyObject *op, PyObject *args)
         return NULL;
     }
 
+#ifdef Py_GIL_DISABLED
+    RangeMedianObject *self = RangeMedianObject_CAST(op);
+    RangeMedianUseGuard guard(self->use_mtx);
+    if (!RangeMedian_try_acquire_use_lock(self, &guard)) {
+        return NULL;
+    }
+#endif
+
     if (RangeMedian_mu_dist(op, left, right, &mu, &dist) == -1) {
         return NULL;
     }
@@ -289,6 +351,14 @@ static PyObject *RangeMedian_dist(PyObject *op, PyObject *args)
     if (!PyArg_ParseTuple(args, "nn", &left, &right)) {
         return NULL;
     }
+
+#ifdef Py_GIL_DISABLED
+    RangeMedianObject *self = RangeMedianObject_CAST(op);
+    RangeMedianUseGuard guard(self->use_mtx);
+    if (!RangeMedian_try_acquire_use_lock(self, &guard)) {
+        return NULL;
+    }
+#endif
 
     if (RangeMedian_mu_dist(op, left, right, &mu, &dist) == -1) {
         return NULL;
@@ -308,6 +378,13 @@ static PyObject *RangeMedian_find_best_partition(PyObject *op, PyObject *args)
     if (!PyArg_ParseTuple(args, "dnnnn", &gamma, &min_size, &max_size, &min_pos, &max_pos)) {
         return NULL;
     }
+
+#ifdef Py_GIL_DISABLED
+    RangeMedianUseGuard guard(self->use_mtx);
+    if (!RangeMedian_try_acquire_use_lock(self, &guard)) {
+        return NULL;
+    }
+#endif
 
     size = self->y->size();
 

--- a/asv/_rangemedian.cpp
+++ b/asv/_rangemedian.cpp
@@ -14,6 +14,7 @@
 #include <queue>
 #include <limits>
 #include <map>
+#include <mutex>
 #include <algorithm>
 #include <utility>
 
@@ -91,10 +92,12 @@ private:
     };
 
     std::map<std::pair<size_t, size_t>, Item> items_;
+    mutable std::mutex mtx_;
 
 public:
     Cache() {};
     bool get(size_t left, size_t right, double *mu, double *dist) const {
+        std::lock_guard<std::mutex> lock(mtx_);
         auto it = items_.find(std::make_pair(left, right));
         if (it != items_.end()) {
             *mu = it->second.mu;
@@ -105,6 +108,7 @@ public:
     }
 
     void set(size_t left, size_t right, double mu, double dist) {
+        std::lock_guard<std::mutex> lock(mtx_);
         items_[std::make_pair(left, right)] = { mu, dist };
     }
 };
@@ -159,12 +163,14 @@ int RangeMedian_init(PyObject *op, PyObject *args, PyObject *kwds)
         return -1;
     }
 
+    // Free any previous data from a prior __init__ call
+    delete self->y;
+    delete self->cache;
+    self->y = NULL;
+    self->cache = NULL;
+
     try {
         self->y = new std::vector<std::pair<double,double> >(size);
-
-        // Multiplier based on hardcoded constant sizes in step_detect.py, about
-        // this many accesses expected --- but prefer primes due to a modulo
-        // calculation in the cache.
         self->cache = new Cache();
     }
     catch (const std::bad_alloc&) {
@@ -418,6 +424,10 @@ static PyModuleDef_Slot rangemedian_slots[] = {
      * after the object was added to sys.modules)
      */
     {Py_mod_exec, (void *)rangemedian_modexec},
+
+#ifdef Py_mod_gil
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
 
     {0, NULL}
 };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ write_to = "asv/_version.py"
 
 [tool.cibuildwheel]
 free-threaded-support = true
+skip = ["cp313t-*"]
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,9 @@ quote-style = "preserve"
 [tool.setuptools_scm]
 write_to = "asv/_version.py"
 
+[tool.cibuildwheel]
+free-threaded-support = true
+
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"

--- a/test/test_step_detect.py
+++ b/test/test_step_detect.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import random
+import sysconfig
+import threading
 
 import pytest
 
@@ -249,6 +251,33 @@ def test_l1dist(use_rangemedian):
 
                 assert m == m2, (i, j)
                 assert abs(d - d2) < 1e-10, (i, j)
+
+
+@pytest.mark.skipif(
+    sysconfig.get_config_var("Py_GIL_DISABLED") != 1,
+    reason="test requires a free-threaded Python build",
+)
+def test_rangemedian_concurrent_use_fails_fast(use_rangemedian):
+    y = [float(j % 7) for j in range(2000)]
+    dist = step_detect.get_mu_dist(y, [1] * len(y))
+    barrier = threading.Barrier(4)
+    errors = []
+
+    def worker():
+        barrier.wait()
+        try:
+            dist.find_best_partition(0.1, 1, 200, 0, len(y))
+        except RuntimeError as exc:
+            errors.append(str(exc))
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors
+    assert all("cannot be used concurrently" in err for err in errors)
 
 
 def test_regression_threshold():


### PR DESCRIPTION
Declare `Py_mod_gil` with `Py_MOD_GIL_NOT_USED` so the extension does not force-enable the GIL on free-threaded builds.  The module holds no global mutable state (all data lives in per-object or per-module-state structs), so running without the GIL should be safe...

Enable free-threaded wheel builds in cibuildwheel so cp313t and cp314t wheels are published.

Closes #1515.