### PR TITLE
build: require asv-runner 0.3.1 for setup_cache order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+asv next (unreleased)
+---------------------
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Require ``asv-runner>=0.3.1`` so class ``setup(self)`` does not run
+  before ``setup_cache`` (asv_runner#52). The ``>=0.2.5`` floor still
+  resolves to the broken 0.2.2--0.3.0 wheels.
+
+
 asv 0.6.6 (2026-06-27)
 ----------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "asv-runner>=0.2.5",
+    "asv-runner>=0.3.1",
     "json5",
     "build",
     "tabulate",


### PR DESCRIPTION
Require `asv-runner>=0.3.1`.

The `>=0.2.5` floor still resolves to 0.2.2--0.3.0, which run bound
class `setup(self)` before `setup_cache` (asv_runner#52). 0.3.1 is on
PyPI (wheel and sdist).