### PR TITLE
FIX: avoid matrix key benchmark clobbering web UI params

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -17,6 +17,11 @@ from asv.publishing import OutputPublisher
 from asv.repo import get_repo
 from asv.results import iter_results
 
+# URL / graphdisplay query keys (asv/www); matrix packages must not reuse these
+GRAPH_UI_RESERVED_PARAMS = frozenset({
+    'benchmark', 'commits', 'y-axis-scale', 'x-axis-scale', 'show-legend',
+})
+
 
 def check_benchmark_params(name, benchmark):
     """
@@ -216,6 +221,17 @@ class Publish(Command):
 
                     for branch in branches_for_commit:
                         cur_params = dict(results.params)
+                        # Matrix requirement names become graph params; rename
+                        # reserved UI keys (e.g. package "benchmark") so the
+                        # HTML viewer does not treat them as the benchmark id
+                        # (issue #819).
+                        for reserved in GRAPH_UI_RESERVED_PARAMS:
+                            if reserved in cur_params:
+                                cur_params[f'req-{reserved}'] = cur_params.pop(reserved)
+                                log.warning(
+                                    f"Matrix/result parameter {reserved!r} is reserved "
+                                    f"in the web UI; published as 'req-{reserved}'"
+                                )
                         cur_env = {f'env-{name}': val for name, val in results.env_vars.items()}
                         cur_params.update(cur_env)
                         cur_params['branch'] = repo.get_branch_name(branch)

--- a/asv/config.py
+++ b/asv/config.py
@@ -44,6 +44,11 @@ class Config:
 
     api_version = 1
 
+    # Matrix package names that collide with web UI URL params (see publish.py)
+    GRAPH_UI_RESERVED_MATRIX_KEYS = frozenset({
+        'benchmark', 'commits', 'y-axis-scale', 'x-axis-scale', 'show-legend',
+    })
+
     def __init__(self):
         self.project = "project"
         self.project_url = "#"
@@ -111,5 +116,15 @@ class Config:
             # If 'branches' attribute is present, at least some must
             # be listed.
             raise util.UserError("No branches specified in config file.")
+
+        matrix = getattr(conf, "matrix", None) or {}
+        reserved = set(matrix) & cls.GRAPH_UI_RESERVED_MATRIX_KEYS
+        if reserved:
+            log.warning(
+                "Matrix keys %s are reserved by the results web UI (for example "
+                "the benchmark page id). Prefer a different requirement name, "
+                "or expect publish to rename them to 'req-<name>' (issue #819)."
+                % (sorted(reserved),)
+            )
 
         return conf

--- a/test/test_matrix_reserved_keys.py
+++ b/test/test_matrix_reserved_keys.py
@@ -1,0 +1,17 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from asv.config import Config
+from asv.commands.publish import GRAPH_UI_RESERVED_PARAMS
+
+
+def test_reserved_matrix_keys_constant():
+    assert 'benchmark' in Config.GRAPH_UI_RESERVED_MATRIX_KEYS
+    assert 'benchmark' in GRAPH_UI_RESERVED_PARAMS
+
+
+def test_config_loads_with_benchmark_matrix_key():
+    conf = Config.from_json({
+        'repo': '.',
+        'project': 'x',
+        'matrix': {'benchmark': ['1.4.1'], 'numpy': []},
+    })
+    assert 'benchmark' in conf.matrix


### PR DESCRIPTION
## Summary
Matrix/result parameter `benchmark` (and other UI-reserved keys) is warned at config load and renamed to `req-<name>` when publishing graphs so the HTML viewer does not drop benchmarks (issue #819).

## Test plan
- [x] `test/test_matrix_reserved_keys.py`

**Draft — do not merge until reviewed.**
Fixes #819