### PR TITLE
Add failure summary to the end of the run

### DIFF
--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -14,7 +14,7 @@ from ..console import log
 from ..machine import Machine
 from ..repo import NoSuchNameError, get_repo
 from ..results import Results, get_existing_hashes, iter_results_for_machine_and_hash
-from ..runner import run_benchmarks, skip_benchmarks
+from ..runner import JSON_ERROR_RETCODE, run_benchmarks, skip_benchmarks
 from . import Command, common_args
 from .setup import Setup
 from .show import Show
@@ -310,6 +310,8 @@ class Run(Command):
 
         # Track failures across the run command
         failures = False
+        failed_benchmarks = []
+        failed_builds = []
 
         # Comparison period for date_period filtering
         old_commit_hashes = None
@@ -611,7 +613,19 @@ class Run(Command):
                         if not skip_save:
                             result.save(conf.results_dir)
 
-                        failures = failures or any(code != 0 for code in result.errcode.values())
+                        failed = {
+                            name: code for name, code in result.errcode.items() if code != 0
+                        }
+                        if failed:
+                            failures = True
+                            if success:
+                                failed_benchmarks.extend(
+                                    (commit_hash, env.name, name, code)
+                                    for name, code in sorted(failed.items())
+                                )
+                            else:
+                                # a failed build fails every benchmark; report it once
+                                failed_builds.append((commit_hash, env.name))
 
                         if durations > 0:
                             duration_set = Show._get_durations([(machine, result)], benchmark_set)
@@ -620,7 +634,38 @@ class Run(Command):
                             )
 
         if failures:
+            log.info(
+                cls.format_failures(
+                    failed_benchmarks,
+                    failed_builds,
+                    show_context=len(commit_hashes) > 1 or len(environments) > 1,
+                ),
+                color='red',
+            )
             return 2
+
+    @classmethod
+    def format_failures(cls, failed_benchmarks, failed_builds, show_context=False):
+        """Summarize failures, so they are greppable without the whole run log."""
+
+        def context(commit_hash, env_name):
+            if not show_context:
+                return ""
+            commit = f"{commit_hash[:8]} " if commit_hash else ""
+            return f" [{commit}{env_name}]"
+
+        lines = [f"Failures ({len(failed_builds) + len(failed_benchmarks)}):"]
+        for commit_hash, env_name in failed_builds:
+            lines.append(f"  FAILED build{context(commit_hash, env_name)}")
+        for commit_hash, env_name, name, code in failed_benchmarks:
+            if code == util.TIMEOUT_RETCODE:
+                reason = "timed out"
+            elif code == JSON_ERROR_RETCODE:
+                reason = "invalid benchmark result"
+            else:
+                reason = f"exit status {code}"
+            lines.append(f"  FAILED {name}{context(commit_hash, env_name)} -- {reason}")
+        return "\n".join(lines)
 
     @classmethod
     def format_durations(cls, durations, num_durations):

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -308,10 +308,12 @@ class Run(Command):
         if set_commit_hash is not None:
             set_commit_hash = repo.get_hash_from_name(set_commit_hash)
 
-        # Track failures across the run command
+        # Track failures across the run command. Interleaved rounds revisit each
+        # (commit, env) once per round and errcode is not reloaded from disk, so
+        # key these to report a persistently failing benchmark only once.
         failures = False
-        failed_benchmarks = []
-        failed_builds = []
+        failed_benchmarks = {}
+        failed_builds = {}
 
         # Comparison period for date_period filtering
         old_commit_hashes = None
@@ -613,19 +615,15 @@ class Run(Command):
                         if not skip_save:
                             result.save(conf.results_dir)
 
-                        failed = {
-                            name: code for name, code in result.errcode.items() if code != 0
-                        }
+                        failed = {name: code for name, code in result.errcode.items() if code != 0}
                         if failed:
                             failures = True
                             if success:
-                                failed_benchmarks.extend(
-                                    (commit_hash, env.name, name, code)
-                                    for name, code in sorted(failed.items())
-                                )
+                                for name, code in failed.items():
+                                    failed_benchmarks[commit_hash, env.name, name] = code
                             else:
                                 # a failed build fails every benchmark; report it once
-                                failed_builds.append((commit_hash, env.name))
+                                failed_builds[commit_hash, env.name] = None
 
                         if durations > 0:
                             duration_set = Show._get_durations([(machine, result)], benchmark_set)
@@ -655,9 +653,9 @@ class Run(Command):
             return f" [{commit}{env_name}]"
 
         lines = [f"Failures ({len(failed_builds) + len(failed_benchmarks)}):"]
-        for commit_hash, env_name in failed_builds:
+        for commit_hash, env_name in sorted(failed_builds):
             lines.append(f"  FAILED build{context(commit_hash, env_name)}")
-        for commit_hash, env_name, name, code in failed_benchmarks:
+        for (commit_hash, env_name, name), code in sorted(failed_benchmarks.items()):
             if code == util.TIMEOUT_RETCODE:
                 reason = "timed out"
             elif code == JSON_ERROR_RETCODE:

--- a/changelog.d/+failure_summary.feat.rst
+++ b/changelog.d/+failure_summary.feat.rst
@@ -1,0 +1,5 @@
+``asv run`` now prints a summary of failed benchmarks at the end of the run, in the
+style of ``pytest``'s short test summary (#1201). Failures were previously only visible
+at the point they occurred, which is easy to miss in a long log and is often truncated
+away entirely by CI log size limits. A failed build is reported once rather than once
+per benchmark.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -224,6 +224,12 @@ def basic_conf(tmpdir, dummy_packages):
 
 
 @pytest.fixture
+def basic_conf_no_packages(tmpdir):
+    """A real (non-existing) environment, without the dummy-package matrix."""
+    return generate_basic_conf(tmpdir, dummy_packages=False)
+
+
+@pytest.fixture
 def basic_conf_2(tmpdir, dummy_packages):
     return generate_basic_conf(tmpdir, conf_version=2)
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -5,6 +5,7 @@ import glob
 import os
 import re
 import shutil
+import sys
 import textwrap
 from os.path import join
 
@@ -505,6 +506,50 @@ def test_run_python_same(capsys, basic_conf):
     # Check that it did not clone or install
     assert "Cloning" not in text
     assert "Installing" not in text
+
+
+def test_run_failure_summary(capsys, existing_env_conf):
+    tmpdir, local, conf, machine_file = existing_env_conf
+
+    tools.run_asv_with_conf(
+        conf,
+        'run',
+        '--bench=time_secondary.TimeSecondary.time_exception',
+        '--bench=time_secondary.track_value',
+        _machine_file=join(tmpdir, 'asv-machine.json'),
+    )
+    text, err = capsys.readouterr()
+
+    # the console indents continuation lines, so compare without it
+    summary = [line.strip() for line in text[text.index("Failures ("):].strip().splitlines()]
+    assert summary == [
+        "Failures (1):",
+        "FAILED time_secondary.TimeSecondary.time_exception -- exit status 1",
+    ]
+
+
+def test_run_failure_summary_multiple_environments(capsys, existing_env_conf):
+    tmpdir, local, conf, machine_file = existing_env_conf
+
+    tools.run_asv_with_conf(
+        conf,
+        'run',
+        '-E', 'existing:same',
+        '-E', f'existing:{sys.executable}',
+        '--bench=time_secondary.TimeSecondary.time_exception',
+        _machine_file=join(tmpdir, 'asv-machine.json'),
+    )
+    text, err = capsys.readouterr()
+
+    # more than one environment, so each failure is tagged with the one it came from
+    summary = [line.strip() for line in text[text.index("Failures ("):].strip().splitlines()]
+    assert summary[0] == "Failures (2):"
+    assert all(
+        re.fullmatch(
+            r"FAILED time_secondary\.TimeSecondary\.time_exception \[\S+\] -- exit status 1", line
+        )
+        for line in summary[1:]
+    ), summary
 
 
 def test_run_python_arg():

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -5,7 +5,6 @@ import glob
 import os
 import re
 import shutil
-import sys
 import textwrap
 from os.path import join
 
@@ -521,35 +520,66 @@ def test_run_failure_summary(capsys, existing_env_conf):
     text, err = capsys.readouterr()
 
     # the console indents continuation lines, so compare without it
-    summary = [line.strip() for line in text[text.index("Failures ("):].strip().splitlines()]
+    summary = [line.strip() for line in text[text.index("Failures (") :].strip().splitlines()]
     assert summary == [
         "Failures (1):",
         "FAILED time_secondary.TimeSecondary.time_exception -- exit status 1",
     ]
 
 
-def test_run_failure_summary_multiple_environments(capsys, existing_env_conf):
-    tmpdir, local, conf, machine_file = existing_env_conf
+def test_run_failure_summary_multiple_environments(capsys, basic_conf_no_packages):
+    tmpdir, local, conf, machine_file = basic_conf_no_packages
+
+    # an env matrix gives two genuinely distinct environments cheaply; passing the
+    # same interpreter twice would collapse, as both specs yield one env name
+    conf.matrix = {"env": {"SOME_TEST_VAR": ["1", "2"]}}
 
     tools.run_asv_with_conf(
         conf,
         'run',
-        '-E', 'existing:same',
-        '-E', f'existing:{sys.executable}',
+        f"{util.git_default_branch()}^!",
+        '--quick',
         '--bench=time_secondary.TimeSecondary.time_exception',
-        _machine_file=join(tmpdir, 'asv-machine.json'),
+        _machine_file=machine_file,
     )
     text, err = capsys.readouterr()
 
     # more than one environment, so each failure is tagged with the one it came from
-    summary = [line.strip() for line in text[text.index("Failures ("):].strip().splitlines()]
-    assert summary[0] == "Failures (2):"
-    assert all(
-        re.fullmatch(
-            r"FAILED time_secondary\.TimeSecondary\.time_exception \[\S+\] -- exit status 1", line
+    summary = [line.strip() for line in text[text.index("Failures (") :].strip().splitlines()]
+    assert summary[0] == "Failures (2):", summary
+    tags = set()
+    for line in summary[1:]:
+        match = re.fullmatch(
+            r"FAILED time_secondary\.TimeSecondary\.time_exception \[([^\]]+)\] "
+            r"-- exit status 1",
+            line,
         )
-        for line in summary[1:]
-    ), summary
+        assert match, line
+        tags.add(match.group(1))
+    assert len(tags) == 2, tags
+
+
+def test_run_failure_summary_interleaved_rounds(capsys, basic_conf_no_packages):
+    tmpdir, local, conf, machine_file = basic_conf_no_packages
+
+    # interleaved rounds revisit each (commit, env) once per round, so a
+    # persistently failing benchmark must still be reported only once
+    tools.run_asv_with_conf(
+        conf,
+        'run',
+        f'{util.git_default_branch()}^!',
+        '--interleave-rounds',
+        '-a',
+        'rounds=2',
+        '--bench=time_secondary.TimeSecondary.time_exception',
+        _machine_file=machine_file,
+    )
+    text, err = capsys.readouterr()
+
+    summary = [line.strip() for line in text[text.index("Failures (") :].strip().splitlines()]
+    assert summary[0] == "Failures (1):", summary
+    assert len(summary) == 2, summary
+    assert summary[1].startswith("FAILED time_secondary.TimeSecondary.time_exception"), summary
 
 
 def test_run_python_arg():


### PR DESCRIPTION
Closes #1201

Related to #1610, it would have been really nice to have a failure summary at the end of the test run. This adds such failure reporting, like taking this on `main`:

```
               True     True    65536   1.38±0ms
               True     True    65537   4.76±0ms
               True     True    65538   1.65±0ms
             ======= ========= ======= ==========

$ echo $?
2
```

and turning it into this on this PR:

```
             ======= ========= ======= ==========

[50.00%] · Failures (4):
           FAILED fft_basic.FftThreading.time_fft -- exit status 1
           FAILED fft_basic.FftThreading.time_fftn -- exit status 1
           FAILED signal.Convolve.time_convolve2d -- exit status 1
           FAILED signal.Convolve.time_correlate2d -- exit status 1
```

The 50% above is fixed separately by #1610.

Changes drafted by Claude Opus 5, but I understand all code (this is the sort of thing I've previously plumbed myself in `pytest` for MNE-Python, etc.).