### PR TITLE
FIX: use commit date for regression Atom feed updated field

### DIFF
--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -94,9 +94,9 @@ class Regressions(OutputPublisher):
 
         filename = os.path.join(conf.html_dir, 'regressions.xml')
 
-        # Determine publication date as the date when the benchmark
-        # was run --- if it is missing, use the date of the commit
-        run_timestamps = {}
+        # Map revisions to commit dates (results.date is the DVCS commit time).
+        # Feed entry updated timestamps use commit dates so re-running old
+        # history does not look like new regressions in feed readers (#938).
         revision_timestamps = {}
         for results in iter_results(conf.results_dir):
             if results.commit_hash not in revisions:
@@ -105,18 +105,6 @@ class Regressions(OutputPublisher):
                 continue
             revision = revisions[results.commit_hash]
             revision_timestamps[revision] = results.date
-
-            # Time when the benchmark was run
-            for benchmark_name, timestamp in results.started_at.items():
-                if timestamp is None:
-                    continue
-                key = (benchmark_name, revision)
-                run_timestamps[key] = timestamp
-
-            # Fallback to commit date
-            for benchmark_name in results.get_result_keys(benchmarks):
-                key = (benchmark_name, revision)
-                run_timestamps.setdefault(key, results.date)
 
         # Generate feed entries
         entries = []

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -128,10 +128,9 @@ class Regressions(OutputPublisher):
                     graph_params['p-' + k] = v
 
             for rev1, rev2, value1, value2 in jumps:
-                timestamps = (
-                    run_timestamps[benchmark_name, t] for t in (rev1, rev2) if t is not None
-                )
-                last_timestamp = max(timestamps)
+                # Feed entry "updated" must be the regression *commit* date
+                # (rev2), not the time the benchmarks were last run (#938).
+                last_timestamp = revision_timestamps[rev2]
 
                 updated = datetime.datetime.fromtimestamp(last_timestamp / 1000)
 

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -459,18 +459,18 @@ def test_regression_atom_feed(generate_result_dir):
     assert root.tag == '{http://www.w3.org/2005/Atom}feed'
     entries = root.findall('{http://www.w3.org/2005/Atom}entry')
 
-    # Check entry titles
+    # Check entry titles (sorted by regression commit date, newest first)
     assert len(entries) == 2
     title = entries[0].find('{http://www.w3.org/2005/Atom}title')
-    assert title.text == '900.00% time_func'
-    title = entries[1].find('{http://www.w3.org/2005/Atom}title')
     assert title.text == '50.00% time_func'
+    title = entries[1].find('{http://www.w3.org/2005/Atom}title')
+    assert title.text == '900.00% time_func'
 
     # Check there's a link of some sort to the website in the content
     content = entries[0].find('{http://www.w3.org/2005/Atom}content')
-    assert ('<a href="index.html#time_func?commits=' + commits[5]) in content.text
-    content = entries[1].find('{http://www.w3.org/2005/Atom}content')
     assert ('<a href="index.html#time_func?commits=' + commits[10]) in content.text
+    content = entries[1].find('{http://www.w3.org/2005/Atom}content')
+    assert ('<a href="index.html#time_func?commits=' + commits[5]) in content.text
 
     # Smoke check ids
     id_1 = entries[0].find('{http://www.w3.org/2005/Atom}id')


### PR DESCRIPTION
## Summary
Regression feed entry `updated` uses the regression commit date, not the last run timestamp, so re-measuring history does not reappear as new feed items (issue #938).

## Test plan
- [x] `test/test_feed.py` (atom writer unchanged)
- [ ] Manual: publish with regressions.xml and check entry dates

**Draft — do not merge until reviewed.**
Fixes #938