### PR TITLE
DOCS: address open tracker documentation issues

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -75,10 +75,11 @@ class Run(Command):
         parser.add_argument(
             'range', nargs='?', default=None,
             help="""Range of commits to benchmark.  For a git
-            repository, this is passed as the first argument to ``git
-            rev-list``; or Mercurial log command. See 'specifying ranges'
-            section of the `gitrevisions` manpage, or 'hg help revisions',
-            for more info. Also accepts the
+            repository, this is passed to ``git rev-list --first-parent``
+            (so merge side history is omitted; not the same as plain
+            ``git log``).  For Mercurial, a revset is used. See
+            'specifying ranges' in the `gitrevisions` manpage, or
+            'hg help revisions', for more info. Also accepts the
             special values 'NEW', 'ALL', 'EXISTING', and 'HASHFILE:xxx'.
             'NEW' will benchmark all commits since the latest
             benchmarked on this machine.  'ALL' will benchmark all

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -3,6 +3,14 @@
 ``asv.conf.json`` reference
 ===========================
 
+The commented starter file shipped with ASV is
+``asv/template/asv.conf.json`` (copied by ``asv quickstart``).
+Prefer keeping that template and this reference page aligned when
+adding options; machine-readable schema validation (for example
+JSON Schema or pydantic models rendered into the docs) is desirable
+future work so the template cannot drift from documented keys.
+
+
 The ``asv.conf.json`` file contains information about a particular
 benchmarking project.  The following describes each of the keys in
 this file and their expected values.
@@ -125,6 +133,24 @@ number of cached builds retained at any time is determined by the
 The ``install_command`` and ``build_command`` are by default launched
 in ``{build_dir}``. The ``uninstall_command`` is launched in the
 environment root directory.
+
+Environment variables for build and install commands
+````````````````````````````````````````````````````
+
+Commands run with a copy of the **process environment** ASV was started
+with, plus ASV-defined variables (see :doc:`env_vars`) such as ``ASV``,
+``ASV_ENV_DIR``, ``ASV_BUILD_DIR``, and ``ASV_COMMIT``.  Matrix ``env`` /
+``env_nobuild`` entries are applied for the active environment combination.
+
+Therefore you can pass secrets and tokens **from the caller environment**
+without storing them in ``asv.conf.json``.  For example, export
+``POETRY_HTTP_BASIC_…`` or ``USER`` / ``PASSWORD`` in CI or your shell, and
+reference them from a build script or from a command that expands
+environment variables in the subprocess.  Prefer tool-specific env vars
+(Poetry, pip, conda) over embedding credentials in the JSON file.
+
+Do not rely on interactive prompts inside ``build_command``; non-interactive
+CI will hang or fail.
 
 The commands are specified in typical POSIX shell syntax (Python
 shlex), but are not run in a shell, so that e.g. ``cd`` has no effect

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -67,14 +67,17 @@ benchmark types:
 
 - ``pretty_source``: If given, used to display a custom version of the benchmark source.
 
-- ``version``: Used to determine when to invalidate old benchmark
-  results.  Benchmark results produced with a different value of the
-  version than the current value will be ignored.  The value can be
-  any Python string (or other object, ``str()`` will be taken).
+- ``version``: **Benchmark suite version** for this benchmark only (not
+  the project's release version and not the results-file API version).
+  Used to invalidate old measurements when the benchmark definition
+  changes.  Results recorded with a different ``version`` than the
+  current suite are ignored in compare/publish.  The value can be any
+  Python string (or other object; ``str()`` is taken).
 
   Default (if ``version=None`` or not given): hash of the source code
   of the benchmark function and setup and setup_cache methods. If the
   source code of any of these changes, old results become invalidated.
+  See also the note under :ref:`comparing` in :doc:`using`.
 
 - ``setup``: function to be called as a setup function for the benchmark
   See :ref:`setup-and-teardown` for discussion.
@@ -124,41 +127,52 @@ benchmark types:
 Timing benchmarks
 `````````````````
 
-- ``warmup_time``: ``asv`` will spend this time (in seconds) in calling
-  the benchmarked function repeatedly, before starting to run the actual
-  benchmark. If not specified, ``warmup_time`` defaults to 0.1 seconds
-  (on PyPy, the default is 1.0 sec).
+- ``warmup_time``: After the benchmark process starts (and after ``number``
+  is calibrated when applicable), ``asv`` spends this many **seconds**
+  calling the benchmarked function repeatedly **before** recorded samples.
+  Default is 0.1 seconds (1.0 on PyPy).  Warmup is per benchmark process,
+  not a separate outer loop over the whole suite.
 
-- ``rounds``: How many rounds to run the benchmark in (default: 2).
-  The rounds run different timing benchmarks in an interleaved order,
-  allowing to sample over longer periods of background performance
-  variations (e.g. CPU power levels).
+- ``rounds``: How many **interleaved rounds** to run this timing benchmark
+  in (default: 2).  In each round, ASV runs through the selected benchmarks
+  (with other timing benchmarks interleaved) so measurements span longer
+  periods of background variation (for example CPU power levels).  With a
+  single benchmark selected (``asv run -b …``), you still get ``rounds``
+  passes over that benchmark; you will not necessarily see ``rounds`` as a
+  separate user-visible "loop counter" in the UI.
 
-- ``repeat``: The number measurement samples to collect per round.
-  Each sample consists of running the benchmark ``number`` times.
-  The median time from all samples collected in all roudns is used
-  as the final measurement result.
+- ``repeat``: How many **measurement samples** to collect **per round**.
+  Each sample runs the benchmark function ``number`` times (see below);
+  ``setup`` / ``teardown`` run around each sample, not around each inner
+  iteration.  The median over samples (across rounds) is the reported time.
 
   ``repeat`` can be a tuple ``(min_repeat, max_repeat, max_time)``.
-  In this case, the measurement first collects at least ``min_repeat``
-  samples, and continues until either ``max_repeat`` samples are collected
-  or the collection time exceeds ``max_time``.
+  ASV collects at least ``min_repeat`` samples, then continues until
+  ``max_repeat`` samples or about ``max_time`` seconds of sampling, whichever
+  comes first.
 
-  When not provided (``repeat`` set to 0), the default value is
+  When not provided (``repeat`` set to 0), the default is
   ``(1, 10, 20.0)`` if ``rounds==1`` and ``(1, 5, 10.0)`` otherwise.
 
-- ``number``: Manually choose the number of iterations in each sample.
-  If ``number`` is specified, ``sample_time`` is ignored.
-  Note that ``setup`` and ``teardown`` are not run between iterations:
-  ``setup`` runs first, then the timed benchmark routine is called
-  ``number`` times, and after that ``teardown`` runs.
+- ``number``: Inner iterations **per sample** (timed together, then divided
+  by ``number``).  If set manually, ``sample_time`` is ignored.
+  ``setup`` runs once per sample, then the function is called ``number``
+  times, then ``teardown``.
 
-- ``sample_time``: ``asv`` will automatically select ``number`` so that
-  each sample takes approximately ``sample_time`` seconds.  If not
-  specified, ``sample_time`` defaults to 10 milliseconds.
+- ``sample_time``: Target duration **in seconds** for one sample (default
+  0.01, i.e. 10 ms).  When ``number`` is not set, ASV **calibrates**
+  ``number`` once in the benchmark process so that running the function
+  ``number`` times takes about ``sample_time`` seconds, then collects
+  samples with that ``number``.  Calibration runs are not the reported
+  result; they only choose ``number``.
 
-- ``min_run_count``: the function is run at least this many times during
-  benchmark. Default: 2
+- ``min_run_count``: Ensure the benchmark function body runs at least this
+  many times in total during the timing protocol (default: 2).  This is a
+  **floor on total invocations**, distinct from ``repeat``'s
+  ``min_repeat`` (minimum **samples** per round).  Use ``min_run_count``
+  when you need a minimum amount of work even if ``number`` calibration
+  would otherwise stay very small; use ``repeat`` / ``min_repeat`` to
+  control how many timed samples feed the median.
 
 - ``timer``: The timing function to use, which can be any source of
   monotonically increasing numbers, such as ``time.clock``, ``time.time``

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -208,9 +208,11 @@ A benchmark suite directory has the following layout.  The
 
           For non-parametrized benchmarks, ``[]``.
 
-        - ``version``: string, a benchmark version identifier.  Results whose version
-          is not equal to the current version of the benchmark are ignored.
-          If the value is missing, no version comparisons are done
+        - ``version``: string, **benchmark suite version** for that benchmark
+          (hash of benchmark source by default; see :ref:`benchmark-versioning`).
+          Not the project release version and not a global results-API field.
+          Results whose version is not equal to the current benchmark version
+          are ignored.  If the value is missing, no version comparisons are done
           (backward compatibility).
 
         - ``started_at``: Javascript timestamp indicating start time of latest

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -253,12 +253,20 @@ captured by a single run.  How to deal with this is discussed in :doc:`tuning`.
 
 The killer feature of **airspeed velocity** is that it can track the
 benchmark performance of your project over time.  The ``range``
-argument to ``asv run`` specifies a range of commits that should be
-benchmarked.  The value of this argument is passed directly to either ``git
-log`` or to the Mercurial log command to get the set of commits, so it actually
-has a very powerful syntax defined in the `gitrevisions manpage
-<https://www.kernel.org/pub/software/scm/git/docs/gitrevisions.html>`__, or the
-`revsets help section <http://www.selenic.com/hg/help/revsets>`_ for Mercurial.
+argument to ``asv run`` selects which commits are benchmarked.
+
+For **Git** repositories, the range is passed to ``git rev-list`` (not
+plain ``git log``), and ASV always adds ``--first-parent``.  That means
+only the first-parent history is walked: commits that are only on
+merged-in side branches are omitted, so ``asv run A..B`` often lists
+**fewer** commits than ``git log A..B``.  The range expression itself
+still follows the `gitrevisions
+<https://git-scm.com/docs/gitrevisions>`__ syntax (for example
+``main..mybranch``, ``v0.1..main``, ``HEAD^!`` for a single commit).
+
+For **Mercurial**, the range is interpreted with Mercurial revsets
+(`hg help revisions` / revsets); see Mercurial documentation for the
+full language.
 
 For example, in a Git repository, one can test a range of commits on a
 particular branch since branching off main::
@@ -577,13 +585,75 @@ Where different benchmarks may be used. A specific ``json`` may also be loaded
 directly with ``asv.results.Results.load(<json_path>)``, after which
 ``get_profile_stats`` can be used.
 
+
+.. _analyzing-results:
+
+Analyzing results (single commit, compare, profiles)
+----------------------------------------------------
+
+ASV is often introduced as a **history** tool (``asv run`` over many commits
+plus ``asv publish`` graphs), but the same result store supports **single
+revision** and **pair-wise** analysis without opening the web UI.
+
+Single commit
+`````````````
+
+- Run one revision only (Git)::
+
+      asv run HEAD^!
+      asv run v1.2.3^!
+
+- Print stored numbers for a revision (or branch tip) on the command line::
+
+      asv show HEAD
+      asv show main
+
+  See :ref:`viewing-results` and :ref:`cmd-asv-show`.
+
+- Continuous integration style check of **this commit vs another** (runs
+  benchmarks and compares) is ``asv continuous``; pair-wise display of
+  **already stored** results is ``asv compare`` (below).
+
+Comparing two result sets
+`````````````````````````
+
+- Tags or commits that already have results::
+
+      asv compare v0.1 v0.2
+      asv compare HASH1 HASH2
+
+- To compare **raw result files** or dig into machine/env dimensions, use
+  ``asv show`` per revision, or load JSON with ``asv.results.Results`` as in
+  the profiling section.  Full website tables come from ``asv publish`` then
+  ``asv preview``.
+
+Profiles
+````````
+
+Use ``asv profile`` for one benchmark at one commit, or ``asv run --profile``
+to attach cProfile data while measuring.  Details and GUI backends are in
+:ref:`Running a benchmark in the profiler` (below in this guide) and
+:ref:`cmd-asv-profile`.
+
+Result format migration
+```````````````````````
+
+On-disk result layout and column names are described in :doc:`dev` (directory
+structure and ``result_columns``).  When upgrading ASV, prefer regenerating
+HTML with ``asv publish``; if a results schema field is missing, ASV treats
+some fields as optional for backward compatibility (for example an absent
+benchmark ``version`` skips version filtering).  There is no separate
+end-user "v1 to v2" conversion command — keep the ``results/`` tree and
+upgrade the ASV install, then re-publish.
+
 .. _comparing:
 
 Comparing the benchmarking results for two revisions
 ----------------------------------------------------
 
 In some cases, you may want to directly compare the results for two specific
-revisions of the project. You can do so with the ``compare`` command::
+**project revisions** (Git commits or tags — not Python package versions).
+You can do so with the ``compare`` command::
 
     $ asv compare v0.1 v0.2
     All benchmarks:
@@ -612,6 +682,32 @@ are color coded). The threshold can be set with the
 into ones that have improved, stayed the same, and worsened, using the
 same threshold using the ``--split`` option.
 See :ref:`cmd-asv-compare` for more.
+
+.. note::
+
+   **Three different meanings of "version"** often appear in ASV output and
+   result files; they are easy to confuse:
+
+   1. **Project revision** — a Git commit, tag, or branch name passed to
+      ``asv run``, ``asv compare``, or shown as ``commit_hash`` / tag labels
+      (for example ``v0.1`` vs ``v0.2`` in ``asv compare v0.1 v0.2``).  This
+      is the generational axis ASV optimizes for.
+
+   2. **Benchmark suite version** — a per-benchmark identifier stored with
+      each measurement (default: hash of the benchmark source, including
+      ``setup`` / ``setup_cache``).  If you change the benchmark code, this
+      changes and ASV **ignores** older results for that benchmark so you
+      do not compare unlike measurements.  It is **not** your package's
+      PEP 440 version.  See :ref:`benchmark-versioning` and the ``version``
+      attribute in :doc:`benchmarks`.
+
+   3. **Results JSON API version** — a format version field in result files
+      under ``results/`` (see :doc:`dev`).  That versions the on-disk schema,
+      not the project or the benchmark code.
+
+   If ``asv compare`` marks benchmarks as not comparable, check (2) first:
+   the benchmark source (or explicit ``.version``) may have diverged between
+   the two revisions' recorded results.
 
 ASV also has a compare column which can be used to get a quick (and colorless)
 visual summary of benchmark results. This consists of a single ``mark`` where
@@ -658,3 +754,81 @@ each of its symbolic states can be understood as:
      - Better
 
 Additionally, statistically insignificant results have ``~`` in the ratio column as well.
+
+
+.. _non-python-and-cpp:
+
+Benchmarking C++ and other non-Python projects
+----------------------------------------------
+
+ASV's runner and result formats are Python-centric, but you can track **any**
+command-line benchmark whose primary metric you can turn into a number (or a
+dict of numbers) from Python.
+
+Recommended pattern:
+
+1. Keep building and installing the C++ (or other) project in
+   ``build_command`` / ``install_command`` (or install a wheel that embeds
+   binaries).  Use ``matrix`` / ``env`` entries for toolchains or flags when
+   needed.
+
+2. Write **Python benchmarks** that **invoke the binary** (subprocess) or call
+   a thin Python binding, and return timings via ``time_*`` or custom values
+   via ``track_*`` (see :doc:`writing_benchmarks` and :doc:`benchmarks`).
+
+3. For **multiple hardware targets**, use different ``asv machine`` names (or
+   separate result trees / machines in CI) and the same benchmark suite; the
+   web UI and ``asv compare`` are keyed by machine and environment labels.
+
+4. Prefer **stable command lines and inputs** inside ``setup`` /
+   ``setup_cache`` so process startup is not mixed into ``time_*`` unless that
+   is what you intend to measure.  For wall-clock of an external process,
+   set ``timer = timeit.default_timer`` on the benchmark when appropriate.
+
+ASV does not replace a hardware-in-the-loop harness; it stores and visualizes
+metrics you collect from the target (local subprocess, SSH, or simulator CLI
+wrapped in Python).
+
+.. _uv-and-lockfiles:
+
+Using ``uv`` and lockfiles
+-------------------------
+
+ASV does not replace your package manager's lockfile solver.  Environments are
+created by the configured ``environment_type`` (virtualenv, conda, mamba, …),
+then **build** / **install** commands run with substitutions such as
+``{build_dir}``, ``{env_dir}``, and ``{wheel_file}`` (see :doc:`asv.conf.json`).
+
+Common approaches:
+
+- **Build a wheel, install into the ASV env** (keeps ASV's env intact)::
+
+      "build_command": [
+          "python -m pip install uv",
+          "uv build . -o {build_cache_dir}"
+      ],
+      "install_command": [
+          "in-dir={env_dir} python -mpip install {wheel_file}"
+      ]
+
+  Or install with ``uv pip install`` **into** ``{env_dir}`` using that env's
+  interpreter.  This does **not** by itself apply ``uv.lock`` to the whole
+  environment.
+
+- **``uv sync`` against the project lockfile** can recreate the project env,
+  but it may **remove** packages ASV already installed into the managed
+  environment (including runner dependencies).  If you sync, use an approach
+  that preserves ASV's needs (for example an optional dependency group that
+  includes what the runner requires, or install the project with
+  ``uv pip install`` / ``uv sync`` in a way that does not wipe the env).
+  Treat lockfile fidelity and ASV's managed env as two constraints you must
+  reconcile explicitly.
+
+- Prefer documenting secrets and tokens via the **process environment** (see
+  build command environment variables in :doc:`asv.conf.json`), not in
+  ``asv.conf.json``.
+
+There is no single built-in ``environment_type`` that means "exactly this
+``uv.lock``" on all ASV versions; use custom commands as above, or a plugin
+backend if you maintain one.
+

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -382,19 +382,21 @@ Timing
 
 Timing benchmarks have the prefix ``time``.
 
-How ASV runs benchmarks is as follows (pseudocode for main idea)::
+How ASV runs benchmarks is as follows (pseudocode for the main idea)::
 
-     for round in range(`rounds`):
+     for round in range(rounds):           # interleaved with other benchmarks
         for benchmark in benchmarks:
             with new process:
-                <calibrate `number` if not manually set>
-                for j in range(`repeat`):
-                    <setup `benchmark`>
-                    sample = timing_function(<run benchmark `number` times>) / `number`
-                    <teardown `benchmark`>
+                calibrate number from sample_time if number is unset
+                spend about warmup_time calling the function (unrecorded)
+                for j in range(repeat):    # or adaptive (min_repeat, max_repeat, max_time)
+                    setup(benchmark)
+                    sample = timing_function(run function number times) / number
+                    teardown(benchmark)
+                # enforce min_run_count on total function invocations if needed
 
-where the actual ``rounds``, ``repeat``, and ``number`` are :doc:`attributes
-of the benchmark <benchmarks>`.
+where ``rounds``, ``repeat``, ``number``, ``sample_time``, ``warmup_time``,
+and ``min_run_count`` are :doc:`attributes of the benchmark <benchmarks>`.
 
 The default timing function is `timeit.default_timer`, which uses the
 highest resolution clock available on a given platform to measure the
@@ -568,6 +570,8 @@ garbage collector at a given state::
 For details, see :doc:`benchmarks`.
 
 
+.. _benchmark-versioning:
+
 Benchmark versioning
 --------------------
 
@@ -575,13 +579,14 @@ When you edit benchmark's code in the benchmark suite, this often
 changes what is measured, and previously measured results should be
 discarded.
 
-Airspeed Velocity records with each benchmark measurement a "version
-number" for the benchmark. By default, it is computed by hashing the
-benchmark source code text, including any ``setup`` and
-``setup_cache`` routines.  If there are changes in the source code of
-the benchmark in the benchmark suite, the version number changes, and
-``asv`` will ignore results whose version number is different from the
-current one.
+Airspeed Velocity records with each benchmark measurement a **benchmark
+suite version** string (attribute ``version`` on the benchmark).  This is
+**not** your project's package version and **not** the results JSON format
+version.  By default it is computed by hashing the benchmark source code
+text, including any ``setup`` and ``setup_cache`` routines.  If that source
+changes, the version string changes, and ``asv`` ignores older results for
+that benchmark (so ``asv compare`` does not mix incompatible definitions).
+Project revisions remain identified by commit hashes / tags.
 
 It is also possible to control the versioning of benchmark results
 manually, by setting the ``.version`` attribute for the benchmark. The


### PR DESCRIPTION
## Summary


| Issue | What this PR does |
|-------|-------------------|
| [#956](https://github.com/airspeed-velocity/asv/issues/956) | `asv run` range uses `git rev-list --first-parent`, not plain `git log` |
| [#1456](https://github.com/airspeed-velocity/asv/issues/1456) | Project revision vs benchmark suite `version` vs results JSON fields |
| [#1458](https://github.com/airspeed-velocity/asv/issues/1458) | Single-commit analysis, compare, profiles, publish/format notes |
| [#1355](https://github.com/airspeed-velocity/asv/issues/1355) | Build/install inherit process env + ASV/`matrix` env (secrets out of JSON) |
| [#1361](https://github.com/airspeed-velocity/asv/issues/1361) | Recommended C++ / non-Python pattern (subprocess / `track_*`, machines) |
| [#1561](https://github.com/airspeed-velocity/asv/issues/1561) | `uv` wheel vs `uv sync` / lockfile caveats with managed envs |
| [#1213](https://github.com/airspeed-velocity/asv/issues/1213) | Timing attributes: warmup, `sample_time` calibration, `rounds`, `min_run_count` vs `repeat` |
| [#1430](https://github.com/airspeed-velocity/asv/issues/1430) | Point conf reference at `asv/template/asv.conf.json`; note future schema sync (no full pydantic port in this PR) |

## Test plan

- [ ] Review Sphinx pages: using, benchmarks, writing_benchmarks, asv.conf.json, dev
- [ ] `asv run --help` mentions `rev-list --first-parent`
- [ ] No behavioral code changes beyond CLI help string
