### PR TITLE
fix: allow complilation with Python 3.15

### DIFF
--- a/asv/_rangemedian.cpp
+++ b/asv/_rangemedian.cpp
@@ -502,7 +502,7 @@ static PyModuleDef_Slot rangemedian_slots[] = {
      */
     {Py_mod_exec, (void *)rangemedian_modexec},
 
-#ifdef Py_mod_gil
+#ifdef Py_GIL_DISABLED
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif
 


### PR DESCRIPTION
Python 3.15 has moved the GIL into the stable API, which means Py_mod_gil is always defined. Use the correct define to support older versions as well as 3.15 and above.