### PR TITLE
Add average_over to collapse a parameter across graphs

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -89,6 +89,15 @@ class Publish(Command):
             hashes = None
         for result in iter_results(conf.results_dir):
             if hashes is None or result.commit_hash in hashes:
+                for name in conf.average_over:
+                    # Forgetting a parameter here is what merges results that
+                    # differ only in it: they land in one graph, and the values
+                    # they contribute to a revision are averaged by
+                    # Graph.get_data. Both properties return the live dicts,
+                    # and publish never writes a result back to disk.
+                    result.params.pop(name, None)
+                    if name.startswith('env-'):
+                        result.env_vars.pop(name[len('env-'):], None)
                 yield result
 
     @classmethod

--- a/asv/config.py
+++ b/asv/config.py
@@ -78,6 +78,7 @@ class Config:
         self.install_command = None
         self.uninstall_command = None
         self.launch_method = None
+        self.average_over = []
 
     @classmethod
     def load(cls, path=None):
@@ -126,5 +127,12 @@ class Config:
                 "or expect publish to rename them to 'req-<name>' (issue #819)."
                 % (sorted(reserved),)
             )
+
+        average_over = getattr(conf, "average_over", None) or []
+        if isinstance(average_over, str):
+            average_over = [average_over]
+        if not all(isinstance(name, str) for name in average_over):
+            raise util.UserError("'average_over' must be a list of parameter names.")
+        conf.average_over = list(average_over)
 
         return conf

--- a/changelog.d/1619.feat.rst
+++ b/changelog.d/1619.feat.rst
@@ -1,0 +1,8 @@
+A new ``average_over`` configuration key names parameters that
+:ref:`cmd-asv-publish` should average over rather than plot as separate series.
+Results differing only in a listed parameter land in one graph, and where two
+of them fall on the same commit their values are averaged. The common use is
+``["python"]``, for a project that leaves ``pythons`` unset and does not want
+an upgrade of the interpreter running ``asv`` to split every graph in two.
+Nothing in ``results_dir`` is rewritten, so removing the key and republishing
+restores the separate series.

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -543,3 +543,44 @@ Example::
 
 In this case, the reporting threshold is 1% for all benchmarks, except
 ``benchmark_1`` which uses a threshold of 20%.
+``average_over``
+----------------
+
+Parameters the published site should average over rather than plot separately.
+
+Every parameter recorded with a result -- the machine details, the Python
+version, and each ``matrix`` requirement -- is part of a graph's identity, so
+two results differing in any of them are drawn as two lines and the parameter
+gets a row in the web UI's parameter selector.  That is what you want for a
+matrix you deliberately benchmark across.  It is not what you want for a
+parameter that merely drifts.
+
+Listing one here forgets it: results that differ only in that parameter land in
+the same graph, and where two of them fall on the same commit their values are
+averaged -- the reduction asv already applies to repeated runs within a single
+graph.
+
+The case this was written for is ``pythons`` being left unset.  It then
+defaults to the version of Python running ``asv``, so upgrading that
+interpreter on the benchmark machine starts a second, disconnected timeline on
+every graph, for a dimension the project never asked to vary.  A project that
+uses a ``conda_environment_file`` already lets the rest of the environment move
+underneath one continuous history; this lets the interpreter move the same
+way::
+
+    "average_over": ["python"]
+
+The value is a list of parameter names; a bare string is accepted for a single
+one.  Environment variables are matched under their published names, i.e.
+``"env-FOO"`` for ``FOO``.  Unknown names are ignored, so a project can list a
+parameter it only sometimes records.
+
+This is a view of the published site, not a migration.  Nothing in
+``results_dir`` is rewritten, so each result still records the parameter it was
+measured with, and removing the key and re-running :ref:`cmd-asv-publish`
+brings the separate series back.
+
+It is applied when the site is built rather than in the browser because step
+detection and the Regressions page are computed by :ref:`cmd-asv-publish` from
+the same graphs.  Averaging only at display time would leave those views
+disagreeing with the graphs about how many series there are.

--- a/test/test_average_over.py
+++ b/test/test_average_over.py
@@ -1,0 +1,190 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for ``average_over``.
+
+A parameter listed there stops being part of a graph's identity, so results
+that differ only in it land in one series instead of several, and where two of
+them fall on the same commit their values are averaged.  It is a view over the
+published site: nothing in ``results_dir`` is touched, and removing the key and
+republishing brings the separate series back.
+
+The motivating case is ``pythons`` being left unset, so that upgrading the
+interpreter on the benchmark machine would otherwise split every graph.
+"""
+
+import datetime
+import os
+from hashlib import sha256
+from os.path import isdir, isfile, join
+
+import pytest
+
+from asv import config, runner, util
+from asv.repo import get_repo
+from asv.results import Results
+
+from . import tools
+
+BENCHMARK_VERSION = sha256(b'time_func').hexdigest()
+
+
+def _write_result(conf, repo, commit, python, value):
+    result = Results(
+        {'machine': 'tarzan', 'python': python},
+        {},
+        commit,
+        repo.get_date_from_name(commit),
+        python,
+        f'conda-py{python}',
+        {},
+    )
+    result.add_result(
+        {'name': 'time_func', 'version': BENCHMARK_VERSION, 'params': []},
+        runner.BenchmarkResult(
+            result=[value],
+            samples=[None],
+            number=[None],
+            errcode=0,
+            stderr='',
+            profile=None,
+        ),
+        started_at=datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc),
+        duration=1.0,
+    )
+    result.save(conf.results_dir)
+
+
+def _conf(tmpdir, dvcs, **extra):
+    result_dir = join(tmpdir, 'results')
+    if not isdir(join(result_dir, 'tarzan')):
+        os.makedirs(join(result_dir, 'tarzan'))
+    conf = config.Config.from_json(
+        {
+            'results_dir': result_dir,
+            'html_dir': join(tmpdir, 'html'),
+            'repo': dvcs.path,
+            'project': 'asv',
+            'branches': [util.git_default_branch()],
+            **extra,
+        }
+    )
+    util.write_json(
+        join(result_dir, 'tarzan', 'machine.json'), {'machine': 'tarzan', 'version': 1}
+    )
+    return conf
+
+
+def _write_benchmarks(conf):
+    util.write_json(
+        join(conf.results_dir, 'benchmarks.json'),
+        {
+            'time_func': {
+                'name': 'time_func',
+                'params': [],
+                'param_names': [],
+                'version': BENCHMARK_VERSION,
+            }
+        },
+        api_version=2,
+    )
+
+
+@pytest.fixture
+def upgraded_interpreter(tmpdir):
+    # Three commits on 3.13, then three on 3.14 after the machine was upgraded.
+    tmpdir = str(tmpdir)
+    os.chdir(tmpdir)
+    dvcs = tools.generate_repo_from_ops(tmpdir, 'git', [('commit', i) for i in range(6)])
+    commits = list(reversed(dvcs.get_branch_hashes()))
+    conf = _conf(tmpdir, dvcs)
+    repo = get_repo(conf)
+    for i, commit in enumerate(commits):
+        _write_result(conf, repo, commit, '3.13' if i < 3 else '3.14', 1.0 + i)
+    _write_benchmarks(conf)
+    return conf, tmpdir
+
+
+def _graph_dir(tmpdir, *parts):
+    return join(tmpdir, 'html', 'graphs', f'branch-{util.git_default_branch()}', *parts)
+
+
+def test_defaults_to_averaging_over_nothing():
+    conf = config.Config.from_json({'repo': '.', 'project': 'x'})
+    assert conf.average_over == []
+
+
+def test_accepts_a_bare_string():
+    conf = config.Config.from_json({'repo': '.', 'project': 'x', 'average_over': 'python'})
+    assert conf.average_over == ['python']
+
+
+def test_rejects_non_strings():
+    with pytest.raises(util.UserError, match='average_over'):
+        config.Config.from_json({'repo': '.', 'project': 'x', 'average_over': [3.14]})
+
+
+def test_recorded_python_splits_the_graphs(upgraded_interpreter):
+    conf, tmpdir = upgraded_interpreter
+
+    tools.run_asv_with_conf(conf, 'publish')
+
+    index = util.load_json(join(tmpdir, 'html', 'index.json'))
+    assert index['params']['python'] == ['3.13', '3.14']
+    for python in ['3.13', '3.14']:
+        assert isfile(_graph_dir(tmpdir, 'machine-tarzan', f'python-{python}', 'time_func.json'))
+
+
+def test_averaging_over_python_joins_them(upgraded_interpreter):
+    conf, tmpdir = upgraded_interpreter
+    conf.average_over = ['python']
+
+    tools.run_asv_with_conf(conf, 'publish')
+
+    index = util.load_json(join(tmpdir, 'html', 'index.json'))
+    assert 'python' not in index['params']
+    assert index['graph_param_list'] == [
+        {'branch': util.git_default_branch(), 'machine': 'tarzan'}
+    ]
+    data = util.load_json(_graph_dir(tmpdir, 'machine-tarzan', 'time_func.json'))
+    assert [point[1] for point in data] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+def test_results_on_disk_are_untouched(upgraded_interpreter):
+    # The whole point: this is a view, so the recorded data still says which
+    # interpreter each measurement came from.
+    conf, tmpdir = upgraded_interpreter
+    conf.average_over = ['python']
+    before = sorted(os.listdir(join(conf.results_dir, 'tarzan')))
+
+    tools.run_asv_with_conf(conf, 'publish')
+
+    assert sorted(os.listdir(join(conf.results_dir, 'tarzan'))) == before
+    pythons = {
+        Results.load(join(conf.results_dir, 'tarzan', name)).params.get('python')
+        for name in before
+        if name != 'machine.json'
+    }
+    assert pythons == {'3.13', '3.14'}
+
+    # ... and dropping the key brings the separate series back.
+    conf.average_over = []
+    tools.run_asv_with_conf(conf, 'publish')
+    index = util.load_json(join(tmpdir, 'html', 'index.json'))
+    assert index['params']['python'] == ['3.13', '3.14']
+
+
+def test_two_interpreters_on_one_commit_are_averaged(tmpdir):
+    tmpdir = str(tmpdir)
+    os.chdir(tmpdir)
+    dvcs = tools.generate_repo_from_ops(tmpdir, 'git', [('commit', 0)])
+    commit = dvcs.get_branch_hashes()[0]
+    conf = _conf(tmpdir, dvcs, average_over=['python'])
+    repo = get_repo(conf)
+    for python, value in [('3.13', 10.0), ('3.14', 20.0)]:
+        _write_result(conf, repo, commit, python, value)
+    _write_benchmarks(conf)
+
+    tools.run_asv_with_conf(conf, 'publish')
+
+    data = util.load_json(_graph_dir(tmpdir, 'machine-tarzan', 'time_func.json'))
+    assert [point[1] for point in data] == [15.0]


### PR DESCRIPTION
I would like to simply "ignore" the python version in my benchmark plots. I find that it is just noise since for us, python doesn't affect the performance as much as other factors.

We let it float in our ASV CIs, so when they pickup different pythons for whatever reason, it is not really useful to plot.


Instead of trying to special case things, at visualization time, i'm trying to allow some improved "average over" tools to help customize how things are displayed, given the same backend storage of results.