### PR TITLE
results: Bail out gracefully when profile data is missing

### DIFF
--- a/asv/results.py
+++ b/asv/results.py
@@ -549,11 +549,22 @@ class Results:
 
         Returns
         -------
-        profile_data : pstats.Stats
-            Profile data
+        profile_data : bytes
+            Raw profile data. Use `get_profile_stats` for a `pstats.Stats`
+            object.
+
+        Raises
+        ------
+        UserError
+            If no profile was stored for the benchmark.
 
         """
-        profile_data = self._profiles[benchmark_name]
+        profile_data = self._profiles.get(benchmark_name)
+        if not profile_data:
+            raise util.UserError(
+                f"No profile data available for benchmark '{benchmark_name}'. "
+                f"Re-run the benchmark with --profile to collect it."
+            )
         profile_data = profile_data.encode('ascii')
         profile_bytes = zlib.decompress(base64.b64decode(profile_data))
         return profile_bytes

--- a/changelog.d/1614.bugfix.rst
+++ b/changelog.d/1614.bugfix.rst
@@ -1,0 +1,1 @@
+Raise a clear error from ``Results.get_profile`` when no profile data was stored, instead of ``KeyError`` or ``AttributeError`` (#1459).

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -75,3 +75,20 @@ def test_profile_python_commit(capsys, basic_conf):
     text, err = capsys.readouterr()
 
     assert "Profile data does not already exist" not in text
+
+
+def test_get_profile_missing_data():
+    # A benchmark with no stored profile should report that clearly instead of
+    # raising KeyError or AttributeError from inside get_profile.
+    from asv.results import Results
+
+    results = Results.unnamed()
+
+    with pytest.raises(util.UserError, match="No profile data available"):
+        results.get_profile("time_absent")
+
+    # add_result only stores a profile when it is truthy, so a falsy entry is
+    # reachable too.
+    results._profiles["time_nulled"] = None
+    with pytest.raises(util.UserError, match="No profile data available"):
+        results.get_profile("time_nulled")


### PR DESCRIPTION

Closes #1459.

`get_profile` indexed `_profiles` directly and then called `.encode()` on the result, so a benchmark with no stored profile raised `KeyError`, and one stored as `None` raised `AttributeError`. `add_result` only writes the entry when the profile is truthy, so both shapes are reachable.

```
has_profile('absent')  -> None
get_profile('absent')  -> KeyError: 'time_absent'
get_profile(None-valued) -> AttributeError: 'NoneType' object has no attribute 'encode'
```

It now raises `UserError`, which `main.py` already turns into a logged error and a non-zero exit rather than a traceback. Of the three call sites, two guard with `has_profile` first, and the third is `asv profile` right after a profiling run, which is the one that surfaced this.

Also corrects the docstring, which promised `pstats.Stats` but returns raw bytes. `get_profile_stats` has been the Stats-returning method since #1253.

Added a test covering both shapes. It fails on main with `KeyError` and passes here.

`pytest test/test_profile.py test/test_results.py` passes, 11 tests. `pre-commit run --files` passes on all changed files.
