### PR TITLE
FIX: show compare --split section titles with --only-changed

### DIFF
--- a/asv/commands/compare.py
+++ b/asv/commands/compare.py
@@ -444,7 +444,10 @@ class Compare(Command):
             if len(bench[key]) == 0:
                 continue
 
-            if not only_changed:
+            # In --split mode always show section titles (including with
+            # --only-changed); non-split --only-changed keeps a flat table
+            # without the "All benchmarks:" banner (issue #885).
+            if split or not only_changed:
                 color_print("")
                 color_print(titles[key])
                 color_print("")

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -403,3 +403,21 @@ def test_compare_fixed_failures(capsys, tmpdir, example_results):
     )
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE_FIXED_FAIL.strip()
+
+
+def test_compare_split_only_changed_has_titles(capsys, tmpdir, example_results):
+    """Issue #885: --split must print group titles even with --only-changed."""
+    tmpdir = str(tmpdir)
+    os.chdir(tmpdir)
+    conf = config.Config.from_json(
+        {'results_dir': example_results,
+         'repo': tools.generate_test_repo(tmpdir).path,
+         'project': 'asv',
+         'environment_type': "shouldn't matter what"})
+    Compare.print_table(conf, '22b920c6', 'fcf8c079', factor=2, machine='cheetah',
+                        split=True, only_changed=True, sort='ratio',
+                        env_names=["py2.7-numpy1.8"])
+    text, err = capsys.readouterr()
+    assert "Benchmarks that have improved:" in text
+    assert "Benchmarks that have got worse:" in text
+    assert "time_units.time_unit_to" in text or "time_ci_small" in text


### PR DESCRIPTION
## Summary
`--split` no longer drops group titles when combined with `--only-changed` (issue #885).

## Test plan
- [x] `test_compare_split_only_changed_has_titles`
- [x] existing `test_compare`

**Draft — do not merge until reviewed.**
Fixes #885