### PR TITLE
Fix quick percent logic

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -451,12 +451,14 @@ class Run(Command):
             + ")"
         )
 
-        log.set_nitems(steps * max_rounds)
-
+        progress_rounds = max_rounds
         if interleave_rounds:
             run_round_set = [[j] for j in range(max_rounds, 0, -1)]
         else:
             run_round_set = [None]
+            if quick:
+                progress_rounds = 1
+        log.set_nitems(steps * progress_rounds)
 
         if launch_method is None:
             # Allow the users to set the launch_method by the command line argument

--- a/changelog.d/+quick_progress.bugfix.rst
+++ b/changelog.d/+quick_progress.bugfix.rst
@@ -1,0 +1,4 @@
+``asv run --quick`` no longer stops the progress report short of 100%. ``--quick``
+forces one round per benchmark, but the progress total was still scaled by the
+benchmarks' declared ``rounds``, so a completed run capped at 50% with the default
+of two rounds.

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -507,6 +507,24 @@ def test_run_python_same(capsys, basic_conf):
     assert "Installing" not in text
 
 
+def test_run_quick_progress_completes(capsys, existing_env_conf):
+    tmpdir, local, conf, machine_file = existing_env_conf
+
+    tools.run_asv_with_conf(
+        conf,
+        'run',
+        '--quick',
+        '--bench=time_secondary.TimeSecondary.time_factorial',
+        '--bench=time_secondary.track_value',
+        _machine_file=join(tmpdir, 'asv-machine.json'),
+    )
+    text, err = capsys.readouterr()
+
+    # --quick forces rounds=1, so the progress total must not be scaled by the
+    # benchmarks' declared rounds
+    assert "[100.00%]" in text
+
+
 def test_run_python_arg():
     parser, subparsers = make_argparser()
 


### PR DESCRIPTION
Jobs like [this one in SciPy](https://app.circleci.com/pipelines/github/scipy/scipy/42415/workflows/a4325292-584b-484f-a579-88e745d52a16/jobs/149732) fail "at 50%" because the logic for `--quick` when not in `interleave_rounds` mode. Really they fail at the end of the run.

Investigated and drafted changes with Claude Opus 5 but I understand all the code.