### PR TITLE
BUG: Keep parameterized names single-line in compare tables (#1393)

### DIFF
--- a/asv/commands/compare.py
+++ b/asv/commands/compare.py
@@ -26,6 +26,17 @@ def mean(values):
         return None
 
 
+def _format_param_for_display(param):
+    """
+    Format a benchmark parameter for single-line display (e.g. compare tables).
+
+    Parameter ``repr`` values can contain newlines (common for rich objects),
+    which break markdown/github tables produced by ``tabulate`` (#1393).
+    """
+    text = param if isinstance(param, str) else repr(param)
+    return ' '.join(text.split())
+
+
 def unroll_result(benchmark_name, params, *values):
     """
     Iterate through parameterized result values
@@ -53,7 +64,8 @@ def unroll_result(benchmark_name, params, *values):
         if params == ():
             name = benchmark_name
         else:
-            name = f"{benchmark_name}({', '.join(params)})"
+            formatted = [_format_param_for_display(p) for p in params]
+            name = f"{benchmark_name}({', '.join(formatted)})"
         yield (name,) + value
 
 

--- a/changelog.d/1393.bugfix.rst
+++ b/changelog.d/1393.bugfix.rst
@@ -1,0 +1,1 @@
+Collapse whitespace in parameterized benchmark names in ``asv compare`` output so multiline parameter reprs do not break GitHub-flavored markdown tables.

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -7,7 +7,7 @@ from os.path import abspath, dirname, join
 import pytest
 
 from asv import config, util
-from asv.commands.compare import Compare
+from asv.commands.compare import Compare, _format_param_for_display, unroll_result
 
 from . import tools
 
@@ -19,6 +19,26 @@ except ImportError:
 from .tools import WIN
 
 MACHINE_FILE = abspath(join(dirname(__file__), 'asv-machine.json'))
+
+
+def test_format_param_for_display_collapses_whitespace():
+    """Regression for #1393: multiline parameter repr must not break markdown tables."""
+    multiline = "AnnData(\n    obs: 'a'\n    var: 'b'\n)"
+    assert '\n' not in _format_param_for_display(multiline)
+    assert _format_param_for_display(multiline) == "AnnData( obs: 'a' var: 'b' )"
+
+    names = list(
+        n
+        for n, _ in unroll_result(
+            'suite.bench',
+            [[multiline]],
+            [1.0],
+        )
+    )
+    assert len(names) == 1
+    assert '\n' not in names[0]
+    assert names[0].startswith('suite.bench(')
+
 
 REFERENCE = """
 All benchmarks:


### PR DESCRIPTION
## Summary

Parameterized benchmark names in `asv compare` output could wrap across lines and break table alignment. Keep parameter names on a single line in compare tables.

## Test plan

- [ ] CI green
- [ ] Compare output for parameterized benchmarks stays single-line for names

Fixes #1393