### PR TITLE
environment: Keep PYTHONPATH importable for existing environments

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -1100,4 +1100,19 @@ class ExistingEnvironment(Environment):
 
     def run(self, args, **kwargs):
         log.debug(f"Running '{' '.join(args)}' in {self.name}")
+        # An existing environment is deliberately not isolated: the interpreter,
+        # and everything it can import, is the one the user asked for. Managed
+        # environments drop PYTHONPATH before spawning the interpreter, so
+        # ``asv.benchmark`` treats a PYTHONPATH that survives as a leak and
+        # removes those entries from ``sys.path`` unless the same entries are
+        # advertised through ASV_PYTHONPATH. Promote them here, so that
+        # interpreters which are made importable through PYTHONPATH alone
+        # (pixi, module systems, ``pip install --target``) keep working.
+        env = kwargs.get("env")
+        if env is None:
+            env = os.environ
+        if "PYTHONPATH" in env and "ASV_PYTHONPATH" not in env:
+            env = dict(env)
+            env["ASV_PYTHONPATH"] = env["PYTHONPATH"]
+            kwargs["env"] = env
         return util.check_output([self._executable] + args, **kwargs)

--- a/changelog.d/1616.bugfix.rst
+++ b/changelog.d/1616.bugfix.rst
@@ -1,0 +1,1 @@
+Existing environments (``--python=same``) keep ``PYTHONPATH`` entries importable in the benchmark process, so interpreters set up through ``PYTHONPATH`` alone (pixi, environment modules, ``pip install --target``) no longer fail discovery with ``ModuleNotFoundError`` (#1537).

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from asv import config, environment, util
+from asv import config, environment, runner, util
 from asv.repo import get_repo
 from asv.util import shlex_quote as quote
 
@@ -588,6 +588,63 @@ def test_matrix_existing(skip_no_conda: pytest.FixtureRequest):
     environments = list(environment.get_environments(conf, None))
     items = [(env.tool_name, tuple(env.requirements.keys())) for env in environments]
     assert items == [('existing', ())]
+
+
+def test_existing_environment_keeps_pythonpath(tmpdir, monkeypatch):
+    # An existing environment is not isolated, so a module that is importable
+    # only because of PYTHONPATH has to stay importable in the benchmark
+    # process. asv.benchmark drops PYTHONPATH entries from sys.path unless the
+    # same entries also arrive as ASV_PYTHONPATH.
+    tmpdir = str(tmpdir)
+
+    lib_dir = os.path.join(tmpdir, 'lib')
+    os.makedirs(lib_dir)
+    with open(os.path.join(lib_dir, 'asv_pythonpath_module.py'), 'w') as fd:
+        fd.write('VALUE = 42\n')
+
+    benchmark_dir = os.path.join(tmpdir, 'benchmarks')
+    os.makedirs(benchmark_dir)
+    with open(os.path.join(benchmark_dir, '__init__.py'), 'w') as fd:
+        fd.write('')
+    with open(os.path.join(benchmark_dir, 'bench_pythonpath.py'), 'w') as fd:
+        fd.write(
+            'import asv_pythonpath_module\n'
+            '\n'
+            '\n'
+            'def track_value():\n'
+            '    return asv_pythonpath_module.VALUE\n'
+        )
+
+    conf = config.Config()
+    conf.env_dir = os.path.join(tmpdir, 'env')
+    conf.environment_type = 'existing'
+    conf.pythons = ['same']
+    conf.matrix = {}
+
+    (env,) = environment.get_environments(conf, [])
+
+    monkeypatch.setenv('PYTHONPATH', lib_dir)
+
+    # Discovery imports the benchmark module, and so the PYTHONPATH module
+    result_file = os.path.join(tmpdir, 'result.json')
+    env.run(
+        [runner.BENCHMARK_RUN_SCRIPT, 'discover', benchmark_dir, result_file],
+        cwd=tmpdir,
+        env=dict(os.environ),
+        dots=False,
+    )
+    with open(result_file, 'r') as fd:
+        names = [benchmark['name'] for benchmark in json.load(fd)]
+    assert names == ['bench_pythonpath.track_value']
+
+    output = env.run(['-c', 'import os; print(os.environ["ASV_PYTHONPATH"])'])
+    assert output.strip() == lib_dir
+
+    # An ASV_PYTHONPATH the caller set themselves is left alone
+    other_dir = os.path.join(tmpdir, 'other')
+    monkeypatch.setenv('ASV_PYTHONPATH', other_dir)
+    output = env.run(['-c', 'import os; print(os.environ["ASV_PYTHONPATH"])'])
+    assert output.strip() == other_dir
 
 
 # environment.yml should respect the specified order


### PR DESCRIPTION
Closes #1537.

## The problem

`asv run --python=same` fails during discovery with `ModuleNotFoundError` whenever the interpreter under test is made importable through `PYTHONPATH` alone — pixi workspaces (as in the linked issue, against SciPy), environment-module setups, and `pip install --target` layouts.

## Root cause

`asv/benchmark.py` fixes up `sys.path` in the benchmark process:

- if `ASV_PYTHONPATH` is set, its entries are **prepended** to `sys.path`;
- otherwise, if `PYTHONPATH` is set, its entries are **removed** from `sys.path`.

Managed environments never reach that second branch: `Environment.run_executable` pops `PYTHONPATH` out of the child environment (or replaces it from `ASV_PYTHONPATH`) before spawning the interpreter, so isolation is achieved by the variable simply not being there.

`ExistingEnvironment.run` bypasses `run_executable` and hands the caller's environment straight to `util.check_output`. Callers build it as `dict(os.environ)` (`asv/benchmarks.py`, `asv/runner.py`), so the outer `PYTHONPATH` does survive into the benchmark process — and `asv/benchmark.py`, seeing `PYTHONPATH` without `ASV_PYTHONPATH`, treats it as a leak from the outside world and strips exactly the paths that make the user's packages importable.

An existing environment is deliberately not isolated — `install_project` is a no-op and `can_install_project()` returns `False`. The interpreter, and everything it can import, is the one the user asked for, so stripping it is never the intent.

## The fix

Promote `PYTHONPATH` to `ASV_PYTHONPATH` in `ExistingEnvironment.run`, so the entries are kept on `sys.path` rather than removed. An `ASV_PYTHONPATH` the caller set themselves is left alone, and behaviour is unchanged when `PYTHONPATH` is unset. This is the in-asv equivalent of the `os.environ['ASV_PYTHONPATH'] = os.environ['PYTHONPATH']` workaround noted at the end of #1537.

Other environment types are untouched — they continue to discard `PYTHONPATH` in `run_executable`.

## Verification

Added `test_existing_environment_keeps_pythonpath`, which builds a module reachable only via `PYTHONPATH` and runs real discovery through `ExistingEnvironment`. Without the change it fails with the symptom from the issue:

```
ModuleNotFoundError: No module named 'asv_pythonpath_module'
```

Test suites run locally on macOS (Python 3.12), no conda/pypy available so those cases skip:

- `test/test_environment.py` — 13 passed, 22 skipped
- `test/test_benchmarks.py`, `test/test_runner.py`, `test/test_existing_env_commits.py`, `test/test_check.py` — 20 passed, 1 skipped

`pre-commit run --files asv/environment.py test/test_environment.py` passes clean.

I'll add the `changelog.d` fragment once this PR has a number.