### PR TITLE
BUG: Fix asv rm python= filter (#1557)

### DIFF
--- a/asv/commands/rm.py
+++ b/asv/commands/rm.py
@@ -69,11 +69,13 @@ class Rm(Command):
                         found = False
                         break
                 elif key == 'python':
-                    if not fnmatchcase(result.env.python, val):
+                    py = result.python
+                    if py is None or not fnmatchcase(str(py), val):
                         found = False
                         break
                 else:
-                    if not fnmatchcase(result.params.get(key), val):
+                    param_val = result.params.get(key)
+                    if param_val is None or not fnmatchcase(str(param_val), val):
                         found = False
                         break
 

--- a/asv/results.py
+++ b/asv/results.py
@@ -775,6 +775,11 @@ class Results:
     def env_name(self):
         return self._env_name
 
+    @property
+    def python(self):
+        """Python version string for this result set (e.g. used by ``asv rm python=...``)."""
+        return self._python
+
     #
     # Old data format support
     #

--- a/changelog.d/1557.bugfix.rst
+++ b/changelog.d/1557.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``asv rm python=...`` raising ``AttributeError`` on ``Results`` (no ``env`` attribute).

--- a/test/test_rm.py
+++ b/test/test_rm.py
@@ -31,3 +31,33 @@ def test_rm(tmpdir, example_results):
 
     results_b = list(results.iter_results(tmpdir))
     assert len(results_b) == len(results_a) - 1
+
+
+def test_rm_python_filter(tmpdir, example_results):
+    """Regression for #1557: ``asv rm python=...`` must not use missing ``result.env``."""
+    tmpdir = str(tmpdir)
+    shutil.copytree(example_results, join(tmpdir, 'example_results'))
+
+    conf = config.Config.from_json(
+        {'results_dir': join(tmpdir, 'example_results'), 'repo': "### IGNORED, BUT REQUIRED ###"}
+    )
+
+    before = list(results.iter_results(join(tmpdir, 'example_results')))
+    assert before, "example_results fixture should yield results"
+
+    # Example results use python 2.7; pattern must match without AttributeError.
+    tools.run_asv_with_conf(conf, 'rm', '-y', 'python=2.7')
+
+    after = list(results.iter_results(join(tmpdir, 'example_results')))
+    assert len(after) < len(before)
+
+    # Non-matching version removes nothing (and still must not crash).
+    shutil.rmtree(join(tmpdir, 'example_results'))
+    shutil.copytree(example_results, join(tmpdir, 'example_results'))
+    conf = config.Config.from_json(
+        {'results_dir': join(tmpdir, 'example_results'), 'repo': "### IGNORED, BUT REQUIRED ###"}
+    )
+    n_before = len(list(results.iter_results(join(tmpdir, 'example_results'))))
+    tools.run_asv_with_conf(conf, 'rm', '-y', 'python=3.12')
+    n_after = len(list(results.iter_results(join(tmpdir, 'example_results'))))
+    assert n_after == n_before


### PR DESCRIPTION
## Summary

`asv rm python=...` failed to resolve the filter against stored results because the env key was not applied correctly. Resolve the `python=` filter without requiring `result.env` in the broken shape.

## Test plan

- [ ] CI green
- [ ] `asv rm python=3.x` removes matching results on a fixture machine

Fixes #1557