### PR TITLE
docs: clarify setup vs number for timing benchmarks

### DIFF
--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -162,15 +162,18 @@ Timing benchmarks
   If ``number`` is specified, ``sample_time`` is ignored.
   Note that ``setup`` and ``teardown`` are not run between those
   iterations: ``setup`` runs first, then the timed benchmark routine is
-  called ``number`` times, and after that ``teardown`` runs.
-  When a benchmark defines ``setup()``, the runner forces ``number=1``
-  so state restored in ``setup`` is not reused across timed calls
-  (asv#966).
+  called ``number`` times, and after that ``teardown`` runs.  State
+  mutated by one iteration is therefore visible to the next; set
+  ``number = 1`` when each timed call needs freshly set-up state.
 
 - ``sample_time``: ``asv`` will automatically select ``number`` so that
   each sample takes approximately ``sample_time`` seconds.  If not
-  specified, ``sample_time`` defaults to 10 milliseconds.  Auto
-  selection is skipped when ``setup()`` is present (``number`` stays 1).
+  specified, ``sample_time`` defaults to 10 milliseconds.  When a
+  benchmark defines a ``setup`` hook, automatic selection keeps
+  ``number`` at 1 (asv_runner 0.3.0+) so state restored in ``setup`` is
+  not reused across timed calls (`asv#966
+  <https://github.com/airspeed-velocity/asv/issues/966>`__); an
+  explicitly set ``number`` overrides this.
 
 - ``min_run_count``: the function is run at least this many times during
   benchmark. Default: 2

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -160,11 +160,11 @@ Timing benchmarks
 
 - ``number``: Manually choose the number of iterations in each sample.
   If ``number`` is specified, ``sample_time`` is ignored.
-  Note that ``setup`` and ``teardown`` are not run between those
-  iterations: ``setup`` runs first, then the timed benchmark routine is
-  called ``number`` times, and after that ``teardown`` runs.  State
-  mutated by one iteration is therefore visible to the next; set
-  ``number = 1`` when each timed call needs freshly set-up state.
+  When the benchmark has no ``setup`` hook, the timed routine is simply
+  called ``number`` times back-to-back.  With a ``setup`` hook present
+  (asv_runner 0.3.0+), ``setup`` and ``teardown`` re-run between the
+  iterations and only the calls themselves are timed, so every timed
+  call observes freshly set-up state.
 
 - ``sample_time``: ``asv`` will automatically select ``number`` so that
   each sample takes approximately ``sample_time`` seconds.  If not
@@ -173,7 +173,8 @@ Timing benchmarks
   ``number`` at 1 (asv_runner 0.3.0+) so state restored in ``setup`` is
   not reused across timed calls (`asv#966
   <https://github.com/airspeed-velocity/asv/issues/966>`__); an
-  explicitly set ``number`` overrides this.
+  explicitly set ``number`` still batches, with ``setup`` re-run
+  between the timed calls.
 
 - ``min_run_count``: the function is run at least this many times during
   benchmark. Default: 2

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -160,13 +160,17 @@ Timing benchmarks
 
 - ``number``: Manually choose the number of iterations in each sample.
   If ``number`` is specified, ``sample_time`` is ignored.
-  Note that ``setup`` and ``teardown`` are not run between iterations:
-  ``setup`` runs first, then the timed benchmark routine is called
-  ``number`` times, and after that ``teardown`` runs.
+  Note that ``setup`` and ``teardown`` are not run between those
+  iterations: ``setup`` runs first, then the timed benchmark routine is
+  called ``number`` times, and after that ``teardown`` runs.
+  When a benchmark defines ``setup()``, the runner forces ``number=1``
+  so state restored in ``setup`` is not reused across timed calls
+  (asv#966).
 
 - ``sample_time``: ``asv`` will automatically select ``number`` so that
   each sample takes approximately ``sample_time`` seconds.  If not
-  specified, ``sample_time`` defaults to 10 milliseconds.
+  specified, ``sample_time`` defaults to 10 milliseconds.  Auto
+  selection is skipped when ``setup()`` is present (``number`` stays 1).
 
 - ``min_run_count``: the function is run at least this many times during
   benchmark. Default: 2

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -151,15 +151,14 @@ as skipped.
       they are faster and do not execute the ``setup`` function. See
       :ref:`skipping-benchmarks` for more details.
 
-The ``setup`` method is run for each benchmark sample (each
-``repeat``), not between the inner ``number`` timed iterations within a
-sample.  If your timed code mutates state that ``setup`` restores, set
-``number = 1``, or leave ``number`` unset: with a ``setup`` present,
-automatic ``number`` selection keeps it at 1 (asv_runner 0.3.0+), so
-each sample is a single call.  An explicitly set ``number`` larger than
-1 shares state across the calls within a sample.  Benchmarks whose
-``setup`` only builds inputs keep automatic batching by moving that
-work to ``setup_cache``.  See :ref:`timing-benchmarks` and `asv#966
+The ``setup`` method is run multiple times, for each benchmark and for
+each repeat.  For timing benchmarks it also runs before every timed
+call (asv_runner 0.3.0+): automatic ``number`` selection keeps
+``number`` at 1, and an explicitly set larger ``number`` re-runs
+``setup`` between the individually timed calls, at the cost of two
+extra clock reads per call.  Benchmarks whose ``setup`` only builds
+inputs keep plain ``timeit`` batching by moving that work to
+``setup_cache``.  See :ref:`timing-benchmarks` and `asv#966
 <https://github.com/airspeed-velocity/asv/issues/966>`__.
 
 If the ``setup`` is especially expensive, the ``setup_cache`` method

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -153,10 +153,14 @@ as skipped.
 
 The ``setup`` method is run for each benchmark sample (each
 ``repeat``), not between the inner ``number`` timed iterations within a
-sample.  If your timed code mutates state that ``setup`` restores,
-leave ``number`` unset or ``1`` (with a ``setup`` present, the runner
-forces ``number=1`` so each sample is a single call).  See
-:ref:`timing-benchmarks` and asv#966.
+sample.  If your timed code mutates state that ``setup`` restores, set
+``number = 1``, or leave ``number`` unset: with a ``setup`` present,
+automatic ``number`` selection keeps it at 1 (asv_runner 0.3.0+), so
+each sample is a single call.  An explicitly set ``number`` larger than
+1 shares state across the calls within a sample.  Benchmarks whose
+``setup`` only builds inputs keep automatic batching by moving that
+work to ``setup_cache``.  See :ref:`timing-benchmarks` and `asv#966
+<https://github.com/airspeed-velocity/asv/issues/966>`__.
 
 If the ``setup`` is especially expensive, the ``setup_cache`` method
 may be used instead, which only performs the setup calculation once
@@ -398,7 +402,8 @@ How ASV runs benchmarks is as follows (pseudocode for main idea)::
      for round in range(`rounds`):
         for benchmark in benchmarks:
             with new process:
-                <calibrate `number` if not manually set>
+                <calibrate `number` if not manually set;
+                 kept at 1 when a `setup` hook exists>
                 for j in range(`repeat`):
                     <setup `benchmark`>
                     sample = timing_function(<run benchmark `number` times>) / `number`

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -151,13 +151,18 @@ as skipped.
       they are faster and do not execute the ``setup`` function. See
       :ref:`skipping-benchmarks` for more details.
 
-The ``setup`` method is run multiple times, for each benchmark and for
-each repeat.  If the ``setup`` is especially expensive, the
-``setup_cache`` method may be used instead, which only performs the
-setup calculation once and then caches the result to disk.  It is run
-only once also for repeated benchmarks and profiling, unlike
-``setup``.  ``setup_cache`` can persist the data for the benchmarks it
-applies to in two ways:
+The ``setup`` method is run for each benchmark sample (each
+``repeat``), not between the inner ``number`` timed iterations within a
+sample.  If your timed code mutates state that ``setup`` restores,
+leave ``number`` unset or ``1`` (with a ``setup`` present, the runner
+forces ``number=1`` so each sample is a single call).  See
+:ref:`timing-benchmarks` and asv#966.
+
+If the ``setup`` is especially expensive, the ``setup_cache`` method
+may be used instead, which only performs the setup calculation once
+and then caches the result to disk.  It is run only once also for
+repeated benchmarks and profiling, unlike ``setup``.  ``setup_cache``
+can persist the data for the benchmarks it applies to in two ways:
 
 - Returning a data structure, which ``asv`` pickles to disk, and
   then loads and passes it as the first argument to each benchmark.


### PR DESCRIPTION
## Summary

Docs for asv#966: `setup` runs per sample, not between `number` timed
calls; with a setup present the runner keeps `number=1`.

Companion: airspeed-velocity/asv_runner#53

## Test plan

- [ ] Docs build (Sphinx)