### PR TITLE
[project.optional-dependencies] → [dependency-groups]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,8 @@ jobs:
       - name: Setup a browser for more tests
         uses: browser-actions/setup-chrome@latest
 
-      - name: Install dependencies (with --pre)
-        run: python -m pip install ".[test,hg,envs]" --pre
-
-      - name: Install asv
-        run: pip install .
+      - name: Install asv with test, hg, and envs groups (with --pre)
+        run: python -m pip install -e . --group test --group hg --group envs --pre
 
       - name: Run tests
         run: python -m pytest -v --timeout=300 --webdriver=ChromeHeadless --durations=100 test
@@ -79,12 +76,8 @@ jobs:
             py_rattler
             conda-build
 
-      - name: Install dependencies
-        run: python -m pip install ".[test,hg,envs]" --pre
-        shell: micromamba-shell {0}
-
-      - name: Install asv
-        run: pip install .
+      - name: Install asv with test, hg, and envs groups (with --pre)
+        run: python -m pip install -e . --group test --group hg --group envs --pre
         shell: micromamba-shell {0}
 
       - name: Run tests
@@ -102,8 +95,8 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Install asv
-        run: pip install ".[doc]"
+      - name: Install asv with doc group
+        run: python -m pip install -e . --group doc
 
       - name: Build docs
         run: sphinx-build -W docs/source html

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install and test
         shell: pwsh
         run: |
-          python.exe -m pip install .[test,envs]
+          python.exe -m pip install -e . --group test --group envs
           python.exe -m pip install packaging
           python.exe -m pytest -v -l -x --timeout=300 --durations=100 test --environment-type=rattler
 
@@ -58,12 +58,8 @@ jobs:
             py_rattler
             conda-build
 
-      - name: Install dependencies
-        run: python -m pip install ".[test,hg,envs]" --pre
-        shell: pwsh
-
-      - name: Install asv
-        run: pip install .
+      - name: Install asv with test, hg, and envs groups (with --pre)
+        run: python -m pip install -e . --group test --group hg --group envs --pre
         shell: pwsh
 
       - name: Run tests

--- a/.github/workflows/triggered.yml
+++ b/.github/workflows/triggered.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Setup a browser for more tests
         uses: browser-actions/setup-chrome@latest
 
-      - name: Install asv[test,hg,envs]
-        run: python -m pip install -U pip && python -m pip install ".[test,hg,envs]"
+      - name: Install asv with test, hg, and envs groups
+        run: python -m pip install -U pip && python -m pip install -e . --group test --group hg --group envs
 
       - name: Get asv_runner PR head to be tested
         if: matrix.runner_source == 'pr'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Documentation = "https://asv.readthedocs.io/en/stable/"
 [project.scripts]
 asv = "asv.__main__:main"
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
     "pytest",
     "pytest-xdist",


### PR DESCRIPTION
Apply PEP 735 to package requirements in `pyproject.toml`.

- Rename `[project.optional-dependencies]` to `[dependency-groups]` in `pyproject.toml`
- Update GitHub workflows to use `pip install --group` syntax